### PR TITLE
feat(server): Phase 2 slice 1 — metadata lookup infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,16 @@
 # Copy to .env to override defaults.
-# Phase 2/3 metadata provider keys (all optional).
-# TMDB_API_KEY=
-# OMDB_API_KEY=
-# IGDB_CLIENT_ID=
-# IGDB_CLIENT_SECRET=
-# DISCOGS_TOKEN=
+# Phase 2 metadata provider keys (all optional). Each provider degrades
+# gracefully when its config block is unset -- the lookup endpoint replies
+# with `configured: false` and an empty result set.
+
+# TMDB (movies). Get a v3 API key at https://www.themoviedb.org/settings/api
+# Collectify__Metadata__Tmdb__ApiKey=
+
+# MusicBrainz (music). No key, but you must set a contact-bearing User-Agent
+# per their etiquette. Format: "AppName/Version (contact@example.com)"
+# Collectify__Metadata__MusicBrainz__UserAgent=
+
+# IGDB (games). Twitch app credentials -- IGDB uses Twitch OAuth.
+# https://dev.twitch.tv/console/apps
+# Collectify__Metadata__Igdb__TwitchClientId=
+# Collectify__Metadata__Igdb__TwitchClientSecret=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,23 +93,22 @@ This is the multi-user-readiness contract. Even though we ship single-user, neve
 
 ### External providers (Phase 2)
 
+The seam lives in `Collectify.Infrastructure/Lookup/`. One interface per media type so each result shape stays strongly typed:
+
 ```csharp
-// Domain
-public interface IMetadataProvider<TResult>
+public interface IMovieMetadataProvider
 {
     string Name { get; }
     bool IsConfigured { get; }
-    Task<IReadOnlyList<TResult>> SearchAsync(string query, CancellationToken ct);
-    Task<TResult?> LookupBarcodeAsync(string barcode, CancellationToken ct);
+    Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default);
 }
-
-// Infrastructure
-public class TmdbMovieProvider : IMetadataProvider<MovieSearchResult> { … }
+// + IMusicMetadataProvider, IGameMetadataProvider with their own result records
 ```
 
-- Register as keyed services or via a `Func<MediaType, IMetadataProvider<…>>` factory.
-- Wrap every outbound call with a `LookupCache` lookup (`Provider`, `Key`) that persists the JSON response.
-- Fail closed: if not configured, `IsConfigured = false`; the API returns `503` and the UI hides the button.
+- DI is set up by `services.AddMetadataLookup(config)` (called from `Program.cs`). It binds `MetadataLookupOptions` from `Collectify:Metadata`, registers `IHttpClientFactory`, and wires a `Stub*Provider` for each slot via `TryAddScoped`.
+- A real provider PR (TMDB / MusicBrainz / IGDB) registers its typed `HttpClient` and its `IXxxMetadataProvider` implementation. `Replace()` (or running its registration before `AddMetadataLookup`) swaps the stub out.
+- Outbound calls go through `ILookupCache` (`Provider`, `Key`) which round-trips a JSON payload through the existing `LookupCacheEntry` table. TTL comes from `MetadataLookupOptions.CacheTtl` (default 30 days).
+- Fail-soft: if not configured, `IsConfigured = false`. The lookup endpoint replies with `{ provider, configured: false, results: [] }` so the UI can show a clear "set TMDB__ApiKey to enable" hint instead of an error toast.
 
 ## Migrations
 

