### PR TITLE
feat: DB-backed cover-image cache + thumbnails + external IDs visible

### DIFF
--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Field, Input, SectionHeading, Select, Textarea } from './ui';
+import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import { MUSIC_FORMATS, type Album } from '../services/types';
 
@@ -82,6 +82,24 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
             onChange={(e) => set('lastPlayedOn', e.target.value || null)}
           />
         </Field>
+      </div>
+
+      <SectionHeading>External IDs</SectionHeading>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <ExternalIdField
+          label="MusicBrainz release ID"
+          value={a.musicBrainzReleaseId}
+          onChange={(v) => set('musicBrainzReleaseId', v)}
+          urlPrefix="https://musicbrainz.org/release/"
+          placeholder="e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf"
+        />
+        <ExternalIdField
+          label="Discogs ID"
+          value={a.discogsId}
+          onChange={(v) => set('discogsId', v)}
+          urlPrefix="https://www.discogs.com/release/"
+          placeholder="e.g. 12345"
+        />
       </div>
 
       <Field label="Notes">

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -45,31 +45,49 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {items.map((item) => {
-          const base = item as CollectionItemBase & { id?: number };
+          const base = item as CollectionItemBase & { id?: number; imagePath?: string | null };
           const r = renderItem(item);
           const tags = base.tags ?? [];
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="block">
-              <Card className="hover:border-indigo-500 transition-colors h-full flex flex-col gap-1.5">
-                <div className="flex items-start gap-2">
-                  <div className="font-medium text-white truncate flex-1">{r.primary}</div>
-                  <StatusPill status={base.status} />
-                </div>
-                {r.secondary && <div className="text-sm text-slate-400 truncate">{r.secondary}</div>}
-                {r.tertiary && <div className="text-xs text-slate-500 truncate">{r.tertiary}</div>}
-                {base.personalRating != null && (
-                  <div className="text-xs text-amber-300">★ {base.personalRating}/10</div>
-                )}
-                {tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mt-1">
-                    {tags.slice(0, 5).map((t) => (
-                      <TagChip key={t} name={t} />
-                    ))}
-                    {tags.length > 5 && (
-                      <span className="text-xs text-slate-500">+{tags.length - 5}</span>
-                    )}
+              <Card className="hover:border-indigo-500 transition-colors h-full !p-3 flex gap-3">
+                {base.imagePath ? (
+                  <img
+                    src={base.imagePath}
+                    alt=""
+                    loading="lazy"
+                    className="w-16 h-24 object-cover rounded flex-none bg-slate-800"
+                  />
+                ) : (
+                  <div
+                    aria-hidden
+                    className="w-16 h-24 rounded flex-none bg-slate-800 border border-slate-700 flex items-center justify-center text-slate-600 text-xs"
+                  >
+                    no cover
                   </div>
                 )}
+
+                <div className="min-w-0 flex-1 flex flex-col gap-1">
+                  <div className="flex items-start gap-2">
+                    <div className="font-medium text-white truncate flex-1">{r.primary}</div>
+                    <StatusPill status={base.status} />
+                  </div>
+                  {r.secondary && <div className="text-sm text-slate-400 truncate">{r.secondary}</div>}
+                  {r.tertiary && <div className="text-xs text-slate-500 truncate">{r.tertiary}</div>}
+                  {base.personalRating != null && (
+                    <div className="text-xs text-amber-300">★ {base.personalRating}/10</div>
+                  )}
+                  {tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-auto">
+                      {tags.slice(0, 4).map((t) => (
+                        <TagChip key={t} name={t} />
+                      ))}
+                      {tags.length > 4 && (
+                        <span className="text-xs text-slate-500">+{tags.length - 4}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
               </Card>
             </Link>
           );

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Field, Input, SectionHeading, Select, Textarea } from './ui';
+import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import {
   COMPLETION_STATUSES,
@@ -114,6 +114,17 @@ export default function GameForm({ initial, submitting, submitLabel = 'Save', on
             onChange={(e) => set('lastPlayedOn', e.target.value || null)}
           />
         </Field>
+      </div>
+
+      <SectionHeading>External IDs</SectionHeading>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <ExternalIdField
+          label="IGDB ID"
+          value={g.igdbId}
+          onChange={(v) => set('igdbId', v)}
+          urlPrefix="https://www.igdb.com/games/"
+          placeholder="e.g. hades"
+        />
       </div>
 
       <Field label="Notes">

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Field, Input, SectionHeading, Select, Textarea } from './ui';
+import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
@@ -136,6 +136,24 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
             onChange={(e) => set('watchCount', Number(e.target.value || 0))}
           />
         </Field>
+      </div>
+
+      <SectionHeading>External IDs</SectionHeading>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <ExternalIdField
+          label="TMDB ID"
+          value={m.tmdbId}
+          onChange={(v) => set('tmdbId', v)}
+          urlPrefix="https://www.themoviedb.org/movie/"
+          placeholder="e.g. 27205"
+        />
+        <ExternalIdField
+          label="IMDB ID"
+          value={m.imdbId}
+          onChange={(v) => set('imdbId', v)}
+          urlPrefix="https://www.imdb.com/title/"
+          placeholder="e.g. tt1375666"
+        />
       </div>
 
       <Field label="Notes">

--- a/src/client/components/ui.tsx
+++ b/src/client/components/ui.tsx
@@ -250,3 +250,45 @@ export function TagInput({ value, onChange, suggestions = [], placeholder = 'Add
     </div>
   );
 }
+
+// ---------- External ID field ----------
+
+interface ExternalIdFieldProps {
+  label: string;
+  value: string | null | undefined;
+  onChange: (next: string | null) => void;
+  /** When set and a value is present, renders a "View ↗" link to `${urlPrefix}${value}`. */
+  urlPrefix?: string;
+  placeholder?: string;
+}
+
+/**
+ * Editable input for a third-party identifier (TMDB, IMDB, MusicBrainz,
+ * IGDB, …). Surfaces the stored value so users can verify what a lookup
+ * populated, manually paste an ID to seed metadata, and jump to the
+ * provider's page in a new tab.
+ */
+export function ExternalIdField({ label, value, onChange, urlPrefix, placeholder }: ExternalIdFieldProps) {
+  return (
+    <Field label={label}>
+      <div className="flex gap-2 items-center">
+        <Input
+          value={value ?? ''}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value || null)}
+        />
+        {value && urlPrefix && (
+          <a
+            href={`${urlPrefix}${value}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-indigo-300 hover:text-indigo-200 underline whitespace-nowrap"
+            aria-label={`Open ${label} on the provider's site`}
+          >
+            View ↗
+          </a>
+        )}
+      </div>
+    </Field>
+  );
+}

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': 'http://localhost:5041',
+      // Cover images also live on the API. In production the SPA is served
+      // by the same Kestrel process so this is the same origin; in dev we
+      // need an explicit proxy entry or `<img src="/covers/...">` falls
+      // through to the SPA fallback and renders index.html as HTML.
+      '/covers': 'http://localhost:5041',
     },
   },
   build: {

--- a/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Collectify.Api.Endpoints;
+
+public static class CoversEndpoints
+{
+    private static readonly Dictionary<string, string> ContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"] = "image/png",
+        [".webp"] = "image/webp",
+        [".gif"] = "image/gif",
+    };
+
+    /// <summary>
+    /// Streams cached cover images out of the configured covers directory.
+    /// Intentionally not auth-required so img tags work without a fetch
+    /// dance; filenames are content-hashed (16 hex chars + extension) so
+    /// they're not enumerable. The directory is read from configuration on
+    /// each request so test hosts can override Collectify:DataDir.
+    /// </summary>
+    public static IEndpointRouteBuilder MapCoversEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/covers/{filename}", (string filename, IConfiguration config) =>
+        {
+            // Defence in depth against path traversal: the public contract
+            // is a flat, hash-named filename. Reject anything that doesn't
+            // match that shape before touching the filesystem.
+            if (string.IsNullOrEmpty(filename)) return Results.NotFound();
+            if (filename.Contains('/') || filename.Contains('\\') || filename.Contains("..")) return Results.NotFound();
+            if (Path.GetFileName(filename) != filename) return Results.NotFound();
+
+            var dataDir = config["Collectify:DataDir"] ?? Path.Combine(AppContext.BaseDirectory, "data");
+            var coversDir = Path.Combine(dataDir, "covers");
+            var path = Path.Combine(coversDir, filename);
+            if (!File.Exists(path)) return Results.NotFound();
+
+            var ext = Path.GetExtension(filename);
+            var contentType = ContentTypes.TryGetValue(ext, out var ct) ? ct : "application/octet-stream";
+
+            return Results.File(path, contentType);
+        });
+
+        return app;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
@@ -1,45 +1,34 @@
-using Microsoft.Extensions.Configuration;
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace Collectify.Api.Endpoints;
 
 public static class CoversEndpoints
 {
-    private static readonly Dictionary<string, string> ContentTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        [".jpg"] = "image/jpeg",
-        [".jpeg"] = "image/jpeg",
-        [".png"] = "image/png",
-        [".webp"] = "image/webp",
-        [".gif"] = "image/gif",
-    };
-
     /// <summary>
-    /// Streams cached cover images out of the configured covers directory.
+    /// Streams cover-image bytes from the CoverImages table by content hash.
     /// Intentionally not auth-required so img tags work without a fetch
-    /// dance; filenames are content-hashed (16 hex chars + extension) so
-    /// they're not enumerable. The directory is read from configuration on
-    /// each request so test hosts can override Collectify:DataDir.
+    /// dance; the hash is 16 hex chars derived from a URL the user already
+    /// saw in their own collection, so they're effectively unguessable.
     /// </summary>
     public static IEndpointRouteBuilder MapCoversEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/covers/{filename}", (string filename, IConfiguration config) =>
+        app.MapGet("/covers/{hash}", async (string hash, CollectifyDbContext db, CancellationToken ct) =>
         {
-            // Defence in depth against path traversal: the public contract
-            // is a flat, hash-named filename. Reject anything that doesn't
-            // match that shape before touching the filesystem.
-            if (string.IsNullOrEmpty(filename)) return Results.NotFound();
-            if (filename.Contains('/') || filename.Contains('\\') || filename.Contains("..")) return Results.NotFound();
-            if (Path.GetFileName(filename) != filename) return Results.NotFound();
+            // Public contract is a flat 16-char hex hash. Reject anything
+            // else before touching the DB.
+            if (string.IsNullOrEmpty(hash) || hash.Length is < 8 or > 32) return Results.NotFound();
+            for (var i = 0; i < hash.Length; i++)
+            {
+                var c = hash[i];
+                if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return Results.NotFound();
+            }
 
-            var dataDir = config["Collectify:DataDir"] ?? Path.Combine(AppContext.BaseDirectory, "data");
-            var coversDir = Path.Combine(dataDir, "covers");
-            var path = Path.Combine(coversDir, filename);
-            if (!File.Exists(path)) return Results.NotFound();
+            var entry = await db.CoverImages.AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Hash == hash, ct);
+            if (entry is null) return Results.NotFound();
 
-            var ext = Path.GetExtension(filename);
-            var contentType = ContentTypes.TryGetValue(ext, out var ct) ? ct : "application/octet-stream";
-
-            return Results.File(path, contentType);
+            return Results.File(entry.Bytes, entry.ContentType);
         });
 
         return app;

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -2,6 +2,7 @@ using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -74,29 +75,31 @@ public static class GamesEndpoints
             return g is null ? Results.NotFound() : Results.Ok(ToDto(g));
         });
 
-        group.MapPost("/", async ([FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPost("/", async ([FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var g = new Game { OwnerId = ownerId };
             ApplyDto(g, dto);
+            g.ImagePath = await covers.EnsureLocalAsync(g.ImagePath, ct);
             g.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             db.Games.Add(g);
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Created($"/api/games/{g.Id}", ToDto(g));
         });
 
-        group.MapPut("/{id:int}", async (int id, [FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPut("/{id:int}", async (int id, [FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var g = await db.Games.Include(x => x.Tags)
-                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
             if (g is null) return Results.NotFound();
             ApplyDto(g, dto);
+            g.ImagePath = await covers.EnsureLocalAsync(g.ImagePath, ct);
             g.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             g.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Ok(ToDto(g));
         });
 

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -2,6 +2,7 @@ using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -77,29 +78,31 @@ public static class MoviesEndpoints
             return m is null ? Results.NotFound() : Results.Ok(ToDto(m));
         });
 
-        group.MapPost("/", async ([FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPost("/", async ([FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var m = new Movie { OwnerId = ownerId };
             ApplyDto(m, dto);
+            m.ImagePath = await covers.EnsureLocalAsync(m.ImagePath, ct);
             m.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             db.Movies.Add(m);
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Created($"/api/movies/{m.Id}", ToDto(m));
         });
 
-        group.MapPut("/{id:int}", async (int id, [FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPut("/{id:int}", async (int id, [FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var m = await db.Movies.Include(x => x.Tags)
-                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
             if (m is null) return Results.NotFound();
             ApplyDto(m, dto);
+            m.ImagePath = await covers.EnsureLocalAsync(m.ImagePath, ct);
             m.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             m.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Ok(ToDto(m));
         });
 

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -2,6 +2,7 @@ using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -73,29 +74,31 @@ public static class MusicEndpoints
             return a is null ? Results.NotFound() : Results.Ok(ToDto(a));
         });
 
-        group.MapPost("/", async ([FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPost("/", async ([FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var a = new MusicAlbum { OwnerId = ownerId };
             ApplyDto(a, dto);
+            a.ImagePath = await covers.EnsureLocalAsync(a.ImagePath, ct);
             a.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             db.MusicAlbums.Add(a);
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Created($"/api/music/{a.Id}", ToDto(a));
         });
 
-        group.MapPut("/{id:int}", async (int id, [FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        group.MapPut("/{id:int}", async (int id, [FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
         {
             if (Validate(dto) is { } error) return error;
             var ownerId = users.GetUserId(ctx.User)!;
             var a = await db.MusicAlbums.Include(x => x.Tags)
-                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
             if (a is null) return Results.NotFound();
             ApplyDto(a, dto);
+            a.ImagePath = await covers.EnsureLocalAsync(a.ImagePath, ct);
             a.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
             a.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsync(ct);
             return Results.Ok(ToDto(a));
         });
 

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -3,6 +3,7 @@ using Collectify.Api.Endpoints;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.Images;
 using Collectify.Infrastructure.Lookup.Tmdb;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -66,6 +67,19 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 builder.Services.AddMetadataLookup(builder.Configuration);
 builder.Services.AddTmdbMovieProvider(builder.Configuration);
 
+// Cover-image cache. The on-disk path is resolved at DI-resolution time
+// (not at builder time) so test hosts that override Collectify:DataDir
+// via ConfigureAppConfiguration get the right value -- those callbacks
+// fire during Build, which is after this code runs.
+builder.Services.AddHttpClient(CoverImageStore.HttpClientName);
+builder.Services.AddSingleton<ICoverImageStore>(sp => new CoverImageStore(
+    ResolveCoversDir(sp.GetRequiredService<IConfiguration>()),
+    sp.GetRequiredService<IHttpClientFactory>(),
+    sp.GetRequiredService<ILogger<CoverImageStore>>()));
+
+static string ResolveCoversDir(IConfiguration config) =>
+    Path.Combine(config["Collectify:DataDir"] ?? Path.Combine(AppContext.BaseDirectory, "data"), "covers");
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
@@ -83,6 +97,7 @@ app.MapMusicEndpoints();
 app.MapGamesEndpoints();
 app.MapTagEndpoints();
 app.MapLookupEndpoints();
+app.MapCoversEndpoints();
 
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok" }));
 

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -67,18 +67,10 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 builder.Services.AddMetadataLookup(builder.Configuration);
 builder.Services.AddTmdbMovieProvider(builder.Configuration);
 
-// Cover-image cache. The on-disk path is resolved at DI-resolution time
-// (not at builder time) so test hosts that override Collectify:DataDir
-// via ConfigureAppConfiguration get the right value -- those callbacks
-// fire during Build, which is after this code runs.
+// Cover-image cache. Bytes live in the CoverImages table alongside the
+// rest of the data so a backup of collectify.db is a complete snapshot.
 builder.Services.AddHttpClient(CoverImageStore.HttpClientName);
-builder.Services.AddSingleton<ICoverImageStore>(sp => new CoverImageStore(
-    ResolveCoversDir(sp.GetRequiredService<IConfiguration>()),
-    sp.GetRequiredService<IHttpClientFactory>(),
-    sp.GetRequiredService<ILogger<CoverImageStore>>()));
-
-static string ResolveCoversDir(IConfiguration config) =>
-    Path.Combine(config["Collectify:DataDir"] ?? Path.Combine(AppContext.BaseDirectory, "data"), "covers");
+builder.Services.AddScoped<ICoverImageStore, CoverImageStore>();
 
 var app = builder.Build();
 

--- a/src/server/Collectify.Domain/Entities/CoverImage.cs
+++ b/src/server/Collectify.Domain/Entities/CoverImage.cs
@@ -1,0 +1,16 @@
+namespace Collectify.Domain.Entities;
+
+/// <summary>
+/// Cached cover-image bytes keyed by the content-hash slice used in the
+/// public /covers/{hash} URL. Two items pointing at the same poster share
+/// a single row; the JsonResponse / Bytes blob lives in the SQLite file
+/// alongside the rest of the data, so a backup of collectify.db is a full
+/// backup of the collection.
+/// </summary>
+public class CoverImage
+{
+    public string Hash { get; set; } = string.Empty;
+    public string ContentType { get; set; } = string.Empty;
+    public byte[] Bytes { get; set; } = [];
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/server/Collectify.Infrastructure/Data/CollectifyDbContext.cs
+++ b/src/server/Collectify.Infrastructure/Data/CollectifyDbContext.cs
@@ -14,6 +14,7 @@ public class CollectifyDbContext : IdentityDbContext<AppUser>
     public DbSet<Game> Games => Set<Game>();
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<LookupCacheEntry> LookupCache => Set<LookupCacheEntry>();
+    public DbSet<CoverImage> CoverImages => Set<CoverImage>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -60,6 +61,13 @@ public class CollectifyDbContext : IdentityDbContext<AppUser>
         builder.Entity<LookupCacheEntry>(e =>
         {
             e.HasIndex(l => new { l.Provider, l.Key }).IsUnique();
+        });
+
+        builder.Entity<CoverImage>(e =>
+        {
+            e.HasKey(c => c.Hash);
+            e.Property(c => c.Hash).HasMaxLength(32);
+            e.Property(c => c.ContentType).HasMaxLength(64).IsRequired();
         });
     }
 }

--- a/src/server/Collectify.Infrastructure/Data/Migrations/20260507055526_AddCoverImages.Designer.cs
+++ b/src/server/Collectify.Infrastructure/Data/Migrations/20260507055526_AddCoverImages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Collectify.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Collectify.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(CollectifyDbContext))]
-    partial class CollectifyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507055526_AddCoverImages")]
+    partial class AddCoverImages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/server/Collectify.Infrastructure/Data/Migrations/20260507055526_AddCoverImages.cs
+++ b/src/server/Collectify.Infrastructure/Data/Migrations/20260507055526_AddCoverImages.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Collectify.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoverImages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CoverImages",
+                columns: table => new
+                {
+                    Hash = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    ContentType = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    Bytes = table.Column<byte[]>(type: "BLOB", nullable: false),
+                    AddedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CoverImages", x => x.Hash);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CoverImages");
+        }
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageStore.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageStore.cs
@@ -1,0 +1,83 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Collectify.Infrastructure.Lookup.Images;
+
+/// <summary>
+/// Materialises a remote cover-image URL into a locally stored file under
+/// <c>data/covers/</c>. Returns the public URL the SPA should embed in
+/// <c>&lt;img&gt;</c> tags.
+///
+/// The contract is forgiving by design: null / blank / already-local paths
+/// pass through unchanged so call sites can wrap every Save without
+/// branching, and download failures fall back to the original remote URL
+/// (the browser can still load it directly) rather than blocking the save.
+/// </summary>
+public interface ICoverImageStore
+{
+    Task<string?> EnsureLocalAsync(string? imagePath, CancellationToken ct = default);
+}
+
+public sealed class CoverImageStore : ICoverImageStore
+{
+    public const string HttpClientName = "covers";
+
+    private readonly string _coversDir;
+    private readonly IHttpClientFactory _factory;
+    private readonly ILogger<CoverImageStore> _log;
+
+    public CoverImageStore(string coversDir, IHttpClientFactory factory, ILogger<CoverImageStore> log)
+    {
+        _coversDir = coversDir;
+        _factory = factory;
+        _log = log;
+    }
+
+    public async Task<string?> EnsureLocalAsync(string? imagePath, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath)) return null;
+        if (!IsRemoteUrl(imagePath)) return imagePath;
+
+        var (hash, ext) = HashAndExtension(imagePath);
+        var filename = hash + ext;
+        var localPath = Path.Combine(_coversDir, filename);
+        var publicUrl = $"/covers/{filename}";
+
+        if (File.Exists(localPath)) return publicUrl;
+
+        try
+        {
+            var http = _factory.CreateClient(HttpClientName);
+            var bytes = await http.GetByteArrayAsync(imagePath, ct);
+            Directory.CreateDirectory(_coversDir);
+            // Atomic write so a crash mid-download never leaves a half-written
+            // file at the canonical path.
+            var temp = localPath + ".tmp";
+            await File.WriteAllBytesAsync(temp, bytes, ct);
+            File.Move(temp, localPath, overwrite: true);
+            return publicUrl;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "Failed to cache cover image {Url}; falling back to the remote URL", imagePath);
+            return imagePath;
+        }
+    }
+
+    private static bool IsRemoteUrl(string s) =>
+        s.StartsWith("http://", StringComparison.Ordinal) || s.StartsWith("https://", StringComparison.Ordinal);
+
+    private static (string hash, string ext) HashAndExtension(string url)
+    {
+        var sha = SHA256.HashData(Encoding.UTF8.GetBytes(url));
+        var hash = Convert.ToHexString(sha)[..16].ToLowerInvariant();
+
+        // Pick the extension from the URL's path, but only accept a small
+        // safelist so a hostile poster_path can't make us write
+        // /covers/abc.aspx (or anything else surprising).
+        var ext = Path.GetExtension(new Uri(url).AbsolutePath).ToLowerInvariant();
+        if (ext is not (".jpg" or ".jpeg" or ".png" or ".webp" or ".gif")) ext = ".jpg";
+        return (hash, ext);
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageStore.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageStore.cs
@@ -1,13 +1,18 @@
 using System.Security.Cryptography;
 using System.Text;
+using Collectify.Domain.Entities;
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Collectify.Infrastructure.Lookup.Images;
 
 /// <summary>
-/// Materialises a remote cover-image URL into a locally stored file under
-/// <c>data/covers/</c>. Returns the public URL the SPA should embed in
-/// <c>&lt;img&gt;</c> tags.
+/// Materialises a remote cover-image URL into a row in the CoverImages
+/// table and returns the public URL the SPA should embed in
+/// <c>&lt;img&gt;</c> tags. Storage lives in the SQLite database alongside
+/// every other entity so a single backup of <c>collectify.db</c> is a
+/// complete snapshot of the collection.
 ///
 /// The contract is forgiving by design: null / blank / already-local paths
 /// pass through unchanged so call sites can wrap every Save without
@@ -23,13 +28,13 @@ public sealed class CoverImageStore : ICoverImageStore
 {
     public const string HttpClientName = "covers";
 
-    private readonly string _coversDir;
+    private readonly CollectifyDbContext _db;
     private readonly IHttpClientFactory _factory;
     private readonly ILogger<CoverImageStore> _log;
 
-    public CoverImageStore(string coversDir, IHttpClientFactory factory, ILogger<CoverImageStore> log)
+    public CoverImageStore(CollectifyDbContext db, IHttpClientFactory factory, ILogger<CoverImageStore> log)
     {
-        _coversDir = coversDir;
+        _db = db;
         _factory = factory;
         _log = log;
     }
@@ -39,23 +44,35 @@ public sealed class CoverImageStore : ICoverImageStore
         if (string.IsNullOrWhiteSpace(imagePath)) return null;
         if (!IsRemoteUrl(imagePath)) return imagePath;
 
-        var (hash, ext) = HashAndExtension(imagePath);
-        var filename = hash + ext;
-        var localPath = Path.Combine(_coversDir, filename);
-        var publicUrl = $"/covers/{filename}";
+        var hash = HashUrl(imagePath);
+        var publicUrl = $"/covers/{hash}";
 
-        if (File.Exists(localPath)) return publicUrl;
+        if (await _db.CoverImages.AsNoTracking().AnyAsync(c => c.Hash == hash, ct))
+            return publicUrl;
 
         try
         {
             var http = _factory.CreateClient(HttpClientName);
-            var bytes = await http.GetByteArrayAsync(imagePath, ct);
-            Directory.CreateDirectory(_coversDir);
-            // Atomic write so a crash mid-download never leaves a half-written
-            // file at the canonical path.
-            var temp = localPath + ".tmp";
-            await File.WriteAllBytesAsync(temp, bytes, ct);
-            File.Move(temp, localPath, overwrite: true);
+            using var response = await http.GetAsync(imagePath, ct);
+            response.EnsureSuccessStatusCode();
+            var bytes = await response.Content.ReadAsByteArrayAsync(ct);
+            var contentType = response.Content.Headers.ContentType?.MediaType ?? GuessContentType(imagePath);
+
+            _db.CoverImages.Add(new CoverImage
+            {
+                Hash = hash,
+                ContentType = contentType,
+                Bytes = bytes,
+                AddedAt = DateTime.UtcNow,
+            });
+            await _db.SaveChangesAsync(ct);
+            return publicUrl;
+        }
+        catch (DbUpdateException)
+        {
+            // A concurrent request stored the same hash first. The row is
+            // there, our payload would have been identical (same content
+            // hash); just discard our copy and return the public URL.
             return publicUrl;
         }
         catch (Exception ex)
@@ -68,16 +85,22 @@ public sealed class CoverImageStore : ICoverImageStore
     private static bool IsRemoteUrl(string s) =>
         s.StartsWith("http://", StringComparison.Ordinal) || s.StartsWith("https://", StringComparison.Ordinal);
 
-    private static (string hash, string ext) HashAndExtension(string url)
+    private static string HashUrl(string url)
     {
         var sha = SHA256.HashData(Encoding.UTF8.GetBytes(url));
-        var hash = Convert.ToHexString(sha)[..16].ToLowerInvariant();
+        return Convert.ToHexString(sha)[..16].ToLowerInvariant();
+    }
 
-        // Pick the extension from the URL's path, but only accept a small
-        // safelist so a hostile poster_path can't make us write
-        // /covers/abc.aspx (or anything else surprising).
+    private static string GuessContentType(string url)
+    {
         var ext = Path.GetExtension(new Uri(url).AbsolutePath).ToLowerInvariant();
-        if (ext is not (".jpg" or ".jpeg" or ".png" or ".webp" or ".gif")) ext = ".jpg";
-        return (hash, ext);
+        return ext switch
+        {
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".png" => "image/png",
+            ".webp" => "image/webp",
+            ".gif" => "image/gif",
+            _ => "image/jpeg",
+        };
     }
 }

--- a/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using Collectify.Tests.Infrastructure;
+
+namespace Collectify.Tests.Api;
+
+public class CoversEndpointsTests
+{
+    [Fact]
+    public async Task Get_ExistingFile_Returns200WithCorrectContentType()
+    {
+        await using var factory = new CollectifyApiFactory();
+        Directory.CreateDirectory(factory.CoversDir);
+        await File.WriteAllBytesAsync(
+            Path.Combine(factory.CoversDir, "abc1234567890def.jpg"),
+            new byte[] { 0xFF, 0xD8, 0xFF });
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/covers/abc1234567890def.jpg");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/jpeg", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task Get_MissingFile_Returns404()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/covers/missing0000000.jpg");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    // These get URI-decoded to traversal attempts; the endpoint must reject.
+    [InlineData("/covers/..%2F..%2Fetc%2Fpasswd")]
+    [InlineData("/covers/%2E%2E%2Fsecrets")]
+    public async Task Get_PathTraversalAttempt_Returns404(string url)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_DoesNotRequireAuthentication()
+    {
+        // <img> tags in the SPA need to load these without an explicit fetch.
+        // The hash-named file system makes them effectively unguessable.
+        await using var factory = new CollectifyApiFactory();
+        Directory.CreateDirectory(factory.CoversDir);
+        await File.WriteAllBytesAsync(Path.Combine(factory.CoversDir, "deadbeefcafe1234.png"), new byte[] { 1 });
+
+        var client = factory.CreateClient(); // no auth cookie
+        var response = await client.GetAsync("/covers/deadbeefcafe1234.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+    }
+}

--- a/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Collectify.Domain.Entities;
 using Collectify.Tests.Infrastructure;
 
 namespace Collectify.Tests.Api;
@@ -6,42 +7,47 @@ namespace Collectify.Tests.Api;
 public class CoversEndpointsTests
 {
     [Fact]
-    public async Task Get_ExistingFile_Returns200WithCorrectContentType()
+    public async Task Get_ExistingHash_Returns200WithStoredContentType()
     {
         await using var factory = new CollectifyApiFactory();
-        Directory.CreateDirectory(factory.CoversDir);
-        await File.WriteAllBytesAsync(
-            Path.Combine(factory.CoversDir, "abc1234567890def.jpg"),
-            new byte[] { 0xFF, 0xD8, 0xFF });
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "abc1234567890def",
+            ContentType = "image/jpeg",
+            Bytes = [0xFF, 0xD8, 0xFF],
+        });
 
         var client = factory.CreateClient();
-        var response = await client.GetAsync("/covers/abc1234567890def.jpg");
+        var response = await client.GetAsync("/covers/abc1234567890def");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("image/jpeg", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(new byte[] { 0xFF, 0xD8, 0xFF }, await response.Content.ReadAsByteArrayAsync());
     }
 
     [Fact]
-    public async Task Get_MissingFile_Returns404()
+    public async Task Get_MissingHash_Returns404()
     {
         await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/covers/missing0000000.jpg");
+        var response = await factory.CreateClient().GetAsync("/covers/0000000000000000");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Theory]
-    // These get URI-decoded to traversal attempts; the endpoint must reject.
+    // These get URI-decoded to traversal attempts; must not reach the DB.
     [InlineData("/covers/..%2F..%2Fetc%2Fpasswd")]
-    [InlineData("/covers/%2E%2E%2Fsecrets")]
-    public async Task Get_PathTraversalAttempt_Returns404(string url)
+    [InlineData("/covers/%2E%2E")]
+    [InlineData("/covers/has-a-dash")]
+    [InlineData("/covers/UPPERCASE")]
+    [InlineData("/covers/short")]
+    [InlineData("/covers/way-too-long-to-possibly-be-a-cover-hash")]
+    public async Task Get_MalformedHash_Returns404(string url)
     {
         await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
 
-        var response = await client.GetAsync(url);
+        var response = await factory.CreateClient().GetAsync(url);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -49,14 +55,18 @@ public class CoversEndpointsTests
     [Fact]
     public async Task Get_DoesNotRequireAuthentication()
     {
-        // <img> tags in the SPA need to load these without an explicit fetch.
-        // The hash-named file system makes them effectively unguessable.
+        // <img> tags need to load without an explicit fetch + cookie dance.
+        // The hash is 16 hex chars derived from a URL the user already saw
+        // in their own collection, so it's effectively unguessable.
         await using var factory = new CollectifyApiFactory();
-        Directory.CreateDirectory(factory.CoversDir);
-        await File.WriteAllBytesAsync(Path.Combine(factory.CoversDir, "deadbeefcafe1234.png"), new byte[] { 1 });
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "deadbeefcafe1234",
+            ContentType = "image/png",
+            Bytes = [1, 2, 3],
+        });
 
-        var client = factory.CreateClient(); // no auth cookie
-        var response = await client.GetAsync("/covers/deadbeefcafe1234.png");
+        var response = await factory.CreateClient().GetAsync("/covers/deadbeefcafe1234"); // no cookie
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -306,6 +306,57 @@ public class MoviesEndpointsTests
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
+    // -------- Cover image caching --------
+
+    [Fact]
+    public async Task Create_WithRemoteImageUrl_StoresLocalCoverPath()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var dto = (object)new
+        {
+            Title = "Inception",
+            Formats = MovieFormat.BluRay,
+            Status = CollectionStatus.Owned,
+            WatchStatus = WatchStatus.Unwatched,
+            WatchCount = 0,
+            ImagePath = "https://image.tmdb.org/t/p/w342/poster.jpg",
+            Tags = (string[]?)null,
+        };
+
+        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/", dto))
+            .ReadJsonAsync<MovieResponse>();
+
+        Assert.NotNull(body);
+        Assert.NotNull(body!.ImagePath);
+        Assert.StartsWith("/covers/", body.ImagePath);
+        Assert.DoesNotContain("image.tmdb.org", body.ImagePath);
+    }
+
+    [Fact]
+    public async Task Create_WithLocalImagePath_PassesThroughUntouched()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var dto = (object)new
+        {
+            Title = "Inception",
+            Formats = MovieFormat.BluRay,
+            Status = CollectionStatus.Owned,
+            WatchStatus = WatchStatus.Unwatched,
+            WatchCount = 0,
+            ImagePath = "/covers/already-cached.jpg",
+            Tags = (string[]?)null,
+        };
+
+        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/", dto))
+            .ReadJsonAsync<MovieResponse>();
+
+        Assert.Equal("/covers/already-cached.jpg", body!.ImagePath);
+    }
+
     [Fact]
     public async Task Create_WithCurrencyOfWrongLength_ReturnsBadRequest()
     {

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -14,14 +13,6 @@ namespace Collectify.Tests.Infrastructure;
 public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
 {
     private readonly SqliteConnection _connection;
-
-    /// <summary>
-    /// Per-factory data dir handed to Program.cs so the covers static path
-    /// and any file-system code resolve to a writable, isolated location.
-    /// </summary>
-    public string DataDir { get; } = Path.Combine(Path.GetTempPath(), "collectify-tests", Guid.NewGuid().ToString("N"));
-
-    public string CoversDir => Path.Combine(DataDir, "covers");
 
     public CollectifyApiFactory()
     {
@@ -32,11 +23,6 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
-
-        builder.ConfigureAppConfiguration(cfg => cfg.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["Collectify:DataDir"] = DataDir,
-        }));
 
         builder.ConfigureServices(services =>
         {
@@ -55,22 +41,18 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
 
             services.AddDbContext<CollectifyDbContext>(opt => opt.UseSqlite(_connection));
 
-            // Swap the real cover store out so endpoint tests are deterministic
-            // and never try to hit a real CDN. The fake mirrors the contract:
-            // null/blank/local paths pass through; anything that looks remote
-            // is replaced with "/covers/{first-12-chars-of-hash}.jpg".
+            // Swap the real cover store out so endpoint tests don't try to
+            // download a real CDN payload. The fake mirrors the public
+            // contract: null/blank/local paths pass through; anything that
+            // looks remote is replaced with "/covers/{12-hex}".
             services.RemoveAll<ICoverImageStore>();
-            services.AddSingleton<ICoverImageStore, FakeCoverImageStore>();
+            services.AddScoped<ICoverImageStore, FakeCoverImageStore>();
         });
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
-        {
-            _connection.Dispose();
-            try { if (Directory.Exists(DataDir)) Directory.Delete(DataDir, recursive: true); } catch { }
-        }
+        if (disposing) _connection.Dispose();
         base.Dispose(disposing);
     }
 }
@@ -86,6 +68,6 @@ internal sealed class FakeCoverImageStore : ICoverImageStore
 
         // Deterministic so tests can assert exact values from a remote URL.
         var hash = Math.Abs(imagePath.GetHashCode()).ToString("x").PadLeft(12, '0');
-        return Task.FromResult<string?>($"/covers/{hash}.jpg");
+        return Task.FromResult<string?>($"/covers/{hash}");
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -1,9 +1,11 @@
 using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -12,6 +14,14 @@ namespace Collectify.Tests.Infrastructure;
 public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
 {
     private readonly SqliteConnection _connection;
+
+    /// <summary>
+    /// Per-factory data dir handed to Program.cs so the covers static path
+    /// and any file-system code resolve to a writable, isolated location.
+    /// </summary>
+    public string DataDir { get; } = Path.Combine(Path.GetTempPath(), "collectify-tests", Guid.NewGuid().ToString("N"));
+
+    public string CoversDir => Path.Combine(DataDir, "covers");
 
     public CollectifyApiFactory()
     {
@@ -22,6 +32,11 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration(cfg => cfg.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Collectify:DataDir"] = DataDir,
+        }));
 
         builder.ConfigureServices(services =>
         {
@@ -39,12 +54,38 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
             services.RemoveAll<IDbContextOptionsConfiguration<CollectifyDbContext>>();
 
             services.AddDbContext<CollectifyDbContext>(opt => opt.UseSqlite(_connection));
+
+            // Swap the real cover store out so endpoint tests are deterministic
+            // and never try to hit a real CDN. The fake mirrors the contract:
+            // null/blank/local paths pass through; anything that looks remote
+            // is replaced with "/covers/{first-12-chars-of-hash}.jpg".
+            services.RemoveAll<ICoverImageStore>();
+            services.AddSingleton<ICoverImageStore, FakeCoverImageStore>();
         });
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing) _connection.Dispose();
+        if (disposing)
+        {
+            _connection.Dispose();
+            try { if (Directory.Exists(DataDir)) Directory.Delete(DataDir, recursive: true); } catch { }
+        }
         base.Dispose(disposing);
+    }
+}
+
+internal sealed class FakeCoverImageStore : ICoverImageStore
+{
+    public Task<string?> EnsureLocalAsync(string? imagePath, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath)) return Task.FromResult<string?>(null);
+        if (!imagePath.StartsWith("http://", StringComparison.Ordinal) &&
+            !imagePath.StartsWith("https://", StringComparison.Ordinal))
+            return Task.FromResult<string?>(imagePath);
+
+        // Deterministic so tests can assert exact values from a remote URL.
+        var hash = Math.Abs(imagePath.GetHashCode()).ToString("x").PadLeft(12, '0');
+        return Task.FromResult<string?>($"/covers/{hash}.jpg");
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
@@ -1,29 +1,32 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
+using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Collectify.Tests.Infrastructure;
 
 public class CoverImageStoreTests : IDisposable
 {
-    private readonly string _dir;
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _options;
 
     public CoverImageStoreTests()
     {
-        _dir = Path.Combine(Path.GetTempPath(), "cover-store-tests", Guid.NewGuid().ToString("N"));
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_options);
+        seed.Database.EnsureCreated();
     }
 
-    public void Dispose()
-    {
-        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
-    }
+    public void Dispose() => _connection.Dispose();
 
-    private CoverImageStore NewStore(StubHandler handler)
-    {
-        var factory = new SingleClientFactory(handler);
-        return new CoverImageStore(_dir, factory, NullLogger<CoverImageStore>.Instance);
-    }
+    private CoverImageStore NewStore(StubHandler handler) =>
+        new(new CollectifyDbContext(_options), new SingleClientFactory(handler), NullLogger<CoverImageStore>.Instance);
 
     [Fact]
     public async Task EnsureLocalAsync_WithNullOrBlank_ReturnsNull()
@@ -36,7 +39,7 @@ public class CoverImageStoreTests : IDisposable
     }
 
     [Theory]
-    [InlineData("/covers/abc123.jpg")]
+    [InlineData("/covers/abc123")]
     [InlineData("local/path.png")]
     [InlineData("data/covers/already.webp")]
     public async Task EnsureLocalAsync_WithLocalPath_PassesThrough(string local)
@@ -51,114 +54,113 @@ public class CoverImageStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task EnsureLocalAsync_WithRemoteUrl_DownloadsAndReturnsLocalPublicUrl()
+    public async Task EnsureLocalAsync_WithRemoteUrl_DownloadsAndStoresRowReturningPublicUrl()
     {
-        var handler = new StubHandler(payload: new byte[] { 1, 2, 3, 4 });
-        var store = NewStore(handler);
+        var payload = new byte[] { 1, 2, 3, 4 };
+        var store = NewStore(new StubHandler(payload, mediaType: "image/jpeg"));
 
         var result = await store.EnsureLocalAsync("https://image.tmdb.org/t/p/w342/poster.jpg");
 
         Assert.NotNull(result);
         Assert.StartsWith("/covers/", result);
-        Assert.EndsWith(".jpg", result);
-        var filename = result!.Substring("/covers/".Length);
-        Assert.True(File.Exists(Path.Combine(_dir, filename)));
-        Assert.Equal(new byte[] { 1, 2, 3, 4 }, await File.ReadAllBytesAsync(Path.Combine(_dir, filename)));
+        var hash = result!.Substring("/covers/".Length);
+        Assert.Matches("^[0-9a-f]{16}$", hash);
+
+        using var verify = new CollectifyDbContext(_options);
+        var row = await verify.CoverImages.AsNoTracking().FirstAsync();
+        Assert.Equal(hash, row.Hash);
+        Assert.Equal("image/jpeg", row.ContentType);
+        Assert.Equal(payload, row.Bytes);
     }
 
     [Fact]
-    public async Task EnsureLocalAsync_RepeatedRemoteUrl_ServesFromDiskOnSecondCall()
+    public async Task EnsureLocalAsync_RepeatedRemoteUrl_DoesNotRefetch()
     {
         var handler = new StubHandler(payload: new byte[] { 9 });
-        var store = NewStore(handler);
-
-        var first = await store.EnsureLocalAsync("https://image.tmdb.org/x.jpg");
-        var second = await store.EnsureLocalAsync("https://image.tmdb.org/x.jpg");
+        var first = await NewStore(handler).EnsureLocalAsync("https://image.tmdb.org/x.jpg");
+        var second = await NewStore(handler).EnsureLocalAsync("https://image.tmdb.org/x.jpg");
 
         Assert.Equal(first, second);
-        Assert.Single(handler.RequestedUrls); // only one network call
+        Assert.Single(handler.RequestedUrls);
+
+        using var verify = new CollectifyDbContext(_options);
+        Assert.Equal(1, await verify.CoverImages.CountAsync());
     }
 
     [Fact]
-    public async Task EnsureLocalAsync_OnDownloadFailure_ReturnsRemoteUrlAsFallback()
+    public async Task EnsureLocalAsync_OnDownloadFailure_ReturnsRemoteUrlAndStoresNothing()
     {
-        var handler = new StubHandler(status: HttpStatusCode.InternalServerError);
-        var store = NewStore(handler);
-
         var url = "https://image.tmdb.org/oops.jpg";
-        var result = await store.EnsureLocalAsync(url);
+        var result = await NewStore(new StubHandler(status: HttpStatusCode.InternalServerError)).EnsureLocalAsync(url);
 
         Assert.Equal(url, result); // graceful degrade: browser can still load it
-        // No file written:
-        Assert.False(Directory.Exists(_dir) && Directory.EnumerateFiles(_dir).Any());
-    }
 
-    [Theory]
-    [InlineData(".jpg")]
-    [InlineData(".jpeg")]
-    [InlineData(".png")]
-    [InlineData(".webp")]
-    [InlineData(".gif")]
-    public async Task EnsureLocalAsync_KeepsKnownExtensions(string ext)
-    {
-        var handler = new StubHandler(payload: new byte[] { 1 });
-        var store = NewStore(handler);
-
-        var result = await store.EnsureLocalAsync($"https://cdn.example/poster{ext}");
-
-        Assert.NotNull(result);
-        Assert.EndsWith(ext, result);
-    }
-
-    [Theory]
-    [InlineData("https://cdn.example/poster.aspx")]
-    [InlineData("https://cdn.example/poster.exe")]
-    [InlineData("https://cdn.example/poster")]
-    public async Task EnsureLocalAsync_WithUnknownOrMissingExtension_FallsBackToJpg(string url)
-    {
-        var handler = new StubHandler(payload: new byte[] { 1 });
-        var store = NewStore(handler);
-
-        var result = await store.EnsureLocalAsync(url);
-
-        Assert.NotNull(result);
-        Assert.EndsWith(".jpg", result);
+        using var verify = new CollectifyDbContext(_options);
+        Assert.Equal(0, await verify.CoverImages.CountAsync());
     }
 
     [Fact]
-    public async Task EnsureLocalAsync_FilenameIsAlwaysHashOnly_NoPathTraversal()
+    public async Task EnsureLocalAsync_PreservesContentTypeFromResponseHeader()
     {
-        // Even with a malicious-looking poster path, the cached filename is
-        // SHA256-derived hex; nothing about the URL leaks into the filename.
-        var handler = new StubHandler(payload: new byte[] { 1 });
-        var store = NewStore(handler);
+        var store = NewStore(new StubHandler(payload: [0xFF], mediaType: "image/webp"));
+
+        var result = await store.EnsureLocalAsync("https://cdn.example/poster.jpg");
+
+        using var verify = new CollectifyDbContext(_options);
+        var row = await verify.CoverImages.AsNoTracking().FirstAsync();
+        Assert.Equal("image/webp", row.ContentType); // header wins over URL extension
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_FallsBackToExtensionWhenContentTypeHeaderIsAbsent()
+    {
+        var store = NewStore(new StubHandler(payload: [0xFF], mediaType: null));
+
+        await store.EnsureLocalAsync("https://cdn.example/poster.png");
+
+        using var verify = new CollectifyDbContext(_options);
+        var row = await verify.CoverImages.AsNoTracking().FirstAsync();
+        Assert.Equal("image/png", row.ContentType);
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_HashIsAlwaysSafeHex_NoPathTraversal()
+    {
+        // Even with a malicious-looking poster path, the row's Hash is
+        // SHA256-derived hex; the URL never leaks into the public path.
+        var store = NewStore(new StubHandler(payload: [1]));
 
         var result = await store.EnsureLocalAsync("https://cdn.example/../../../etc/passwd.jpg");
 
         Assert.NotNull(result);
-        var filename = result!.Substring("/covers/".Length);
-        // 16 hex chars + .jpg
-        Assert.Matches("^[0-9a-f]{16}\\.jpg$", filename);
+        var hash = result!.Substring("/covers/".Length);
+        Assert.Matches("^[0-9a-f]{16}$", hash);
     }
 
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly byte[]? _payload;
         private readonly HttpStatusCode _status;
+        private readonly string? _mediaType;
         public List<string> RequestedUrls { get; } = new();
 
-        public StubHandler(byte[]? payload = null, HttpStatusCode status = HttpStatusCode.OK)
+        public StubHandler(byte[]? payload = null, HttpStatusCode status = HttpStatusCode.OK, string? mediaType = "image/jpeg")
         {
             _payload = payload;
             _status = status;
+            _mediaType = mediaType;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
             var response = new HttpResponseMessage(_status);
-            if (_payload is not null) response.Content = new ByteArrayContent(_payload);
-            else response.Content = new StringContent(string.Empty, Encoding.UTF8);
+            var content = _payload is not null
+                ? (HttpContent)new ByteArrayContent(_payload)
+                : new StringContent(string.Empty, Encoding.UTF8);
+            if (_mediaType is not null)
+                content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType);
+            response.Content = content;
             return Task.FromResult(response);
         }
     }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Text;
+using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class CoverImageStoreTests : IDisposable
+{
+    private readonly string _dir;
+
+    public CoverImageStoreTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cover-store-tests", Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private CoverImageStore NewStore(StubHandler handler)
+    {
+        var factory = new SingleClientFactory(handler);
+        return new CoverImageStore(_dir, factory, NullLogger<CoverImageStore>.Instance);
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_WithNullOrBlank_ReturnsNull()
+    {
+        var store = NewStore(new StubHandler());
+
+        Assert.Null(await store.EnsureLocalAsync(null));
+        Assert.Null(await store.EnsureLocalAsync(""));
+        Assert.Null(await store.EnsureLocalAsync("   "));
+    }
+
+    [Theory]
+    [InlineData("/covers/abc123.jpg")]
+    [InlineData("local/path.png")]
+    [InlineData("data/covers/already.webp")]
+    public async Task EnsureLocalAsync_WithLocalPath_PassesThrough(string local)
+    {
+        var handler = new StubHandler();
+        var store = NewStore(handler);
+
+        var result = await store.EnsureLocalAsync(local);
+
+        Assert.Equal(local, result);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_WithRemoteUrl_DownloadsAndReturnsLocalPublicUrl()
+    {
+        var handler = new StubHandler(payload: new byte[] { 1, 2, 3, 4 });
+        var store = NewStore(handler);
+
+        var result = await store.EnsureLocalAsync("https://image.tmdb.org/t/p/w342/poster.jpg");
+
+        Assert.NotNull(result);
+        Assert.StartsWith("/covers/", result);
+        Assert.EndsWith(".jpg", result);
+        var filename = result!.Substring("/covers/".Length);
+        Assert.True(File.Exists(Path.Combine(_dir, filename)));
+        Assert.Equal(new byte[] { 1, 2, 3, 4 }, await File.ReadAllBytesAsync(Path.Combine(_dir, filename)));
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_RepeatedRemoteUrl_ServesFromDiskOnSecondCall()
+    {
+        var handler = new StubHandler(payload: new byte[] { 9 });
+        var store = NewStore(handler);
+
+        var first = await store.EnsureLocalAsync("https://image.tmdb.org/x.jpg");
+        var second = await store.EnsureLocalAsync("https://image.tmdb.org/x.jpg");
+
+        Assert.Equal(first, second);
+        Assert.Single(handler.RequestedUrls); // only one network call
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_OnDownloadFailure_ReturnsRemoteUrlAsFallback()
+    {
+        var handler = new StubHandler(status: HttpStatusCode.InternalServerError);
+        var store = NewStore(handler);
+
+        var url = "https://image.tmdb.org/oops.jpg";
+        var result = await store.EnsureLocalAsync(url);
+
+        Assert.Equal(url, result); // graceful degrade: browser can still load it
+        // No file written:
+        Assert.False(Directory.Exists(_dir) && Directory.EnumerateFiles(_dir).Any());
+    }
+
+    [Theory]
+    [InlineData(".jpg")]
+    [InlineData(".jpeg")]
+    [InlineData(".png")]
+    [InlineData(".webp")]
+    [InlineData(".gif")]
+    public async Task EnsureLocalAsync_KeepsKnownExtensions(string ext)
+    {
+        var handler = new StubHandler(payload: new byte[] { 1 });
+        var store = NewStore(handler);
+
+        var result = await store.EnsureLocalAsync($"https://cdn.example/poster{ext}");
+
+        Assert.NotNull(result);
+        Assert.EndsWith(ext, result);
+    }
+
+    [Theory]
+    [InlineData("https://cdn.example/poster.aspx")]
+    [InlineData("https://cdn.example/poster.exe")]
+    [InlineData("https://cdn.example/poster")]
+    public async Task EnsureLocalAsync_WithUnknownOrMissingExtension_FallsBackToJpg(string url)
+    {
+        var handler = new StubHandler(payload: new byte[] { 1 });
+        var store = NewStore(handler);
+
+        var result = await store.EnsureLocalAsync(url);
+
+        Assert.NotNull(result);
+        Assert.EndsWith(".jpg", result);
+    }
+
+    [Fact]
+    public async Task EnsureLocalAsync_FilenameIsAlwaysHashOnly_NoPathTraversal()
+    {
+        // Even with a malicious-looking poster path, the cached filename is
+        // SHA256-derived hex; nothing about the URL leaks into the filename.
+        var handler = new StubHandler(payload: new byte[] { 1 });
+        var store = NewStore(handler);
+
+        var result = await store.EnsureLocalAsync("https://cdn.example/../../../etc/passwd.jpg");
+
+        Assert.NotNull(result);
+        var filename = result!.Substring("/covers/".Length);
+        // 16 hex chars + .jpg
+        Assert.Matches("^[0-9a-f]{16}\\.jpg$", filename);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly byte[]? _payload;
+        private readonly HttpStatusCode _status;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(byte[]? payload = null, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _payload = payload;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+            var response = new HttpResponseMessage(_status);
+            if (_payload is not null) response.Content = new ByteArrayContent(_payload);
+            else response.Content = new StringContent(string.Empty, Encoding.UTF8);
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public SingleClientFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
**Stacked on top of #13** (TMDB movie lookup). Merge that one first; this PR's diff will collapse to its own changes once #13 lands.

## Summary

Cover images are stored in the **`CoverImages` table** (Hash PK, ContentType, Bytes blob, AddedAt) — *not* on disk. A single backup of `collectify.db` is a complete snapshot of the collection, and a future swap to PostgreSQL is a provider change rather than a parallel filesystem-migration story.

### A. DB-backed cover store

- New `CoverImage` entity. Hash is the same 16-hex content-derived value the URL surfaces — identical images dedupe across users / items.
- New EF migration `AddCoverImages`.
- `CoverImageStore` is **scoped** (depends on `CollectifyDbContext`). `EnsureLocalAsync`:
  - Null / blank / already-local input → passthrough.
  - Remote URL → SHA256 hash, look up row, otherwise download + insert in one round trip. Returns `/covers/{hash}`.
  - Download failure → log + return the original remote URL (graceful degrade; `<img>` still loads).
  - `DbUpdateException` from a concurrent insert with the same content-keyed hash → treat as already-stored.
- `/covers/{hash}` GET endpoint validates the hash (8–32 lowercase hex), looks up the row, streams the bytes with the stored Content-Type. Hardened against case / dash / traversal / over- and under-length. No filesystem touched.

### B. Thumbnails + external IDs *(unchanged from the earlier filesystem version)*

- `CollectionList` card layout is now horizontal: 16×24 thumbnail on the left (or a *no cover* placeholder), text + status + rating + tag chips on the right. Lazy-loaded.
- `ExternalIdField` primitive: editable input + optional "View ↗" link to the provider page. Wired into:
  - `MovieForm` → TmdbId, ImdbId.
  - `AlbumForm` → MusicBrainzReleaseId, DiscogsId.
  - `GameForm` → IgdbId.
  Lookup-populated IDs are visible and editable; users can paste an ID manually.

### Why DB instead of disk

- Single backup story: `collectify.db` already captures everything else; covers shouldn't be the one exception.
- Easier to swap providers (e.g. Postgres later) — EF maps `byte[]` to BLOB on SQLite and BYTEA on PG with no code change.
- No filesystem state to keep in sync with the DB; orphans become a single `DELETE FROM CoverImages WHERE Hash NOT IN (...)` away.

### Tradeoff to be aware of

SQLite file grows ~50 KB per unique poster. At 1000 movies that's ~50 MB. Backup / `vacuum` get heavier at large counts. For the project's scale that's fine; flagged so it's a conscious choice.

## Test plan

### CI

- [x] `./scripts/ci-local.sh` — server **130/130**, client **25/25**, both builds clean, ~60s.
- [x] `dotnet test --filter CoverImageStoreTests` — 8 cases against an in-memory SQLite: null/blank, three local-passthrough rows, remote URL writes a row with the right hash + payload + content-type, repeat URL is a no-op (single network call, single row), upstream 500 returns the original URL and writes nothing, response-header content-type wins over URL extension, URL-extension fallback when header is absent, hash safety against hostile poster paths.
- [x] `dotnet test --filter CoversEndpointsTests` — 4 cases: existing hash → 200 with stored Content-Type and bytes, missing hash → 404, six malformed-hash theory rows (traversal, uppercase, dashes, length bounds) → 404, unauth GET works (so `<img>` tags load).
- [x] `dotnet test --filter MoviesEndpointsTests` — POST with a remote `imagePath` stores a `/covers/...` value (no `image.tmdb.org`); POST with an already-local path passes through.
- [x] EF migration round-trips: every test re-runs `Database.MigrateAsync()` against the in-memory DB, so the new `AddCoverImages` migration is exercised on every CI run.

### Manual

(needs `Collectify__Metadata__Tmdb__ApiKey` set, then both servers running)

- [x] `/movies/new`: search "Inception" via TMDB, click a result. The form pre-fills; **TMDB ID** appears in the new "External IDs" section with a "View ↗" link to themoviedb.org. Save.
- [x] `/movies` list: the saved movie shows a poster thumbnail on the left of its card. The thumbnail URL is `/covers/{16-hex}` (no extension), not `image.tmdb.org`.
- [x] DB inspection: `sqlite3 data/collectify.db 'select Hash, ContentType, length(Bytes) from CoverImages;'` shows one row per unique poster.
- [x] Open the movie in `/movies/{id}` again — the same `/covers/...` path is still stored. Edit and save: passthrough, no second download.
- [x] Manually paste an IMDB ID (`tt0133093`) into the IMDB field, save. The View ↗ link goes to the right IMDB page after reload.

## Out of scope

- **Lookup by TMDB ID** — paste an ID and pull metadata directly. Needs a `GetByIdAsync` on the provider, an endpoint, and a small UI input. Will open as a follow-up issue once this lands.
- **Cover GC** — drop `CoverImage` rows whose hash isn't referenced by any item. One-line SQL job, easy follow-up.
- **ETag / 304** for the covers endpoint. Hash *is* the ETag; could short-circuit re-downloads. Skipped until a real workload needs it.