### PR TITLE
chore: align Vite dev proxy with dotnet run default port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,11 @@ Always check open issues before starting work and link PRs to the relevant issue
 ### Local dev (two terminals)
 
 ```bash
-# Terminal 1 — API on http://localhost:5041 (or 5089 from Properties/launchSettings.json)
+# Terminal 1 — API on http://localhost:5041 (default from Properties/launchSettings.json)
 cd src/server
 dotnet run --project Collectify.Api
 
-# Terminal 2 — Vite dev server on http://localhost:5173 with /api proxy → :8080
+# Terminal 2 — Vite dev server on http://localhost:5173 with /api proxy → :5041
 cd src/client
 npm install
 npm run dev

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:8080',
+      '/api': 'http://localhost:5041',
     },
   },
   build: {


### PR DESCRIPTION
Tiny follow-up to PR #10's "Out of scope" note.

## Why

`Properties/launchSettings.json` makes `dotnet run --project Collectify.Api` bind `http://localhost:5041`, but `vite.config.ts` was proxying `/api/*` to `http://localhost:8080` (a number copied from the Dockerfile, which Docker uses internally — nothing to do with the dev server). Every dev request failed with `ECONNREFUSED` unless you knew to override `ASPNETCORE_URLS=http://+:8080`.

## What

- `src/client/vite.config.ts`: proxy target `:8080` → `:5041`.
- `AGENTS.md`: matching line in the "Local dev" block updated; the misleading "(or 5089 from Properties/launchSettings.json)" aside (a port the project has never used) removed.

Production is unaffected — Docker still binds 8080 inside the container, the SPA is served by the same Kestrel, and the Vite proxy doesn't run at all in production.

## Test plan

- [x] **Live proxy smoke**: `dotnet run --project Collectify.Api` (default port) + `npm run dev` → `curl http://localhost:5173/api/health` returns `{"status":"ok"}` with HTTP 200. No `ECONNREFUSED`, no `ASPNETCORE_URLS` override needed.
- [x] `./scripts/ci-local.sh` green (server 84/84, client 20/20, builds clean).

## Out of scope

- The "How to run locally" command in PR #10's body still mentions the env-var override. After this lands, that recipe simplifies to plain `dotnet run --project Collectify.Api` + `npm run dev`. No code change needed; just history.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_