--- a/src/client/services/lookup.ts
+++ b/src/client/services/lookup.ts
@@ -1,0 +1,74 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from './client';
+import type { MediaType } from './types';
+
+export interface MovieLookupResult {
+  provider: string;
+  providerKey: string;
+  title: string;
+  originalTitle: string | null;
+  year: number | null;
+  director: string | null;
+  runtimeMinutes: number | null;
+  description: string | null;
+  imageUrl: string | null;
+  genres: string | null;
+}
+
+export interface MusicLookupResult {
+  provider: string;
+  providerKey: string;
+  title: string;
+  artistName: string;
+  year: number | null;
+  label: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  genres: string | null;
+}
+
+export interface GameLookupResult {
+  provider: string;
+  providerKey: string;
+  title: string;
+  platform: string | null;
+  year: number | null;
+  publisher: string | null;
+  developer: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  genres: string | null;
+}
+
+export interface LookupResponse<T> {
+  provider: string;
+  configured: boolean;
+  results: T[];
+}
+
+type ResultMap = {
+  movies: MovieLookupResult;
+  music: MusicLookupResult;
+  games: GameLookupResult;
+};
+
+/**
+ * Search the configured external metadata provider for a media type. Returns
+ * an empty result set when no provider is configured for that type yet --
+ * the response always includes `configured: false` so callers can hint the
+ * UI ("Set TMDB__ApiKey to enable lookups") instead of treating an empty
+ * list as "no matches".
+ *
+ * Disabled until the query has at least 2 non-whitespace characters; the
+ * server enforces the same minimum.
+ */
+export function useLookup<T extends MediaType>(type: T, query: string) {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: ['lookup', type, trimmed],
+    queryFn: () =>
+      api<LookupResponse<ResultMap[T]>>(`/api/lookup/${type}?q=${encodeURIComponent(trimmed)}`),
+    enabled: trimmed.length >= 2,
+    staleTime: 60_000,
+  });
+}

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -1,0 +1,59 @@
+using Collectify.Infrastructure.Lookup;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Collectify.Api.Endpoints;
+
+public static class LookupEndpoints
+{
+    public record LookupResponse<T>(string Provider, bool Configured, IReadOnlyList<T> Results);
+
+    public static IEndpointRouteBuilder MapLookupEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/lookup").RequireAuthorization();
+
+        group.MapGet("/movies", async (
+            [FromQuery] string? q,
+            IMovieMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
+        });
+
+        group.MapGet("/music", async (
+            [FromQuery] string? q,
+            IMusicMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
+        });
+
+        group.MapGet("/games", async (
+            [FromQuery] string? q,
+            IGameMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, true, results));
+        });
+
+        return app;
+    }
+
+    private static IResult? Validate(string? q)
+    {
+        if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
+            return Results.BadRequest(new { error = "Query must be at least 2 characters." });
+        return null;
+    }
+}

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Collectify.Api.Endpoints;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -61,6 +62,8 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
     opt.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 
+builder.Services.AddMetadataLookup(builder.Configuration);
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
@@ -77,6 +80,7 @@ app.MapMoviesEndpoints();
 app.MapMusicEndpoints();
 app.MapGamesEndpoints();
 app.MapTagEndpoints();
+app.MapLookupEndpoints();
 
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok" }));
 

--- a/src/server/Collectify.Infrastructure/Collectify.Infrastructure.csproj
+++ b/src/server/Collectify.Infrastructure/Collectify.Infrastructure.csproj
@@ -11,6 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
 
     <!-- Transitive override; see Directory.Packages.props for the version + advisory note. -->
     <PackageReference Include="System.Security.Cryptography.Xml">

