### PR TITLE
feat: TMDB movie lookup — provider + MovieForm "Search online" UI

### DIFF
--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Button, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
+import OnlineSearch from './OnlineSearch';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
+import type { MovieLookupResult } from '../services/lookup';
 
 interface Props {
   initial?: Movie;
@@ -28,6 +30,17 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
   const patch = (p: Partial<Movie>) => setM((prev) => ({ ...prev, ...p }));
   const toggleFormat = (flag: number) => set('formats', (m.formats ?? 0) ^ flag);
 
+  const importLookup = (r: MovieLookupResult) => {
+    patch({
+      title: r.title,
+      originalTitle: r.originalTitle ?? null,
+      year: r.year ?? null,
+      description: r.description ?? null,
+      imagePath: r.imageUrl ?? null,
+      tmdbId: r.provider === 'tmdb' ? r.providerKey : m.tmdbId ?? null,
+    });
+  };
+
   return (
     <form
       className="space-y-4"
@@ -36,6 +49,18 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
         onSubmit({ ...m, title: m.title.trim() });
       }}
     >
+      <OnlineSearch
+        type="movies"
+        label="Search online (TMDB)"
+        placeholder="e.g. Inception"
+        onPick={importLookup}
+        renderItem={(r) => ({
+          primary: r.title + (r.year ? ` (${r.year})` : ''),
+          secondary: r.description?.slice(0, 120),
+          image: r.imageUrl,
+        })}
+      />
+
       <div className="grid sm:grid-cols-2 gap-4">
         <Field label="Title">
           <Input value={m.title} onChange={(e) => set('title', e.target.value)} required />

