### PR TITLE
fix: restore accidentally-deleted Collectify.Api project

### DIFF
--- a/src/server/Collectify.Api/Collectify.Api.csproj
+++ b/src/server/Collectify.Api/Collectify.Api.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Collectify.Infrastructure\Collectify.Infrastructure.csproj" />
+    <ProjectReference Include="..\Collectify.Domain\Collectify.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/server/Collectify.Api/Endpoints/AuthEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/AuthEndpoints.cs
@@ -1,0 +1,68 @@
+using Collectify.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class AuthEndpoints
+{
+    public record SetupRequest(string UserName, string Password);
+    public record LoginRequest(string UserName, string Password);
+    public record AuthState(bool NeedsSetup, bool IsAuthenticated, string? UserName);
+
+    public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/auth");
+
+        group.MapGet("/me", async (HttpContext ctx, UserManager<AppUser> users) =>
+        {
+            var anyUser = await users.Users.AnyAsync();
+            if (!anyUser)
+                return Results.Ok(new AuthState(true, false, null));
+
+            if (ctx.User?.Identity?.IsAuthenticated == true)
+                return Results.Ok(new AuthState(false, true, ctx.User.Identity.Name));
+
+            return Results.Ok(new AuthState(false, false, null));
+        });
+
+        group.MapPost("/setup", async (
+            [FromBody] SetupRequest req,
+            UserManager<AppUser> users,
+            SignInManager<AppUser> signIn) =>
+        {
+            if (await users.Users.AnyAsync())
+                return Results.BadRequest(new { error = "Setup already complete." });
+
+            if (string.IsNullOrWhiteSpace(req.UserName) || string.IsNullOrWhiteSpace(req.Password))
+                return Results.BadRequest(new { error = "Username and password required." });
+
+            var user = new AppUser { UserName = req.UserName };
+            var result = await users.CreateAsync(user, req.Password);
+            if (!result.Succeeded)
+                return Results.BadRequest(new { error = string.Join("; ", result.Errors.Select(e => e.Description)) });
+
+            await signIn.SignInAsync(user, isPersistent: true);
+            return Results.Ok(new { ok = true });
+        });
+
+        group.MapPost("/login", async (
+            [FromBody] LoginRequest req,
+            SignInManager<AppUser> signIn) =>
+        {
+            var result = await signIn.PasswordSignInAsync(req.UserName, req.Password, isPersistent: true, lockoutOnFailure: false);
+            return result.Succeeded
+                ? Results.Ok(new { ok = true })
+                : Results.Unauthorized();
+        });
+
+        group.MapPost("/logout", async (SignInManager<AppUser> signIn) =>
+        {
+            await signIn.SignOutAsync();
+            return Results.Ok(new { ok = true });
+        });
+
+        return app;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
@@ -1,0 +1,36 @@
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class CoversEndpoints
+{
+    /// <summary>
+    /// Streams cover-image bytes from the CoverImages table by content hash.
+    /// Intentionally not auth-required so img tags work without a fetch
+    /// dance; the hash is 16 hex chars derived from a URL the user already
+    /// saw in their own collection, so they're effectively unguessable.
+    /// </summary>
+    public static IEndpointRouteBuilder MapCoversEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/covers/{hash}", async (string hash, CollectifyDbContext db, CancellationToken ct) =>
+        {
+            // Public contract is a flat 16-char hex hash. Reject anything
+            // else before touching the DB.
+            if (string.IsNullOrEmpty(hash) || hash.Length is < 8 or > 32) return Results.NotFound();
+            for (var i = 0; i < hash.Length; i++)
+            {
+                var c = hash[i];
+                if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return Results.NotFound();
+            }
+
+            var entry = await db.CoverImages.AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Hash == hash, ct);
+            if (entry is null) return Results.NotFound();
+
+            return Results.File(entry.Bytes, entry.ContentType);
+        });
+
+        return app;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -1,0 +1,164 @@
+using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class GamesEndpoints
+{
+    public record GameDto(
+        int? Id,
+        string Title,
+        string? Platform,
+        int? Year,
+        string? Publisher,
+        string? Developer,
+        bool IsDigital,
+        DigitalStore? DigitalStore,
+        string? Barcode,
+        string? IgdbId,
+        string? ImagePath,
+        string? Description,
+        string? Notes,
+        int? PersonalRating,
+        CollectionStatus Status,
+        Condition? Condition,
+        DateOnly? AcquiredOn,
+        decimal? AcquisitionPrice,
+        string? AcquisitionCurrency,
+        string? AcquisitionSource,
+        CompletionStatus CompletionStatus,
+        int? HoursPlayed,
+        DateOnly? LastPlayedOn,
+        string[]? Tags,
+        DateTime? AddedAt,
+        DateTime? UpdatedAt);
+
+    public static IEndpointRouteBuilder MapGamesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/games").RequireAuthorization();
+
+        group.MapGet("/", async (
+            [FromQuery] string? query,
+            [FromQuery] string? platform,
+            [FromQuery] bool? digital,
+            CollectifyDbContext db,
+            UserManager<AppUser> users,
+            HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var q = db.Games.AsNoTracking().Include(g => g.Tags).Where(g => g.OwnerId == ownerId);
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var like = $"%{query}%";
+                q = q.Where(g => EF.Functions.Like(g.Title, like)
+                              || (g.Publisher != null && EF.Functions.Like(g.Publisher, like))
+                              || (g.Developer != null && EF.Functions.Like(g.Developer, like)));
+            }
+            if (!string.IsNullOrWhiteSpace(platform)) q = q.Where(g => g.Platform == platform);
+            if (digital.HasValue) q = q.Where(g => g.IsDigital == digital.Value);
+
+            var items = await q.OrderByDescending(g => g.AddedAt).Take(500).ToListAsync();
+            return Results.Ok(items.Select(ToDto));
+        });
+
+        group.MapGet("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var g = await db.Games.AsNoTracking().Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            return g is null ? Results.NotFound() : Results.Ok(ToDto(g));
+        });
+
+        group.MapPost("/", async ([FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var g = new Game { OwnerId = ownerId };
+            ApplyDto(g, dto);
+            g.ImagePath = await covers.EnsureLocalAsync(g.ImagePath, ct);
+            g.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            db.Games.Add(g);
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/api/games/{g.Id}", ToDto(g));
+        });
+
+        group.MapPut("/{id:int}", async (int id, [FromBody] GameDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var g = await db.Games.Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
+            if (g is null) return Results.NotFound();
+            ApplyDto(g, dto);
+            g.ImagePath = await covers.EnsureLocalAsync(g.ImagePath, ct);
+            g.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            g.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(ToDto(g));
+        });
+
+        group.MapDelete("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var g = await db.Games.FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            if (g is null) return Results.NotFound();
+            db.Games.Remove(g);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+
+    private static IResult? Validate(GameDto dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+            return Results.BadRequest(new { error = "Title is required." });
+        if (dto.PersonalRating is { } r && (r < 1 || r > 10))
+            return Results.BadRequest(new { error = "PersonalRating must be between 1 and 10." });
+        if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)
+            return Results.BadRequest(new { error = "AcquisitionCurrency must be a 3-letter ISO 4217 code." });
+        return null;
+    }
+
+    private static GameDto ToDto(Game g) => new(
+        g.Id, g.Title, g.Platform, g.Year, g.Publisher, g.Developer, g.IsDigital, g.DigitalStore,
+        g.Barcode, g.IgdbId, g.ImagePath, g.Description, g.Notes,
+        g.PersonalRating, g.Status, g.Condition,
+        g.AcquiredOn, g.AcquisitionPrice, g.AcquisitionCurrency, g.AcquisitionSource,
+        g.CompletionStatus, g.HoursPlayed, g.LastPlayedOn,
+        TagResolver.ToNameArray(g.Tags),
+        g.AddedAt, g.UpdatedAt);
+
+    private static void ApplyDto(Game g, GameDto dto)
+    {
+        g.Title = dto.Title?.Trim() ?? string.Empty;
+        g.Platform = dto.Platform;
+        g.Year = dto.Year;
+        g.Publisher = dto.Publisher;
+        g.Developer = dto.Developer;
+        g.IsDigital = dto.IsDigital;
+        g.DigitalStore = dto.DigitalStore;
+        g.Barcode = dto.Barcode;
+        g.IgdbId = dto.IgdbId;
+        g.ImagePath = dto.ImagePath;
+        g.Description = dto.Description;
+        g.Notes = dto.Notes;
+        g.PersonalRating = dto.PersonalRating;
+        g.Status = dto.Status;
+        g.Condition = dto.Condition;
+        g.AcquiredOn = dto.AcquiredOn;
+        g.AcquisitionPrice = dto.AcquisitionPrice;
+        g.AcquisitionCurrency = string.IsNullOrWhiteSpace(dto.AcquisitionCurrency) ? null : dto.AcquisitionCurrency.ToUpperInvariant();
+        g.AcquisitionSource = dto.AcquisitionSource;
+        g.CompletionStatus = dto.CompletionStatus;
+        g.HoursPlayed = dto.HoursPlayed;
+        g.LastPlayedOn = dto.LastPlayedOn;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -1,0 +1,59 @@
+using Collectify.Infrastructure.Lookup;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Collectify.Api.Endpoints;
+
+public static class LookupEndpoints
+{
+    public record LookupResponse<T>(string Provider, bool Configured, IReadOnlyList<T> Results);
+
+    public static IEndpointRouteBuilder MapLookupEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/lookup").RequireAuthorization();
+
+        group.MapGet("/movies", async (
+            [FromQuery] string? q,
+            IMovieMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
+        });
+
+        group.MapGet("/music", async (
+            [FromQuery] string? q,
+            IMusicMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
+        });
+
+        group.MapGet("/games", async (
+            [FromQuery] string? q,
+            IGameMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (Validate(q) is { } error) return error;
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, false, []));
+            var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, true, results));
+        });
+
+        return app;
+    }
+
+    private static IResult? Validate(string? q)
+    {
+        if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
+            return Results.BadRequest(new { error = "Query must be at least 2 characters." });
+        return null;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -1,0 +1,169 @@
+using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class MoviesEndpoints
+{
+    public record MovieDto(
+        int? Id,
+        string Title,
+        string? OriginalTitle,
+        int? Year,
+        MovieFormat Formats,
+        string? Director,
+        int? RuntimeMinutes,
+        string? Studio,
+        string? Genres,
+        string? Barcode,
+        string? TmdbId,
+        string? ImdbId,
+        string? ImagePath,
+        string? Description,
+        string? Notes,
+        int? PersonalRating,
+        CollectionStatus Status,
+        Condition? Condition,
+        DateOnly? AcquiredOn,
+        decimal? AcquisitionPrice,
+        string? AcquisitionCurrency,
+        string? AcquisitionSource,
+        WatchStatus WatchStatus,
+        DateOnly? LastWatchedOn,
+        int WatchCount,
+        string[]? Tags,
+        DateTime? AddedAt,
+        DateTime? UpdatedAt);
+
+    public static IEndpointRouteBuilder MapMoviesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/movies").RequireAuthorization();
+
+        group.MapGet("/", async (
+            [FromQuery] string? query,
+            [FromQuery] MovieFormat? format,
+            [FromQuery] int? year,
+            CollectifyDbContext db,
+            UserManager<AppUser> users,
+            HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var q = db.Movies.AsNoTracking().Include(m => m.Tags).Where(m => m.OwnerId == ownerId);
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var like = $"%{query}%";
+                q = q.Where(m => EF.Functions.Like(m.Title, like)
+                              || (m.Director != null && EF.Functions.Like(m.Director, like))
+                              || (m.OriginalTitle != null && EF.Functions.Like(m.OriginalTitle, like)));
+            }
+            if (format.HasValue && format.Value != MovieFormat.None)
+                q = q.Where(m => (m.Formats & format.Value) != 0);
+            if (year.HasValue) q = q.Where(m => m.Year == year);
+
+            var items = await q.OrderByDescending(m => m.AddedAt).Take(500).ToListAsync();
+            return Results.Ok(items.Select(ToDto));
+        });
+
+        group.MapGet("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var m = await db.Movies.AsNoTracking().Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            return m is null ? Results.NotFound() : Results.Ok(ToDto(m));
+        });
+
+        group.MapPost("/", async ([FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var m = new Movie { OwnerId = ownerId };
+            ApplyDto(m, dto);
+            m.ImagePath = await covers.EnsureLocalAsync(m.ImagePath, ct);
+            m.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            db.Movies.Add(m);
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/api/movies/{m.Id}", ToDto(m));
+        });
+
+        group.MapPut("/{id:int}", async (int id, [FromBody] MovieDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var m = await db.Movies.Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
+            if (m is null) return Results.NotFound();
+            ApplyDto(m, dto);
+            m.ImagePath = await covers.EnsureLocalAsync(m.ImagePath, ct);
+            m.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            m.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(ToDto(m));
+        });
+
+        group.MapDelete("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var m = await db.Movies.FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            if (m is null) return Results.NotFound();
+            db.Movies.Remove(m);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+
+    private static IResult? Validate(MovieDto dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+            return Results.BadRequest(new { error = "Title is required." });
+        if (dto.PersonalRating is { } r && (r < 1 || r > 10))
+            return Results.BadRequest(new { error = "PersonalRating must be between 1 and 10." });
+        if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)
+            return Results.BadRequest(new { error = "AcquisitionCurrency must be a 3-letter ISO 4217 code." });
+        return null;
+    }
+
+    private static MovieDto ToDto(Movie m) => new(
+        m.Id, m.Title, m.OriginalTitle, m.Year, m.Formats, m.Director, m.RuntimeMinutes,
+        m.Studio, m.Genres, m.Barcode, m.TmdbId, m.ImdbId, m.ImagePath, m.Description, m.Notes,
+        m.PersonalRating, m.Status, m.Condition,
+        m.AcquiredOn, m.AcquisitionPrice, m.AcquisitionCurrency, m.AcquisitionSource,
+        m.WatchStatus, m.LastWatchedOn, m.WatchCount,
+        TagResolver.ToNameArray(m.Tags),
+        m.AddedAt, m.UpdatedAt);
+
+    private static void ApplyDto(Movie m, MovieDto dto)
+    {
+        m.Title = dto.Title?.Trim() ?? string.Empty;
+        m.OriginalTitle = dto.OriginalTitle;
+        m.Year = dto.Year;
+        m.Formats = dto.Formats;
+        m.Director = dto.Director;
+        m.RuntimeMinutes = dto.RuntimeMinutes;
+        m.Studio = dto.Studio;
+        m.Genres = dto.Genres;
+        m.Barcode = dto.Barcode;
+        m.TmdbId = dto.TmdbId;
+        m.ImdbId = dto.ImdbId;
+        m.ImagePath = dto.ImagePath;
+        m.Description = dto.Description;
+        m.Notes = dto.Notes;
+        m.PersonalRating = dto.PersonalRating;
+        m.Status = dto.Status;
+        m.Condition = dto.Condition;
+        m.AcquiredOn = dto.AcquiredOn;
+        m.AcquisitionPrice = dto.AcquisitionPrice;
+        m.AcquisitionCurrency = string.IsNullOrWhiteSpace(dto.AcquisitionCurrency) ? null : dto.AcquisitionCurrency.ToUpperInvariant();
+        m.AcquisitionSource = dto.AcquisitionSource;
+        m.WatchStatus = dto.WatchStatus;
+        m.LastWatchedOn = dto.LastWatchedOn;
+        m.WatchCount = dto.WatchCount;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -1,0 +1,164 @@
+using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class MusicEndpoints
+{
+    public record AlbumDto(
+        int? Id,
+        string Title,
+        string ArtistName,
+        int? Year,
+        MusicFormat Format,
+        string? Label,
+        string? Genres,
+        string? Barcode,
+        string? MusicBrainzReleaseId,
+        string? DiscogsId,
+        string? ImagePath,
+        string? Description,
+        string? Notes,
+        int? PersonalRating,
+        CollectionStatus Status,
+        Condition? Condition,
+        DateOnly? AcquiredOn,
+        decimal? AcquisitionPrice,
+        string? AcquisitionCurrency,
+        string? AcquisitionSource,
+        int ListenCount,
+        DateOnly? LastPlayedOn,
+        string[]? Tags,
+        DateTime? AddedAt,
+        DateTime? UpdatedAt);
+
+    public static IEndpointRouteBuilder MapMusicEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/music").RequireAuthorization();
+
+        group.MapGet("/", async (
+            [FromQuery] string? query,
+            [FromQuery] MusicFormat? format,
+            [FromQuery] int? year,
+            CollectifyDbContext db,
+            UserManager<AppUser> users,
+            HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var q = db.MusicAlbums.AsNoTracking().Include(a => a.Tags).Where(a => a.OwnerId == ownerId);
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var like = $"%{query}%";
+                q = q.Where(a => EF.Functions.Like(a.Title, like)
+                              || EF.Functions.Like(a.ArtistName, like)
+                              || (a.Label != null && EF.Functions.Like(a.Label, like)));
+            }
+            if (format.HasValue) q = q.Where(a => a.Format == format.Value);
+            if (year.HasValue) q = q.Where(a => a.Year == year);
+
+            var items = await q.OrderByDescending(a => a.AddedAt).Take(500).ToListAsync();
+            return Results.Ok(items.Select(ToDto));
+        });
+
+        group.MapGet("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var a = await db.MusicAlbums.AsNoTracking().Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            return a is null ? Results.NotFound() : Results.Ok(ToDto(a));
+        });
+
+        group.MapPost("/", async ([FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var a = new MusicAlbum { OwnerId = ownerId };
+            ApplyDto(a, dto);
+            a.ImagePath = await covers.EnsureLocalAsync(a.ImagePath, ct);
+            a.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            db.MusicAlbums.Add(a);
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/api/music/{a.Id}", ToDto(a));
+        });
+
+        group.MapPut("/{id:int}", async (int id, [FromBody] AlbumDto dto, CollectifyDbContext db, UserManager<AppUser> users, ICoverImageStore covers, HttpContext ctx, CancellationToken ct) =>
+        {
+            if (Validate(dto) is { } error) return error;
+            var ownerId = users.GetUserId(ctx.User)!;
+            var a = await db.MusicAlbums.Include(x => x.Tags)
+                .FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId, ct);
+            if (a is null) return Results.NotFound();
+            ApplyDto(a, dto);
+            a.ImagePath = await covers.EnsureLocalAsync(a.ImagePath, ct);
+            a.Tags = await TagResolver.ResolveAsync(db, ownerId, dto.Tags);
+            a.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(ToDto(a));
+        });
+
+        group.MapDelete("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var a = await db.MusicAlbums.FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId);
+            if (a is null) return Results.NotFound();
+            db.MusicAlbums.Remove(a);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+
+    private static IResult? Validate(AlbumDto dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+            return Results.BadRequest(new { error = "Title is required." });
+        if (string.IsNullOrWhiteSpace(dto.ArtistName))
+            return Results.BadRequest(new { error = "Artist name is required." });
+        if (dto.PersonalRating is { } r && (r < 1 || r > 10))
+            return Results.BadRequest(new { error = "PersonalRating must be between 1 and 10." });
+        if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)
+            return Results.BadRequest(new { error = "AcquisitionCurrency must be a 3-letter ISO 4217 code." });
+        return null;
+    }
+
+    private static AlbumDto ToDto(MusicAlbum a) => new(
+        a.Id, a.Title, a.ArtistName, a.Year, a.Format, a.Label, a.Genres, a.Barcode,
+        a.MusicBrainzReleaseId, a.DiscogsId, a.ImagePath, a.Description, a.Notes,
+        a.PersonalRating, a.Status, a.Condition,
+        a.AcquiredOn, a.AcquisitionPrice, a.AcquisitionCurrency, a.AcquisitionSource,
+        a.ListenCount, a.LastPlayedOn,
+        TagResolver.ToNameArray(a.Tags),
+        a.AddedAt, a.UpdatedAt);
+
+    private static void ApplyDto(MusicAlbum a, AlbumDto dto)
+    {
+        a.Title = dto.Title?.Trim() ?? string.Empty;
+        a.ArtistName = dto.ArtistName?.Trim() ?? string.Empty;
+        a.Year = dto.Year;
+        a.Format = dto.Format;
+        a.Label = dto.Label;
+        a.Genres = dto.Genres;
+        a.Barcode = dto.Barcode;
+        a.MusicBrainzReleaseId = dto.MusicBrainzReleaseId;
+        a.DiscogsId = dto.DiscogsId;
+        a.ImagePath = dto.ImagePath;
+        a.Description = dto.Description;
+        a.Notes = dto.Notes;
+        a.PersonalRating = dto.PersonalRating;
+        a.Status = dto.Status;
+        a.Condition = dto.Condition;
+        a.AcquiredOn = dto.AcquiredOn;
+        a.AcquisitionPrice = dto.AcquisitionPrice;
+        a.AcquisitionCurrency = string.IsNullOrWhiteSpace(dto.AcquisitionCurrency) ? null : dto.AcquisitionCurrency.ToUpperInvariant();
+        a.AcquisitionSource = dto.AcquisitionSource;
+        a.ListenCount = dto.ListenCount;
+        a.LastPlayedOn = dto.LastPlayedOn;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/TagEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/TagEndpoints.cs
@@ -1,0 +1,60 @@
+using Collectify.Domain.Entities;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class TagEndpoints
+{
+    public record TagDto(int Id, string Name);
+    public record CreateTagRequest(string Name);
+
+    public static IEndpointRouteBuilder MapTagEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/tags").RequireAuthorization();
+
+        group.MapGet("/", async (CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var tags = await db.Tags.AsNoTracking()
+                .Where(t => t.OwnerId == ownerId)
+                .OrderBy(t => t.Name)
+                .Select(t => new TagDto(t.Id, t.Name))
+                .ToListAsync();
+            return Results.Ok(tags);
+        });
+
+        group.MapPost("/", async ([FromBody] CreateTagRequest req, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.Name))
+                return Results.BadRequest(new { error = "Name is required." });
+
+            var ownerId = users.GetUserId(ctx.User)!;
+            var name = req.Name.Trim().ToLowerInvariant();
+
+            var existing = await db.Tags.FirstOrDefaultAsync(t => t.OwnerId == ownerId && t.Name == name);
+            if (existing is not null)
+                return Results.Ok(new TagDto(existing.Id, existing.Name));
+
+            var tag = new Tag { OwnerId = ownerId, Name = name };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+            return Results.Created($"/api/tags/{tag.Id}", new TagDto(tag.Id, tag.Name));
+        });
+
+        group.MapDelete("/{id:int}", async (int id, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+            var tag = await db.Tags.FirstOrDefaultAsync(t => t.Id == id && t.OwnerId == ownerId);
+            if (tag is null) return Results.NotFound();
+            db.Tags.Remove(tag);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/TagResolver.cs
+++ b/src/server/Collectify.Api/Endpoints/TagResolver.cs
@@ -1,0 +1,39 @@
+using Collectify.Domain.Entities;
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+internal static class TagResolver
+{
+    public static async Task<List<Tag>> ResolveAsync(
+        CollectifyDbContext db,
+        string ownerId,
+        IEnumerable<string>? names)
+    {
+        if (names is null) return [];
+
+        var normalized = names
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim().ToLowerInvariant())
+            .Distinct()
+            .ToList();
+        if (normalized.Count == 0) return [];
+
+        var existing = await db.Tags
+            .Where(t => t.OwnerId == ownerId && normalized.Contains(t.Name))
+            .ToListAsync();
+
+        var missing = normalized.Except(existing.Select(t => t.Name)).ToList();
+        foreach (var name in missing)
+        {
+            var t = new Tag { OwnerId = ownerId, Name = name };
+            db.Tags.Add(t);
+            existing.Add(t);
+        }
+        return existing;
+    }
+
+    public static string[] ToNameArray(IEnumerable<Tag> tags) =>
+        tags.Select(t => t.Name).OrderBy(n => n).ToArray();
+}

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -1,0 +1,106 @@
+using System.Text.Json.Serialization;
+using Collectify.Api.Endpoints;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.Images;
+using Collectify.Infrastructure.Lookup.Tmdb;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Resolve / create the data directory inside the registration callback so the
+// filesystem touch happens lazily — only if this DbContext registration is
+// actually used. Tests replace it with an in-memory SqliteConnection and
+// never trigger the mkdir, which avoids platform-specific permission
+// surprises (e.g. AppContext.BaseDirectory resolving to "/" inside the
+// WebApplicationFactory test host).
+builder.Services.AddDbContext<CollectifyDbContext>(opt =>
+{
+    var dataDir = builder.Configuration["Collectify:DataDir"]
+        ?? Path.Combine(AppContext.BaseDirectory, "data");
+    Directory.CreateDirectory(dataDir);
+    var dbPath = Path.Combine(dataDir, "collectify.db");
+    opt.UseSqlite($"Data Source={dbPath}");
+});
+
+builder.Services
+    .AddIdentityCore<AppUser>(opt =>
+    {
+        opt.Password.RequireDigit = false;
+        opt.Password.RequireLowercase = false;
+        opt.Password.RequireUppercase = false;
+        opt.Password.RequireNonAlphanumeric = false;
+        opt.Password.RequiredLength = 8;
+    })
+    .AddSignInManager()
+    .AddEntityFrameworkStores<CollectifyDbContext>();
+
+builder.Services.AddAuthentication(IdentityConstants.ApplicationScheme)
+    .AddCookie(IdentityConstants.ApplicationScheme, opt =>
+    {
+        opt.Cookie.Name = "collectify.auth";
+        opt.Cookie.HttpOnly = true;
+        opt.Cookie.SameSite = SameSiteMode.Lax;
+        opt.ExpireTimeSpan = TimeSpan.FromDays(30);
+        opt.SlidingExpiration = true;
+        opt.LoginPath = "/login";
+        opt.Events.OnRedirectToLogin = ctx =>
+        {
+            if (ctx.Request.Path.StartsWithSegments("/api"))
+            {
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            }
+            ctx.Response.Redirect(ctx.RedirectUri);
+            return Task.CompletedTask;
+        };
+    });
+
+builder.Services.AddAuthorization();
+builder.Services.ConfigureHttpJsonOptions(opt =>
+{
+    opt.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddMetadataLookup(builder.Configuration);
+builder.Services.AddTmdbMovieProvider(builder.Configuration);
+
+// Cover-image cache. Bytes live in the CoverImages table alongside the
+// rest of the data so a backup of collectify.db is a complete snapshot.
+builder.Services.AddHttpClient(CoverImageStore.HttpClientName);
+builder.Services.AddScoped<ICoverImageStore, CoverImageStore>();
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<CollectifyDbContext>();
+    await db.Database.MigrateAsync();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapAuthEndpoints();
+app.MapMoviesEndpoints();
+app.MapMusicEndpoints();
+app.MapGamesEndpoints();
+app.MapTagEndpoints();
+app.MapLookupEndpoints();
+app.MapCoversEndpoints();
+
+app.MapGet("/api/health", () => Results.Ok(new { status = "ok" }));
+
+var webRoot = Path.Combine(AppContext.BaseDirectory, "wwwroot");
+if (Directory.Exists(webRoot))
+{
+    app.UseDefaultFiles();
+    app.UseStaticFiles();
+    app.MapFallbackToFile("index.html");
+}
+
+app.Run();
+
+public partial class Program { }

--- a/src/server/Collectify.Api/Properties/launchSettings.json
+++ b/src/server/Collectify.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5041",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7205;http://localhost:5041",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/server/Collectify.Api/appsettings.Development.json
+++ b/src/server/Collectify.Api/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Collectify": {
+    "DataDir": "./data"
+  }
+}

--- a/src/server/Collectify.Api/appsettings.json
+++ b/src/server/Collectify.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Why

The entire **`Collectify.Api`** project — 13 source files — was accidentally deleted from the tree as part of an earlier commit. Affected files:

- `Collectify.Api.csproj`
- `Program.cs`
- All eight files under `Endpoints/` (`AuthEndpoints`, `CoversEndpoints`, `GamesEndpoints`, `LookupEndpoints`, `MoviesEndpoints`, `MusicEndpoints`, `TagEndpoints`, `TagResolver`)
- `Properties/launchSettings.json`
- `appsettings.json`, `appsettings.Development.json`

Main is currently unbuildable on a fresh clone — `dotnet build` errors out, `dotnet test` can't find the entry point, the SPA dev proxy points at a server that won't start.

## What

Restore each of those 13 files verbatim from **`7e85c2e`** (the merge commit of PR #14 — the last known-good `Collectify.Api` tree). No content changes — pure recovery commit. Domain, Infrastructure, and tests were unaffected and stay as-is.

## Test plan

- [x] `./scripts/ci-local.sh` — server **130/130**, client **25/25**, both builds clean.
- [x] `dotnet build src/server/Collectify.slnx` — 0 warnings, 0 errors.
- [ ] (Optional) Smoke check `dotnet run --project src/server/Collectify.Api` + `npm run dev` to confirm setup / login still flow end-to-end.

## Note on the commit message

The commit text on this branch speculates that graphify caused the deletion. That turned out to be incorrect — it was a manual `git rm`. Not worth a force-push to amend; squash-merging this PR will let you write a clean final commit message that drops the misattribution.