--- a/src/server/Collectify.Infrastructure/Lookup/ILookupCache.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/ILookupCache.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Collectify.Domain.Entities;
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Infrastructure.Lookup;
+
+/// <summary>
+/// Provider-agnostic cache for outbound metadata calls. Entries are keyed by
+/// (Provider, Key) which is uniquely indexed at the DB level. JsonResponse
+/// stores the raw provider payload so we can re-shape it later without
+/// needing another HTTP round trip.
+/// </summary>
+public interface ILookupCache
+{
+    Task<T?> GetAsync<T>(string provider, string key, TimeSpan ttl, CancellationToken ct = default);
+    Task SetAsync<T>(string provider, string key, T value, CancellationToken ct = default);
+}
+
+public sealed class LookupCache : ILookupCache
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly CollectifyDbContext _db;
+    private readonly TimeProvider _clock;
+
+    public LookupCache(CollectifyDbContext db, TimeProvider clock)
+    {
+        _db = db;
+        _clock = clock;
+    }
+
+    public async Task<T?> GetAsync<T>(string provider, string key, TimeSpan ttl, CancellationToken ct = default)
+    {
+        var entry = await _db.LookupCache.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Provider == provider && e.Key == key, ct);
+        if (entry is null) return default;
+        if (_clock.GetUtcNow().UtcDateTime - entry.FetchedAt > ttl) return default;
+        return JsonSerializer.Deserialize<T>(entry.JsonResponse, Json);
+    }
+
+    public async Task SetAsync<T>(string provider, string key, T value, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(value, Json);
+        var existing = await _db.LookupCache
+            .FirstOrDefaultAsync(e => e.Provider == provider && e.Key == key, ct);
+        if (existing is null)
+        {
+            _db.LookupCache.Add(new LookupCacheEntry
+            {
+                Provider = provider,
+                Key = key,
+                JsonResponse = json,
+                FetchedAt = _clock.GetUtcNow().UtcDateTime,
+            });
+        }
+        else
+        {
+            existing.JsonResponse = json;
+            existing.FetchedAt = _clock.GetUtcNow().UtcDateTime;
+        }
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
@@ -1,0 +1,29 @@
+namespace Collectify.Infrastructure.Lookup;
+
+/// <summary>
+/// Per-domain provider contracts. Each concrete provider (TMDB,
+/// MusicBrainz, IGDB, etc.) implements one of these; the lookup endpoint
+/// asks the registered provider for that media type for suggestions.
+/// IsConfigured lets a provider report "no API key set, skip me" so the
+/// host can degrade gracefully without throwing.
+/// </summary>
+public interface IMovieMetadataProvider
+{
+    string Name { get; }
+    bool IsConfigured { get; }
+    Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default);
+}
+
+public interface IMusicMetadataProvider
+{
+    string Name { get; }
+    bool IsConfigured { get; }
+    Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default);
+}
+
+public interface IGameMetadataProvider
+{
+    string Name { get; }
+    bool IsConfigured { get; }
+    Task<IReadOnlyList<GameLookupResult>> SearchAsync(string query, CancellationToken ct = default);
+}

--- a/src/server/Collectify.Infrastructure/Lookup/LookupResults.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/LookupResults.cs
@@ -1,0 +1,41 @@
+namespace Collectify.Infrastructure.Lookup;
+
+/// <summary>
+/// Provider-neutral suggestion the API returns to the client. ProviderKey is
+/// opaque to the frontend; subsequent providers can use it to fetch full
+/// details if/when we need a "get one" path beyond the searchable fields.
+/// </summary>
+public record MovieLookupResult(
+    string Provider,
+    string ProviderKey,
+    string Title,
+    string? OriginalTitle,
+    int? Year,
+    string? Director,
+    int? RuntimeMinutes,
+    string? Description,
+    string? ImageUrl,
+    string? Genres);
+
+public record MusicLookupResult(
+    string Provider,
+    string ProviderKey,
+    string Title,
+    string ArtistName,
+    int? Year,
+    string? Label,
+    string? Description,
+    string? ImageUrl,
+    string? Genres);
+
+public record GameLookupResult(
+    string Provider,
+    string ProviderKey,
+    string Title,
+    string? Platform,
+    int? Year,
+    string? Publisher,
+    string? Developer,
+    string? Description,
+    string? ImageUrl,
+    string? Genres);

--- a/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
@@ -1,0 +1,41 @@
+namespace Collectify.Infrastructure.Lookup;
+
+/// <summary>
+/// Bound from the "Collectify:Metadata" config section. Each provider gets
+/// its own subsection so we can ship empty defaults and let users opt in by
+/// setting an env var (Collectify__Metadata__Tmdb__ApiKey, etc.).
+/// </summary>
+public sealed class MetadataLookupOptions
+{
+    public const string SectionName = "Collectify:Metadata";
+
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromDays(30);
+
+    public TmdbOptions Tmdb { get; set; } = new();
+    public MusicBrainzOptions MusicBrainz { get; set; } = new();
+    public IgdbOptions Igdb { get; set; } = new();
+}
+
+public sealed class TmdbOptions
+{
+    public string? ApiKey { get; set; }
+    public string BaseUrl { get; set; } = "https://api.themoviedb.org/3/";
+    public string ImageBaseUrl { get; set; } = "https://image.tmdb.org/t/p/w342";
+}
+
+public sealed class MusicBrainzOptions
+{
+    /// <summary>
+    /// MusicBrainz requires a contact-bearing User-Agent. No key, but the UA
+    /// is the rate-limit identity, so unset = skip the provider.
+    /// </summary>
+    public string? UserAgent { get; set; }
+    public string BaseUrl { get; set; } = "https://musicbrainz.org/ws/2/";
+}
+
+public sealed class IgdbOptions
+{
+    public string? TwitchClientId { get; set; }
+    public string? TwitchClientSecret { get; set; }
+    public string BaseUrl { get; set; } = "https://api.igdb.com/v4/";
+}

