### PR TITLE
chore: add scripts/ci-local.sh to run CI jobs locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,6 @@ See [`docs/conventions.md`](docs/conventions.md). Key points:
 | Add a frontend page | `src/client/pages/` + register in `src/client/App.tsx` |
 | Wire an API call | `src/client/api/` (one file per resource) |
 | Configure deployment | `Dockerfile`, `docker-compose.yml`, `.env.example` |
-| Touch CI | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — runs server build + xUnit suite and client build on every push / PR |
+| Touch CI | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — runs server build + xUnit suite and client build on every push / PR. Run the same jobs locally with [`./scripts/ci-local.sh`](scripts/ci-local.sh) (optionally `server` or `client` to scope). |
 | Read project specs | `docs/` |
 | Write a test | [`docs/testing.md`](docs/testing.md) — TDD workflow, layers, required coverage |

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run the same jobs that .github/workflows/ci.yml runs, locally.
+# Mirrors the workflow command-for-command so a green run here means
+# CI should be green too.
+#
+# Usage:
+#   ./scripts/ci-local.sh             # both jobs
+#   ./scripts/ci-local.sh server      # server only (.NET build + xUnit)
+#   ./scripts/ci-local.sh client      # client only (npm ci + build)
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-all}"
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+red()  { printf '\033[31m%s\033[0m\n' "$*"; }
+grn()  { printf '\033[32m%s\033[0m\n' "$*"; }
+
+server_job() {
+  bold "==> server (.NET 10)"
+  cd "$REPO_ROOT/src/server"
+  dotnet restore Collectify.slnx
+  dotnet build  Collectify.slnx --no-restore --configuration Release
+  dotnet test   --no-build --configuration Release --logger "console;verbosity=normal"
+}
+
+client_job() {
+  bold "==> client (Vite/TS)"
+  cd "$REPO_ROOT/src/client"
+  npm ci
+  npm run build
+}
+
+start_ts=$(date +%s)
+trap 'red "ci-local: FAILED (job exited non-zero)"; exit 1' ERR
+
+case "$TARGET" in
+  server) server_job ;;
+  client) client_job ;;
+  all)    server_job; client_job ;;
+  *)      red "unknown target: $TARGET (expected: server | client | all)"; exit 2 ;;
+esac
+
+elapsed=$(( $(date +%s) - start_ts ))
+grn "ci-local: OK ($TARGET, ${elapsed}s)"


### PR DESCRIPTION
Adds a small Bash helper that runs the same jobs as `.github/workflows/ci.yml` locally, so we can verify a green CI pre-push without burning Actions minutes.

## What's in it

- `scripts/ci-local.sh` (executable) — mirrors the workflow command-for-command:
  - **server**: `dotnet restore` → `dotnet build --configuration Release` → `dotnet test --no-build --configuration Release`.
  - **client**: `npm ci` → `npm run build`.
- Targets:
  ```bash
  ./scripts/ci-local.sh           # both jobs
  ./scripts/ci-local.sh server    # .NET only
  ./scripts/ci-local.sh client    # client only
  ```
- `set -Eeuo pipefail` + `trap ... ERR` so the first non-zero exit prints a clear `FAILED` line; success path reports total elapsed.
- `AGENTS.md` "Where to look first" table updated with a one-liner pointing at the script.

## Test plan

- [x] `./scripts/ci-local.sh` (full run) — completes ~40s on this machine, 84/84 tests pass, client `dist/` produced.
- [x] `./scripts/ci-local.sh server` — runs only the .NET path.
- [x] `./scripts/ci-local.sh client` — runs only the npm path.
- [x] Bad arg (`./scripts/ci-local.sh foo`) — exits 2 with a clear message.
- [x] Forced failure (introduce a failing test) — script exits non-zero with the red `FAILED` summary.

## Out of scope

- Equivalent of `act` / Docker-based workflow replay (heavier; not needed for routine pre-push checks).
- Frontend tests — none yet; will plug into the script when Vitest lands per `docs/testing.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_