--- a/src/client/components/OnlineSearch.test.tsx
+++ b/src/client/components/OnlineSearch.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OnlineSearch from './OnlineSearch';
+
+// Swap the data layer with a controllable test double.
+const mockUseLookup = vi.fn();
+vi.mock('../services/lookup', () => ({
+  useLookup: (type: string, query: string) => mockUseLookup(type, query),
+}));
+
+describe('OnlineSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    mockUseLookup.mockReset();
+    vi.useRealTimers();
+  });
+
+  function renderForMovies(onPick = vi.fn()) {
+    render(
+      <OnlineSearch
+        type="movies"
+        onPick={onPick}
+        renderItem={(r) => ({
+          primary: r.title,
+          secondary: r.description ?? undefined,
+          image: r.imageUrl,
+        })}
+      />,
+    );
+    return { onPick };
+  }
+
+  it('does not query until at least 2 chars after debounce', async () => {
+    mockUseLookup.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    renderForMovies();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await user.type(screen.getByPlaceholderText('Type a title…'), 'i');
+    vi.advanceTimersByTime(500);
+
+    // Hook is still called by React on every render, but with the empty
+    // debounced value -- never with the in-progress single-char input.
+    const queries = mockUseLookup.mock.calls.map(([, q]) => q);
+    expect(queries).not.toContain('i');
+  });
+
+  it('passes the debounced query to the hook once the user stops typing', async () => {
+    mockUseLookup.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    renderForMovies();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await user.type(screen.getByPlaceholderText('Type a title…'), 'inception');
+    vi.advanceTimersByTime(400);
+
+    await waitFor(() => {
+      const queries = mockUseLookup.mock.calls.map(([, q]) => q);
+      expect(queries).toContain('inception');
+    });
+  });
+
+  it('renders the suggestions and calls onPick with the chosen item', async () => {
+    const item = {
+      provider: 'tmdb',
+      providerKey: '27205',
+      title: 'Inception',
+      originalTitle: 'Inception',
+      year: 2010,
+      director: null,
+      runtimeMinutes: null,
+      description: 'A heist on the subconscious.',
+      imageUrl: 'https://image.tmdb.org/t/p/w342/poster.jpg',
+      genres: null,
+    };
+    mockUseLookup.mockReturnValue({
+      data: { provider: 'tmdb', configured: true, results: [item] },
+      isLoading: false,
+      error: null,
+    });
+    const { onPick } = renderForMovies();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await user.type(screen.getByPlaceholderText('Type a title…'), 'inception');
+    vi.advanceTimersByTime(400);
+
+    const choice = await screen.findByText('Inception');
+    await user.click(choice);
+
+    expect(onPick).toHaveBeenCalledWith(item);
+  });
+
+  it('shows the not-configured hint when the server reports configured=false', () => {
+    // The dropdown is closed at mount; the inline label below the input
+    // surfaces the hint so users see it before they even start typing.
+    mockUseLookup.mockReturnValue({
+      data: { provider: 'tmdb', configured: false, results: [] },
+      isLoading: false,
+      error: null,
+    });
+    renderForMovies();
+
+    expect(screen.getByText(/online lookup not configured/i)).toBeInTheDocument();
+  });
+
+  it('shows "no matches" when the provider is configured but returned nothing', async () => {
+    mockUseLookup.mockReturnValue({
+      data: { provider: 'tmdb', configured: true, results: [] },
+      isLoading: false,
+      error: null,
+    });
+    renderForMovies();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await user.type(screen.getByPlaceholderText('Type a title…'), 'zzz');
+    vi.advanceTimersByTime(400);
+
+    expect(await screen.findByText('No matches.')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/OnlineSearch.tsx
+++ b/src/client/components/OnlineSearch.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { useLookup } from '../services/lookup';
+import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
+import type { MediaType } from '../services/types';
+import { Field, Input, Label } from './ui';
+
+type ResultMap = {
+  movies: MovieLookupResult;
+  music: MusicLookupResult;
+  games: GameLookupResult;
+};
+
+interface Props<T extends MediaType> {
+  type: T;
+  /** How to render a single suggestion row in the dropdown. */
+  renderItem: (item: ResultMap[T]) => { primary: string; secondary?: ReactNode; image?: string | null };
+  /** Called when the user clicks a suggestion. The form converts the result into its own state shape. */
+  onPick: (item: ResultMap[T]) => void;
+  /** Optional label shown above the input. */
+  label?: string;
+  placeholder?: string;
+}
+
+/**
+ * Provider-backed type-ahead used as a "Search online" affordance on the
+ * three media forms. Debounces input by 300 ms, hides the dropdown when the
+ * query is empty, and surfaces a small hint when the server reports
+ * `configured: false` so users know they need to set the provider key.
+ */
+export default function OnlineSearch<T extends MediaType>({
+  type,
+  renderItem,
+  onPick,
+  label = 'Search online',
+  placeholder = 'Type a title…',
+}: Props<T>) {
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query), 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const lookup = useLookup(type, debounced);
+  const data = lookup.data;
+
+  const results = (data?.results ?? []) as ResultMap[T][];
+  const showDropdown = open && debounced.trim().length >= 2;
+
+  return (
+    <div className="relative">
+      <Field label={label}>
+        <Input
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder={placeholder}
+        />
+      </Field>
+
+      {showDropdown && (
+        <div className="absolute z-10 mt-1 w-full rounded-md bg-slate-900 border border-slate-700 shadow-lg max-h-80 overflow-auto">
+          {lookup.isLoading && <div className="px-3 py-2 text-sm text-slate-400">Searching…</div>}
+          {lookup.error && <div className="px-3 py-2 text-sm text-rose-400">Lookup failed.</div>}
+
+          {data && !data.configured && (
+            <div className="px-3 py-2 text-xs text-slate-400 border-b border-slate-800">
+              Online lookup is not configured. Set the provider env var to enable.
+            </div>
+          )}
+
+          {data && data.configured && results.length === 0 && !lookup.isLoading && (
+            <div className="px-3 py-2 text-sm text-slate-400">No matches.</div>
+          )}
+
+          {results.map((item, i) => {
+            const r = renderItem(item);
+            return (
+              <button
+                type="button"
+                key={`${(item as { providerKey: string }).providerKey ?? i}`}
+                onClick={() => {
+                  onPick(item);
+                  setOpen(false);
+                  setQuery('');
+                  setDebounced('');
+                }}
+                className="w-full text-left flex gap-3 items-start px-3 py-2 hover:bg-slate-800 border-b border-slate-800 last:border-b-0"
+              >
+                {r.image && (
+                  <img src={r.image} alt="" className="w-10 h-14 object-cover rounded flex-none" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-slate-100 truncate">{r.primary}</div>
+                  {r.secondary && <div className="text-xs text-slate-400 truncate">{r.secondary}</div>}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {data && !data.configured && !showDropdown && (
+        <Label>
+          <span className="text-slate-500 italic">
+            Online lookup not configured.
+          </span>
+        </Label>
+      )}
+    </div>
+  );
+}

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -3,6 +3,7 @@ using Collectify.Api.Endpoints;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.Tmdb;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -63,6 +64,7 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 });
 
 builder.Services.AddMetadataLookup(builder.Configuration);
+builder.Services.AddTmdbMovieProvider(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
@@ -1,0 +1,90 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.Tmdb;
+
+/// <summary>
+/// IMovieMetadataProvider backed by themoviedb.org v3 /search/movie. Empty
+/// query strings and unconfigured installs short-circuit to an empty result.
+/// Every successful upstream call is cached in the LookupCacheEntry table
+/// keyed by the lowercased query string, so repeat searches don't burn rate
+/// limits or wait on the network.
+/// </summary>
+public sealed class TmdbMovieProvider : IMovieMetadataProvider
+{
+    public const string ProviderName = "tmdb";
+
+    private readonly HttpClient _http;
+    private readonly ILookupCache _cache;
+    private readonly MetadataLookupOptions _options;
+    private readonly ILogger<TmdbMovieProvider> _log;
+
+    public TmdbMovieProvider(
+        HttpClient http,
+        ILookupCache cache,
+        IOptions<MetadataLookupOptions> options,
+        ILogger<TmdbMovieProvider> log)
+    {
+        _http = http;
+        _cache = cache;
+        _options = options.Value;
+        _log = log;
+    }
+
+    public string Name => ProviderName;
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_options.Tmdb.ApiKey);
+
+    public async Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return [];
+        var trimmed = query.Trim();
+        if (trimmed.Length == 0) return [];
+
+        var cacheKey = "search:" + trimmed.ToLowerInvariant();
+
+        var cached = await _cache.GetAsync<List<MovieLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        TmdbSearchResponse? body;
+        try
+        {
+            var url = $"search/movie?query={Uri.EscapeDataString(trimmed)}&include_adult=false&api_key={Uri.EscapeDataString(_options.Tmdb.ApiKey!)}";
+            body = await _http.GetFromJsonAsync<TmdbSearchResponse>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "TMDB search failed for {Query}", trimmed);
+            return [];
+        }
+
+        var mapped = (body?.Results ?? []).Select(Map).ToList();
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+
+    private MovieLookupResult Map(TmdbMovieSummary s) => new(
+        Provider: ProviderName,
+        ProviderKey: s.Id.ToString(),
+        Title: s.Title ?? s.OriginalTitle ?? string.Empty,
+        OriginalTitle: s.OriginalTitle,
+        Year: ParseYear(s.ReleaseDate),
+        Director: null,
+        RuntimeMinutes: null,
+        Description: s.Overview,
+        ImageUrl: BuildImageUrl(s.PosterPath),
+        Genres: null);
+
+    private static int? ParseYear(string? releaseDate)
+    {
+        if (releaseDate is null || releaseDate.Length < 4) return null;
+        return int.TryParse(releaseDate[..4], out var year) ? year : null;
+    }
+
+    private string? BuildImageUrl(string? posterPath)
+    {
+        if (string.IsNullOrWhiteSpace(posterPath)) return null;
+        var baseUrl = _options.Tmdb.ImageBaseUrl.TrimEnd('/');
+        return $"{baseUrl}{posterPath}";
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Collectify.Infrastructure.Lookup.Tmdb;
+
+/// <summary>
+/// Subset of the TMDB v3 /search/movie response we actually consume.
+/// Fields we don't need (vote_average, popularity, backdrop_path, …) are
+/// intentionally absent so the JsonResponse cached on disk stays compact.
+/// </summary>
+internal sealed record TmdbSearchResponse(
+    [property: JsonPropertyName("results")] IReadOnlyList<TmdbMovieSummary> Results);
+
+internal sealed record TmdbMovieSummary(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("original_title")] string? OriginalTitle,
+    [property: JsonPropertyName("release_date")] string? ReleaseDate,
+    [property: JsonPropertyName("overview")] string? Overview,
+    [property: JsonPropertyName("poster_path")] string? PosterPath);

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.Tmdb;
+
+public static class TmdbServiceCollectionExtensions
+{
+    /// <summary>
+    /// Replace the stub IMovieMetadataProvider with a real TMDB-backed one.
+    /// Call after AddMetadataLookup so the options are bound first; the
+    /// typed HttpClient picks up MetadataLookupOptions.Tmdb.BaseUrl from
+    /// the same Collectify:Metadata config block.
+    /// </summary>
+    public static IServiceCollection AddTmdbMovieProvider(this IServiceCollection services, IConfiguration _)
+    {
+        services.AddHttpClient<TmdbMovieProvider>((sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MetadataLookupOptions>>().Value;
+            client.BaseAddress = new Uri(opts.Tmdb.BaseUrl);
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        });
+
+        // AddMetadataLookup uses TryAddScoped for the stub, so a hard
+        // RemoveAll + AddScoped here wins regardless of call order.
+        services.RemoveAll<IMovieMetadataProvider>();
+        services.AddScoped<IMovieMetadataProvider>(sp => sp.GetRequiredService<TmdbMovieProvider>());
+
+        return services;
+    }
+}

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -40,7 +40,7 @@ public class LookupEndpointsTests
     }
 
     [Fact]
-    public async Task SearchMovies_WithStubProvider_ReportsNotConfiguredAndEmpty()
+    public async Task SearchMovies_WithoutConfiguredProvider_ReturnsEmpty()
     {
         await using var factory = new CollectifyApiFactory();
         var alice = await factory.CreateAuthenticatedUserAsync("alice");
@@ -49,8 +49,7 @@ public class LookupEndpointsTests
             "/api/lookup/movies?q=inception");
 
         Assert.NotNull(body);
-        Assert.Equal("stub", body!.Provider);
-        Assert.False(body.Configured);
+        Assert.False(body!.Configured);
         Assert.Empty(body.Results);
     }
 

--- a/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
@@ -1,0 +1,217 @@
+using System.Net;
+using System.Text;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.Tmdb;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class TmdbMovieProviderTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _dbOptions;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    public TmdbMovieProviderTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbOptions = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_dbOptions);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private TmdbMovieProvider NewProvider(StubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.themoviedb.org/3/") };
+        var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
+        var options = overrideOptions ?? new MetadataLookupOptions
+        {
+            Tmdb = new TmdbOptions { ApiKey = "key-xyz" },
+        };
+        return new TmdbMovieProvider(http, cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task IsConfigured_ReflectsApiKeyPresence()
+    {
+        var configured = NewProvider(new StubHandler("{ \"results\": [] }"));
+        var unconfigured = NewProvider(new StubHandler("never called"), new MetadataLookupOptions());
+
+        Assert.True(configured.IsConfigured);
+        Assert.False(unconfigured.IsConfigured);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithoutApiKey_ShortCircuitsToEmpty_AndDoesNotCallTmdb()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, new MetadataLookupOptions());
+
+        var results = await provider.SearchAsync("inception");
+
+        Assert.Empty(results);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithBlankQuery_ReturnsEmptyWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler);
+
+        var results = await provider.SearchAsync("   ");
+
+        Assert.Empty(results);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_HitsTmdbWithUrlEncodedQuery_AndIncludesApiKey()
+    {
+        var handler = new StubHandler("{ \"results\": [] }");
+        var provider = NewProvider(handler);
+
+        await provider.SearchAsync("the matrix");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("search/movie", url);
+        Assert.Contains("query=the%20matrix", url);
+        Assert.Contains("api_key=key-xyz", url);
+        Assert.Contains("include_adult=false", url);
+    }
+
+    [Fact]
+    public async Task SearchAsync_MapsSummariesToLookupResults_WithImageUrlAndYear()
+    {
+        const string body = """
+        {
+          "results": [
+            {
+              "id": 27205,
+              "title": "Inception",
+              "original_title": "Inception",
+              "release_date": "2010-07-15",
+              "overview": "A heist on the subconscious.",
+              "poster_path": "/poster123.jpg"
+            }
+          ]
+        }
+        """;
+        var provider = NewProvider(new StubHandler(body));
+
+        var results = await provider.SearchAsync("inception");
+
+        var hit = Assert.Single(results);
+        Assert.Equal("tmdb", hit.Provider);
+        Assert.Equal("27205", hit.ProviderKey);
+        Assert.Equal("Inception", hit.Title);
+        Assert.Equal("Inception", hit.OriginalTitle);
+        Assert.Equal(2010, hit.Year);
+        Assert.Equal("A heist on the subconscious.", hit.Description);
+        Assert.Equal("https://image.tmdb.org/t/p/w342/poster123.jpg", hit.ImageUrl);
+        Assert.Null(hit.Director);
+        Assert.Null(hit.RuntimeMinutes);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithMissingPoster_LeavesImageUrlNull()
+    {
+        var provider = NewProvider(new StubHandler("""
+            { "results": [ { "id": 1, "title": "X", "release_date": "1999-01-01" } ] }
+            """));
+
+        var results = await provider.SearchAsync("x");
+
+        Assert.Null(results[0].ImageUrl);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithUnparseableReleaseDate_LeavesYearNull()
+    {
+        var provider = NewProvider(new StubHandler("""
+            { "results": [ { "id": 1, "title": "X", "release_date": "" } ] }
+            """));
+
+        var results = await provider.SearchAsync("x");
+
+        Assert.Null(results[0].Year);
+    }
+
+    [Fact]
+    public async Task SearchAsync_RepeatedQuery_HitsCacheOnSecondCall()
+    {
+        var handler = new StubHandler("""
+            { "results": [ { "id": 1, "title": "X", "release_date": "1999-01-01" } ] }
+            """);
+        var provider1 = NewProvider(handler);
+        var provider2 = NewProvider(handler); // same cache (shared sqlite), fresh provider instance
+
+        var first = await provider1.SearchAsync("x");
+        var second = await provider2.SearchAsync("X"); // case-insensitive cache key
+
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Single(handler.RequestedUrls); // second call served from cache
+    }
+
+    [Fact]
+    public async Task SearchAsync_AfterTtlExpires_RefreshesFromTmdb()
+    {
+        var handler = new StubHandler("""
+            { "results": [ { "id": 1, "title": "X", "release_date": "1999-01-01" } ] }
+            """);
+        var provider = NewProvider(handler);
+
+        await provider.SearchAsync("x");
+        _clock.Advance(TimeSpan.FromDays(31));
+        await provider.SearchAsync("x");
+
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    [Fact]
+    public async Task SearchAsync_OnUpstreamFailure_ReturnsEmpty_AndDoesNotCache()
+    {
+        var handler = new StubHandler("error", HttpStatusCode.InternalServerError);
+        var provider = NewProvider(handler);
+
+        var results = await provider.SearchAsync("x");
+        Assert.Empty(results);
+
+        // A subsequent call should attempt the network again rather than
+        // returning an empty cached value.
+        await provider.SearchAsync("x");
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly HttpStatusCode _status;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // AbsoluteUri keeps percent-encoding intact; ToString unescapes %20 -> space.
+            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
Phase 2 slice 2: TMDB end-to-end. Replaces the `StubMovieProvider` with a real TMDB v3 search-backed provider and wires a debounced type-ahead into `MovieForm`.

## Summary

### Server (`Collectify.Infrastructure/Lookup/Tmdb/`)

- **`TmdbResponses.cs`** — minimal JSON DTOs for `/search/movie` (only the fields we map; cached payload stays compact).
- **`TmdbMovieProvider.cs`** — `IMovieMetadataProvider` impl. Empty/blank queries and unconfigured installs short-circuit to `[]`. Cache key is `"search:" + lowercased query`, TTL from `MetadataLookupOptions.CacheTtl` (30 days). Upstream failures are logged and surfaced as `[]` without poisoning the cache.
- **`TmdbServiceCollectionExtensions.AddTmdbMovieProvider`** — registers a typed `HttpClient<TmdbMovieProvider>` against `MetadataLookupOptions.Tmdb.BaseUrl`, then `RemoveAll<IMovieMetadataProvider>` + `AddScoped` so it wins over the stub regardless of registration order.
- `Program.cs` calls `AddTmdbMovieProvider` after `AddMetadataLookup`.

### Client

- **`OnlineSearch.tsx`** — reusable type-ahead generic over `MediaType`. 300 ms debounce, dropdown opens on focus / typing, closes on pick / clears the input. Surfaces "not configured" both inline (initial state) and inside the open dropdown. Empty-result case reads "No matches." Image thumbnail per row when the provider returns one. Designed to drop into `AlbumForm` and `GameForm` later.
- **`MovieForm.tsx`** — drops in `<OnlineSearch type="movies" label="Search online (TMDB)" />`. `importLookup()` patches `title`, `originalTitle`, `year`, `description`, `imagePath` (the TMDB CDN URL) and `tmdbId` from the picked result.

## Test plan

### CI

- [x] `./scripts/ci-local.sh` — server **109/109** (99 prior + 10 new TMDB), client **25/25** (20 prior + 5 new OnlineSearch). Both builds clean, ~48s.
- [x] `dotnet test --filter TmdbMovieProviderTests`:
  1. `IsConfigured` reflects API-key presence.
  2. Unconfigured `SearchAsync` short-circuits — never calls the network.
  3. Blank query short-circuits — never calls the network.
  4. URL is built with URL-encoded query, the api_key, and `include_adult=false`.
  5. Summaries map to `MovieLookupResult` (id, title, year from `release_date`, image URL = CDN base + poster_path, overview).
  6. Missing `poster_path` → `null` `imageUrl`.
  7. Unparseable `release_date` → `null` year.
  8. Repeat query is cache-served (case-insensitive key).
  9. Past TTL the next call refreshes from TMDB.
  10. Upstream 500 returns `[]` and does not cache an empty list.
- [x] Existing `LookupEndpointsTests` were updated to drop the hard-coded `provider == "stub"` check (registered provider is now `tmdb`); behaviour assertion (`configured: false` + `[]` when no key set) is unchanged.

### Manual

Set the env var, then start both servers:

```bash
export Collectify__Metadata__Tmdb__ApiKey=YOUR_V3_KEY
cd src/server && dotnet run --project Collectify.Api
# in another terminal
cd src/client && npm run dev
```

- [x] Open `/movies/new`. The new "Search online (TMDB)" input sits above the Title field.
- [x] Without the env var: typing `inception` shows "Online lookup not configured." inline and inside the dropdown; no requests to themoviedb.org.
- [x] With the env var: typing `inception` (debounce 300 ms) shows TMDB results with poster thumbnails. Clicking a row populates Title, Original title, Year, Description, Image URL, and TMDB ID. The user can edit anything before saving.
- [x] Repeat the same search → DevTools Network shows no second request (served from `LookupCacheEntry` table).

## Out of scope

- **Director / runtime** — TMDB needs a second `/movie/{id}` (and `/credits`) call. Easy follow-up; the provider already has a cache to hang it off.
- **Local image download** — currently `imagePath` stores the TMDB CDN URL and the browser fetches it directly. A future PR can introduce a server-side download to `data/covers/` so collections work fully offline / privately.
- **MusicBrainz / IGDB** — slices 3 and 4. The seam from PR #12 means each is mostly typed `HttpClient` + provider class.
- **v4 API Bearer token** — current support is the v3 `?api_key=` query param only. Adding `Authorization: Bearer {token}` is a small follow-up if/when someone needs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_