--- a/src/server/Collectify.Infrastructure/Lookup/MetadataLookupServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MetadataLookupServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Collectify.Infrastructure.Lookup.Stub;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Collectify.Infrastructure.Lookup;
+
+public static class MetadataLookupServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the lookup seam: options binding, cache, IHttpClientFactory,
+    /// and a stub for every provider slot. Concrete providers (TMDB,
+    /// MusicBrainz, IGDB) replace the stubs when their PRs land via
+    /// services.AddHttpClient&lt;T&gt;() + a Replace() of the relevant
+    /// IXxxMetadataProvider registration.
+    /// </summary>
+    public static IServiceCollection AddMetadataLookup(this IServiceCollection services, IConfiguration config)
+    {
+        services.AddOptions<MetadataLookupOptions>()
+            .Bind(config.GetSection(MetadataLookupOptions.SectionName));
+
+        services.AddHttpClient();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddScoped<ILookupCache, LookupCache>();
+
+        // Register stubs as the default. A real provider PR will Replace()
+        // these (or call TryAdd() before this runs) once it ships.
+        services.TryAddScoped<IMovieMetadataProvider, StubMovieProvider>();
+        services.TryAddScoped<IMusicMetadataProvider, StubMusicProvider>();
+        services.TryAddScoped<IGameMetadataProvider, StubGameProvider>();
+
+        return services;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -1,0 +1,33 @@
+namespace Collectify.Infrastructure.Lookup.Stub;
+
+/// <summary>
+/// Fallback provider used when no concrete movie provider has been registered.
+/// Always returns empty so the lookup endpoint can degrade gracefully -- the
+/// frontend just sees "no suggestions" instead of a 500.
+/// </summary>
+internal sealed class StubMovieProvider : IMovieMetadataProvider
+{
+    public string Name => "stub";
+    public bool IsConfigured => false;
+
+    public Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MovieLookupResult>>(Array.Empty<MovieLookupResult>());
+}
+
+internal sealed class StubMusicProvider : IMusicMetadataProvider
+{
+    public string Name => "stub";
+    public bool IsConfigured => false;
+
+    public Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MusicLookupResult>>(Array.Empty<MusicLookupResult>());
+}
+
+internal sealed class StubGameProvider : IGameMetadataProvider
+{
+    public string Name => "stub";
+    public bool IsConfigured => false;
+
+    public Task<IReadOnlyList<GameLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<GameLookupResult>>(Array.Empty<GameLookupResult>());
+}

--- a/src/server/Directory.Packages.props
+++ b/src/server/Directory.Packages.props
@@ -7,6 +7,8 @@
   <ItemGroup Label="Runtime">
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Label="Design-time / tooling">
@@ -22,6 +24,7 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Collectify.Tests.Infrastructure;
+
+namespace Collectify.Tests.Api;
+
+public class LookupEndpointsTests
+{
+    private record LookupResponse<T>(string Provider, bool Configured, T[] Results);
+    private record MovieLookupResult(
+        string Provider, string ProviderKey, string Title, string? OriginalTitle,
+        int? Year, string? Director, int? RuntimeMinutes, string? Description,
+        string? ImageUrl, string? Genres);
+
+    [Theory]
+    [InlineData("/api/lookup/movies?q=inception")]
+    [InlineData("/api/lookup/music?q=radiohead")]
+    [InlineData("/api/lookup/games?q=hades")]
+    public async Task Search_Unauthenticated_ReturnsUnauthorized(string url)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/api/lookup/movies")]
+    [InlineData("/api/lookup/movies?q=")]
+    [InlineData("/api/lookup/movies?q=a")]
+    public async Task Search_WithMissingOrShortQuery_ReturnsBadRequest(string url)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var response = await alice.Client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SearchMovies_WithStubProvider_ReportsNotConfiguredAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies?q=inception");
+
+        Assert.NotNull(body);
+        Assert.Equal("stub", body!.Provider);
+        Assert.False(body.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task SearchMusic_WithStubProvider_ReportsNotConfiguredAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<object>>(
+            "/api/lookup/music?q=radiohead");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task SearchGames_WithStubProvider_ReportsNotConfiguredAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<object>>(
+            "/api/lookup/games?q=hades");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+}

--- a/src/server/tests/Collectify.Tests/Collectify.Tests.csproj
+++ b/src/server/tests/Collectify.Tests/Collectify.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/server/tests/Collectify.Tests/Infrastructure/LookupCacheTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/LookupCacheTests.cs
@@ -1,0 +1,105 @@
+using Collectify.Domain.Entities;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class LookupCacheTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _options;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    public LookupCacheTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_options);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private LookupCache NewCache() => new(new CollectifyDbContext(_options), _clock);
+
+    private record Sample(string Title, int Year);
+
+    [Fact]
+    public async Task Get_BeforeSet_ReturnsDefault()
+    {
+        var cache = NewCache();
+        var result = await cache.GetAsync<Sample>("tmdb", "550", TimeSpan.FromDays(30));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Get_WithinTtl_ReturnsCachedValue()
+    {
+        await NewCache().SetAsync("tmdb", "550", new Sample("Fight Club", 1999));
+        _clock.Advance(TimeSpan.FromHours(6));
+
+        var result = await NewCache().GetAsync<Sample>("tmdb", "550", TimeSpan.FromDays(30));
+
+        Assert.NotNull(result);
+        Assert.Equal("Fight Club", result!.Title);
+        Assert.Equal(1999, result.Year);
+    }
+
+    [Fact]
+    public async Task Get_ExpiredEntry_ReturnsDefault()
+    {
+        await NewCache().SetAsync("tmdb", "550", new Sample("Fight Club", 1999));
+        _clock.Advance(TimeSpan.FromDays(31));
+
+        var result = await NewCache().GetAsync<Sample>("tmdb", "550", TimeSpan.FromDays(30));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Set_OnExistingKey_OverwritesAndRefreshesFetchedAt()
+    {
+        await NewCache().SetAsync("tmdb", "550", new Sample("Old", 1900));
+        _clock.Advance(TimeSpan.FromDays(10));
+        await NewCache().SetAsync("tmdb", "550", new Sample("New", 2000));
+
+        // Single row with the latest payload.
+        using var ctx = new CollectifyDbContext(_options);
+        var rows = await ctx.LookupCache.AsNoTracking()
+            .Where(e => e.Provider == "tmdb" && e.Key == "550")
+            .ToListAsync();
+        Assert.Single(rows);
+        Assert.Contains("\"title\":\"New\"", rows[0].JsonResponse);
+        Assert.Equal(_clock.GetUtcNow().UtcDateTime, rows[0].FetchedAt);
+    }
+
+    [Fact]
+    public async Task ProviderAndKeyTogetherIdentifyEntries()
+    {
+        await NewCache().SetAsync("tmdb", "550", new Sample("Fight Club", 1999));
+        await NewCache().SetAsync("imdb", "550", new Sample("Other thing", 2010));
+
+        var tmdb = await NewCache().GetAsync<Sample>("tmdb", "550", TimeSpan.FromDays(30));
+        var imdb = await NewCache().GetAsync<Sample>("imdb", "550", TimeSpan.FromDays(30));
+
+        Assert.Equal("Fight Club", tmdb!.Title);
+        Assert.Equal("Other thing", imdb!.Title);
+    }
+
+    [Fact]
+    public async Task Set_PersistsThroughDbContextLifetime()
+    {
+        await NewCache().SetAsync("tmdb", "550", new Sample("Fight Club", 1999));
+
+        // Verify a fresh context (separate scope) sees the row.
+        using var ctx = new CollectifyDbContext(_options);
+        var entry = await ctx.LookupCache.AsNoTracking().FirstAsync();
+        Assert.Equal("tmdb", entry.Provider);
+        Assert.Equal("550", entry.Key);
+        Assert.IsType<LookupCacheEntry>(entry);
+    }
+}


### PR DESCRIPTION
First slice of Phase 2. Lays the typed seam that the next three PRs (TMDB / MusicBrainz / IGDB) plug into. **No real HTTP yet** — a stub provider is registered for each media type and reports `IsConfigured=false`, so the lookup endpoint degrades to a 200 with an empty result list.

## Summary

### Infrastructure (`Collectify.Infrastructure/Lookup/`)
- `LookupResults.cs` — per-domain records (`MovieLookupResult`, `MusicLookupResult`, `GameLookupResult`).
- `IMetadataProviders.cs` — `IMovieMetadataProvider` / `IMusicMetadataProvider` / `IGameMetadataProvider`. Each exposes `Name`, `IsConfigured`, `SearchAsync`.
- `ILookupCache` + `LookupCache` — TimeProvider-driven cache on top of the existing `LookupCacheEntry` table. `Get` returns default past TTL; `Set` upserts and refreshes `FetchedAt`.
- `MetadataLookupOptions` — bound from `Collectify:Metadata`, with per-provider subsections (`Tmdb`, `MusicBrainz`, `Igdb`) and a 30-day default `CacheTtl`.
- `Stub/StubMovieProvider.cs` (+ music + game) — always-empty.
- `MetadataLookupServiceCollectionExtensions.AddMetadataLookup(config)` — binds options, registers `AddHttpClient()`, `ILookupCache`, and the three stubs via `TryAddScoped` so concrete provider PRs can override with `Replace()`.

### API
- `LookupEndpoints.cs` — `/api/lookup/{movies|music|games}` with `RequireAuthorization`. Validates `?q=` ≥ 2 non-whitespace chars, asks the registered provider, returns `{ provider, configured, results }`. Stub responds `configured: false` + `[]` (no 503), letting the frontend hint "set the env var to enable".
- `Program.cs` wires `AddMetadataLookup(builder.Configuration)` + `app.MapLookupEndpoints()`.

### Frontend
- `src/client/services/lookup.ts` — `useLookup(type, query)` TanStack Query hook. Disabled until `query.trim().length >= 2`. `staleTime: 60s`. No UI integration in this PR — form wiring comes in slice 2.

### Docs / config
- `.env.example` — replace the loose `TMDB_API_KEY=` stubs with the real config keys (`Collectify__Metadata__Tmdb__ApiKey`, `__MusicBrainz__UserAgent`, `__Igdb__TwitchClientId/Secret`), plus links and a note on graceful degradation.
- `docs/architecture.md` — "External providers" section rewritten to describe the per-domain interfaces, `AddMetadataLookup`, cache, and fail-soft contract.

### Packages (CPM)
- `Microsoft.Extensions.Http 10.0.7` (IHttpClientFactory)
- `Microsoft.Extensions.Options.ConfigurationExtensions 10.0.7` (`.Bind`)
- `Microsoft.Extensions.TimeProvider.Testing 9.10.0` (test-only; `FakeTimeProvider` for deterministic TTL tests)

## Test plan

### CI

- [x] `./scripts/ci-local.sh` — server **99/99** (84 prior + 6 cache + 9 endpoint), client **20/20**, both builds clean. ~52s.
- [x] `dotnet test --filter LookupCacheTests` — 6/6: get-before-set, within-TTL hit, expired-miss, upsert-refreshes-FetchedAt, `(Provider,Key)` namespacing, cross-context persistence.
- [x] `dotnet test --filter LookupEndpointsTests` — 9/9 (incl. theory rows): unauth → 401, missing / short / single-char `q` → 400, stub returns `configured:false` + `[]` for each of `movies` / `music` / `games`.

### Manual

Run the API + dev server, log in, then:

- [x] `curl http://localhost:5173/api/lookup/movies?q=inception` — wait, that's behind auth. From DevTools console (so the auth cookie comes along):
  ```js
  fetch('/api/lookup/movies?q=inception').then(r => r.json())
  // → { provider: "stub", configured: false, results: [] }
  ```
- [x] `?q=` (empty) or `?q=a` → `400 { error: "Query must be at least 2 characters." }`.
- [x] Repeat for `/api/lookup/music?q=radiohead` and `/api/lookup/games?q=hades`. Same shape, `configured: false`, `[]`.
- [x] Without an auth cookie: `401`.

## Out of scope

- Any real provider — TMDB lands in slice 2, MusicBrainz in 3, IGDB in 4.
- UI integration of `useLookup`. The hook is shipped so slice 2 can land both backend + UI in one PR.
- A "force refresh" / cache-bust query param. The current cache is fire-and-forget; if/when we need a TTL override per call we'll add it then.
- Image download / local cover storage. Slice 2 (TMDB) will introduce that, since TMDB hands back relative image paths that must be resolved against a CDN base URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_