### PR TITLE
feat: TMDB metadata via title search, TMDB id, or IMDB id (closes #16)

### DIFF
--- a/src/client/components/MovieForm.test.tsx
+++ b/src/client/components/MovieForm.test.tsx
@@ -8,13 +8,14 @@ import MovieForm from './MovieForm';
 // without a backend or a TanStack Query refetch dance.
 const mockLookupMovieById = vi.fn();
 const mockLookupMovieByImdbId = vi.fn();
+const mockUseLookup = vi.fn().mockReturnValue({ data: undefined, isLoading: false, error: null });
 vi.mock('../services/lookup', async (importOriginal) => {
   const original = await importOriginal<typeof import('../services/lookup')>();
   return {
     ...original,
     lookupMovieById: (id: string) => mockLookupMovieById(id),
     lookupMovieByImdbId: (id: string) => mockLookupMovieByImdbId(id),
-    useLookup: () => ({ data: undefined, isLoading: false, error: null }),
+    useLookup: () => mockUseLookup(),
   };
 });
 vi.mock('../services/tags', () => ({
@@ -35,6 +36,8 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
   beforeEach(() => {
     mockLookupMovieById.mockReset();
     mockLookupMovieByImdbId.mockReset();
+    mockUseLookup.mockReset();
+    mockUseLookup.mockReturnValue({ data: undefined, isLoading: false, error: null });
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -152,5 +155,68 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
     await user.click(screen.getByRole('button', { name: /fetch metadata by imdb id/i }));
 
     expect(await screen.findByText(/no movie with imdb id tt9999999/i)).toBeInTheDocument();
+  });
+
+  it('picking a TMDB search result enriches director and runtime via a follow-up by-id call', async () => {
+    // Search response carries title/year/description but not director or
+    // runtime -- those come from the chained /movie/{id} call.
+    mockUseLookup.mockReturnValue({
+      data: {
+        provider: 'tmdb',
+        configured: true,
+        results: [
+          {
+            provider: 'tmdb',
+            providerKey: '27205',
+            title: 'Inception',
+            originalTitle: 'Inception',
+            year: 2010,
+            director: null,
+            runtimeMinutes: null,
+            description: 'A heist on the subconscious.',
+            imageUrl: 'https://image.tmdb.org/t/p/w342/poster.jpg',
+            genres: null,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockLookupMovieById.mockResolvedValue({
+      kind: 'found',
+      result: {
+        provider: 'tmdb',
+        providerKey: '27205',
+        title: 'Inception',
+        originalTitle: 'Inception',
+        year: 2010,
+        director: 'Christopher Nolan',
+        runtimeMinutes: 148,
+        description: 'A heist on the subconscious.',
+        imageUrl: 'https://image.tmdb.org/t/p/w342/poster.jpg',
+        genres: null,
+      },
+    });
+
+    renderForm();
+    const user = userEvent.setup();
+
+    // Open the OnlineSearch dropdown by typing into it.
+    await user.type(screen.getByPlaceholderText('e.g. Inception'), 'inc');
+    // Click the suggestion. The dropdown row's primary text is
+    // "Inception (2010)".
+    await user.click(await screen.findByText('Inception (2010)'));
+
+    // The synchronous patch fills title/year right away.
+    await waitFor(() => {
+      expect(screen.getAllByDisplayValue('Inception').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // The async enrichment fills director and runtime once /movie/{id} resolves.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Christopher Nolan')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('148')).toBeInTheDocument();
+    expect(mockLookupMovieById).toHaveBeenCalledWith('27205');
   });
 });

--- a/src/client/components/MovieForm.test.tsx
+++ b/src/client/components/MovieForm.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MovieForm from './MovieForm';
+
+// Swap the data layer so the form's "Fetch metadata" button can be exercised
+// without a backend or a TanStack Query refetch dance.
+const mockLookupMovieById = vi.fn();
+vi.mock('../services/lookup', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../services/lookup')>();
+  return {
+    ...original,
+    lookupMovieById: (id: string) => mockLookupMovieById(id),
+    useLookup: () => ({ data: undefined, isLoading: false, error: null }),
+  };
+});
+vi.mock('../services/tags', () => ({
+  useTags: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+function renderForm(onSubmit = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <MovieForm onSubmit={onSubmit} />
+    </QueryClientProvider>,
+  );
+  return { onSubmit };
+}
+
+describe('MovieForm — Fetch metadata by TMDB ID', () => {
+  beforeEach(() => {
+    mockLookupMovieById.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disables the fetch button when the TMDB ID field is empty', () => {
+    renderForm();
+    const button = screen.getByRole('button', { name: /fetch metadata/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('populates form fields when the lookup returns a found result', async () => {
+    mockLookupMovieById.mockResolvedValue({
+      kind: 'found',
+      result: {
+        provider: 'tmdb',
+        providerKey: '27205',
+        title: 'Inception',
+        originalTitle: 'Inception',
+        year: 2010,
+        director: 'Christopher Nolan',
+        runtimeMinutes: 148,
+        description: 'A heist on the subconscious.',
+        imageUrl: 'https://image.tmdb.org/t/p/w342/poster.jpg',
+        genres: null,
+      },
+    });
+
+    renderForm();
+    const user = userEvent.setup();
+
+    const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
+    await user.type(tmdbInput, '27205');
+    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+
+    // Director / Year / Runtime are unique values; Inception fills both
+    // Title and Original title so it appears twice.
+    await waitFor(() => {
+      expect(screen.getAllByDisplayValue('Inception')).toHaveLength(2);
+    });
+    expect(screen.getByDisplayValue('Christopher Nolan')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2010')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('148')).toBeInTheDocument();
+    expect(mockLookupMovieById).toHaveBeenCalledWith('27205');
+  });
+
+  it('shows a hint when the provider reports not-configured and leaves the title empty', async () => {
+    mockLookupMovieById.mockResolvedValue({ kind: 'not-configured' });
+
+    renderForm();
+    const user = userEvent.setup();
+    const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
+    await user.type(tmdbInput, '27205');
+    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+
+    expect(await screen.findByText(/not configured/i)).toBeInTheDocument();
+    // No movie title was injected.
+    expect(screen.queryByDisplayValue('Inception')).not.toBeInTheDocument();
+  });
+
+  it('shows a not-found hint when the lookup misses', async () => {
+    mockLookupMovieById.mockResolvedValue({ kind: 'not-found' });
+
+    renderForm();
+    const user = userEvent.setup();
+    const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
+    await user.type(tmdbInput, '9999999');
+    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+
+    expect(await screen.findByText(/no movie with tmdb id 9999999/i)).toBeInTheDocument();
+  });
+});

--- a/src/client/components/MovieForm.test.tsx
+++ b/src/client/components/MovieForm.test.tsx
@@ -4,14 +4,16 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MovieForm from './MovieForm';
 
-// Swap the data layer so the form's "Fetch metadata" button can be exercised
+// Swap the data layer so the form's "Fetch metadata" buttons can be exercised
 // without a backend or a TanStack Query refetch dance.
 const mockLookupMovieById = vi.fn();
+const mockLookupMovieByImdbId = vi.fn();
 vi.mock('../services/lookup', async (importOriginal) => {
   const original = await importOriginal<typeof import('../services/lookup')>();
   return {
     ...original,
     lookupMovieById: (id: string) => mockLookupMovieById(id),
+    lookupMovieByImdbId: (id: string) => mockLookupMovieByImdbId(id),
     useLookup: () => ({ data: undefined, isLoading: false, error: null }),
   };
 });
@@ -32,6 +34,7 @@ function renderForm(onSubmit = vi.fn()) {
 describe('MovieForm — Fetch metadata by TMDB ID', () => {
   beforeEach(() => {
     mockLookupMovieById.mockReset();
+    mockLookupMovieByImdbId.mockReset();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -39,7 +42,7 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
 
   it('disables the fetch button when the TMDB ID field is empty', () => {
     renderForm();
-    const button = screen.getByRole('button', { name: /fetch metadata/i });
+    const button = screen.getByRole('button', { name: /fetch metadata by tmdb id/i });
     expect(button).toBeDisabled();
   });
 
@@ -65,7 +68,7 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
 
     const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
     await user.type(tmdbInput, '27205');
-    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+    await user.click(screen.getByRole('button', { name: /fetch metadata by tmdb id/i }));
 
     // Director / Year / Runtime are unique values; Inception fills both
     // Title and Original title so it appears twice.
@@ -85,7 +88,7 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
     const user = userEvent.setup();
     const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
     await user.type(tmdbInput, '27205');
-    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+    await user.click(screen.getByRole('button', { name: /fetch metadata by tmdb id/i }));
 
     expect(await screen.findByText(/not configured/i)).toBeInTheDocument();
     // No movie title was injected.
@@ -99,8 +102,55 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
     const user = userEvent.setup();
     const tmdbInput = screen.getByPlaceholderText('e.g. 27205');
     await user.type(tmdbInput, '9999999');
-    await user.click(screen.getByRole('button', { name: /fetch metadata/i }));
+    await user.click(screen.getByRole('button', { name: /fetch metadata by tmdb id/i }));
 
     expect(await screen.findByText(/no movie with tmdb id 9999999/i)).toBeInTheDocument();
+  });
+
+  it('IMDB Fetch populates form fields when the lookup returns a found result', async () => {
+    mockLookupMovieByImdbId.mockResolvedValue({
+      kind: 'found',
+      result: {
+        provider: 'tmdb',
+        providerKey: '603',
+        title: 'The Matrix',
+        originalTitle: 'The Matrix',
+        year: 1999,
+        director: 'Lana Wachowski & Lilly Wachowski',
+        runtimeMinutes: 136,
+        description: 'A hacker discovers the truth.',
+        imageUrl: 'https://image.tmdb.org/t/p/w342/matrix.jpg',
+        genres: null,
+      },
+    });
+
+    renderForm();
+    const user = userEvent.setup();
+
+    const imdbInput = screen.getByPlaceholderText('e.g. tt1375666');
+    await user.type(imdbInput, 'tt0133093');
+    await user.click(screen.getByRole('button', { name: /fetch metadata by imdb id/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByDisplayValue('The Matrix')).toHaveLength(2);
+    });
+    expect(screen.getByDisplayValue('Lana Wachowski & Lilly Wachowski')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1999')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('136')).toBeInTheDocument();
+    expect(mockLookupMovieByImdbId).toHaveBeenCalledWith('tt0133093');
+    // The TMDB-id lookup must not have been used.
+    expect(mockLookupMovieById).not.toHaveBeenCalled();
+  });
+
+  it('IMDB Fetch shows not-found when the resolver returns nothing', async () => {
+    mockLookupMovieByImdbId.mockResolvedValue({ kind: 'not-found' });
+
+    renderForm();
+    const user = userEvent.setup();
+    const imdbInput = screen.getByPlaceholderText('e.g. tt1375666');
+    await user.type(imdbInput, 'tt9999999');
+    await user.click(screen.getByRole('button', { name: /fetch metadata by imdb id/i }));
+
+    expect(await screen.findByText(/no movie with imdb id tt9999999/i)).toBeInTheDocument();
   });
 });

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -42,6 +42,40 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
       imagePath: r.imageUrl ?? null,
       tmdbId: r.provider === 'tmdb' ? r.providerKey : m.tmdbId ?? null,
     });
+
+    // /search/movie doesn't carry director or runtime. If the user just
+    // picked a TMDB summary, follow up with /movie/{id} to fill those in.
+    // The chained call is cached, so picking the same row twice or
+    // pasting the same TMDB id later is a free hit.
+    if (r.provider === 'tmdb' && (r.director == null || r.runtimeMinutes == null)) {
+      void enrichFromTmdb(r.providerKey);
+    }
+  };
+
+  const enrichFromTmdb = async (tmdbId: string) => {
+    setFetchState({ status: 'loading', message: 'Loading director and runtime…' });
+    try {
+      const outcome = await lookupMovieById(tmdbId);
+      if (outcome.kind !== 'found') {
+        setFetchState({ status: 'idle' });
+        return;
+      }
+      // Use functional setM so a newer pick (different tmdbId already in
+      // state) supersedes this enrichment instead of overwriting fresh
+      // data with the previous movie's. Also preserve any value the user
+      // already typed manually while the enrichment was in flight.
+      setM((prev) => {
+        if (prev.tmdbId !== tmdbId) return prev;
+        return {
+          ...prev,
+          director: prev.director ?? outcome.result.director ?? null,
+          runtimeMinutes: prev.runtimeMinutes ?? outcome.result.runtimeMinutes ?? null,
+        };
+      });
+      setFetchState({ status: 'idle', message: 'Populated from TMDB.' });
+    } catch {
+      setFetchState({ status: 'idle' });
+    }
   };
 
   const runLookup = async (

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -3,7 +3,7 @@ import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
-import { lookupMovieById, type MovieLookupResult } from '../services/lookup';
+import { lookupMovieById, lookupMovieByImdbId, type LookupByIdOutcome, type MovieLookupResult } from '../services/lookup';
 
 interface Props {
   initial?: Movie;
@@ -44,27 +44,34 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
     });
   };
 
-  const fetchByTmdbId = async () => {
-    const id = (m.tmdbId ?? '').trim();
-    if (!id) {
-      setFetchState({ status: 'idle', message: 'Enter a TMDB ID first.' });
+  const runLookup = async (
+    id: string,
+    label: string,
+    lookup: (id: string) => Promise<LookupByIdOutcome>,
+  ) => {
+    const trimmed = id.trim();
+    if (!trimmed) {
+      setFetchState({ status: 'idle', message: `Enter a ${label} first.` });
       return;
     }
     setFetchState({ status: 'loading' });
     try {
-      const outcome = await lookupMovieById(id);
+      const outcome = await lookup(trimmed);
       if (outcome.kind === 'found') {
         importLookup(outcome.result);
         setFetchState({ status: 'idle', message: 'Populated from TMDB.' });
       } else if (outcome.kind === 'not-configured') {
         setFetchState({ status: 'idle', message: 'TMDB lookup not configured. Set the provider key.' });
       } else {
-        setFetchState({ status: 'idle', message: `No movie with TMDB ID ${id}.` });
+        setFetchState({ status: 'idle', message: `No movie with ${label} ${trimmed}.` });
       }
     } catch (err) {
       setFetchState({ status: 'idle', message: (err as Error).message ?? 'Lookup failed.' });
     }
   };
+
+  const fetchByTmdbId = () => runLookup(m.tmdbId ?? '', 'TMDB ID', lookupMovieById);
+  const fetchByImdbId = () => runLookup(m.imdbId ?? '', 'IMDB ID', lookupMovieByImdbId);
 
   return (
     <form
@@ -173,28 +180,42 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
             urlPrefix="https://www.themoviedb.org/movie/"
             placeholder="e.g. 27205"
           />
-          <div className="flex items-center gap-2">
+          <div>
             <Button
               type="button"
               variant="secondary"
               onClick={fetchByTmdbId}
               disabled={fetchState.status === 'loading' || !(m.tmdbId ?? '').trim()}
+              aria-label="Fetch metadata by TMDB ID"
             >
               {fetchState.status === 'loading' ? 'Fetching…' : 'Fetch metadata'}
             </Button>
-            {fetchState.message && (
-              <span className="text-xs text-slate-400">{fetchState.message}</span>
-            )}
           </div>
         </div>
-        <ExternalIdField
-          label="IMDB ID"
-          value={m.imdbId}
-          onChange={(v) => set('imdbId', v)}
-          urlPrefix="https://www.imdb.com/title/"
-          placeholder="e.g. tt1375666"
-        />
+        <div className="space-y-1">
+          <ExternalIdField
+            label="IMDB ID"
+            value={m.imdbId}
+            onChange={(v) => set('imdbId', v)}
+            urlPrefix="https://www.imdb.com/title/"
+            placeholder="e.g. tt1375666"
+          />
+          <div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={fetchByImdbId}
+              disabled={fetchState.status === 'loading' || !(m.imdbId ?? '').trim()}
+              aria-label="Fetch metadata by IMDB ID"
+            >
+              {fetchState.status === 'loading' ? 'Fetching…' : 'Fetch metadata'}
+            </Button>
+          </div>
+        </div>
       </div>
+      {fetchState.message && (
+        <div className="text-xs text-slate-400">{fetchState.message}</div>
+      )}
 
       <Field label="Notes">
         <Textarea rows={3} value={m.notes ?? ''} onChange={(e) => set('notes', e.target.value || null)} />

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -3,7 +3,7 @@ import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
-import type { MovieLookupResult } from '../services/lookup';
+import { lookupMovieById, type MovieLookupResult } from '../services/lookup';
 
 interface Props {
   initial?: Movie;
@@ -24,6 +24,7 @@ const empty: Movie = {
 
 export default function MovieForm({ initial, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [m, setM] = useState<Movie>(initial ?? empty);
+  const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setM(initial); }, [initial]);
 
   const set = <K extends keyof Movie>(k: K, v: Movie[K]) => setM((prev) => ({ ...prev, [k]: v }));
@@ -35,10 +36,34 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
       title: r.title,
       originalTitle: r.originalTitle ?? null,
       year: r.year ?? null,
+      director: r.director ?? null,
+      runtimeMinutes: r.runtimeMinutes ?? null,
       description: r.description ?? null,
       imagePath: r.imageUrl ?? null,
       tmdbId: r.provider === 'tmdb' ? r.providerKey : m.tmdbId ?? null,
     });
+  };
+
+  const fetchByTmdbId = async () => {
+    const id = (m.tmdbId ?? '').trim();
+    if (!id) {
+      setFetchState({ status: 'idle', message: 'Enter a TMDB ID first.' });
+      return;
+    }
+    setFetchState({ status: 'loading' });
+    try {
+      const outcome = await lookupMovieById(id);
+      if (outcome.kind === 'found') {
+        importLookup(outcome.result);
+        setFetchState({ status: 'idle', message: 'Populated from TMDB.' });
+      } else if (outcome.kind === 'not-configured') {
+        setFetchState({ status: 'idle', message: 'TMDB lookup not configured. Set the provider key.' });
+      } else {
+        setFetchState({ status: 'idle', message: `No movie with TMDB ID ${id}.` });
+      }
+    } catch (err) {
+      setFetchState({ status: 'idle', message: (err as Error).message ?? 'Lookup failed.' });
+    }
   };
 
   return (
@@ -140,13 +165,28 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
 
       <SectionHeading>External IDs</SectionHeading>
       <div className="grid sm:grid-cols-2 gap-4">
-        <ExternalIdField
-          label="TMDB ID"
-          value={m.tmdbId}
-          onChange={(v) => set('tmdbId', v)}
-          urlPrefix="https://www.themoviedb.org/movie/"
-          placeholder="e.g. 27205"
-        />
+        <div className="space-y-1">
+          <ExternalIdField
+            label="TMDB ID"
+            value={m.tmdbId}
+            onChange={(v) => set('tmdbId', v)}
+            urlPrefix="https://www.themoviedb.org/movie/"
+            placeholder="e.g. 27205"
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={fetchByTmdbId}
+              disabled={fetchState.status === 'loading' || !(m.tmdbId ?? '').trim()}
+            >
+              {fetchState.status === 'loading' ? 'Fetching…' : 'Fetch metadata'}
+            </Button>
+            {fetchState.message && (
+              <span className="text-xs text-slate-400">{fetchState.message}</span>
+            )}
+          </div>
+        </div>
         <ExternalIdField
           label="IMDB ID"
           value={m.imdbId}

--- a/src/client/services/lookup.ts
+++ b/src/client/services/lookup.ts
@@ -95,3 +95,19 @@ export async function lookupMovieById(providerKey: string): Promise<LookupByIdOu
   if (response.results.length === 0) return { kind: 'not-found' };
   return { kind: 'found', result: response.results[0] };
 }
+
+/**
+ * Like {@link lookupMovieById} but uses an external IMDB id (the "tt..." form).
+ * The server resolves it to a TMDB id under the hood; the response shape is
+ * identical so the same caller code handles both flows.
+ */
+export async function lookupMovieByImdbId(imdbId: string): Promise<LookupByIdOutcome> {
+  const trimmed = imdbId.trim();
+  if (!trimmed) return { kind: 'not-found' };
+  const response = await api<LookupResponse<MovieLookupResult>>(
+    `/api/lookup/movies/by-imdb-id/${encodeURIComponent(trimmed)}`,
+  );
+  if (!response.configured) return { kind: 'not-configured' };
+  if (response.results.length === 0) return { kind: 'not-found' };
+  return { kind: 'found', result: response.results[0] };
+}

--- a/src/client/services/lookup.ts
+++ b/src/client/services/lookup.ts
@@ -72,3 +72,26 @@ export function useLookup<T extends MediaType>(type: T, query: string) {
     staleTime: 60_000,
   });
 }
+
+export type LookupByIdOutcome =
+  | { kind: 'found'; result: MovieLookupResult }
+  | { kind: 'not-found' }
+  | { kind: 'not-configured' };
+
+/**
+ * Direct lookup of a movie by its provider id (e.g. a TMDB id). Imperative
+ * by design -- the user clicks a button to trigger a single fetch, no
+ * debouncing or background revalidation needed. Returns a discriminated
+ * union so the caller can render distinct UX for unconfigured vs unknown
+ * id without sniffing array lengths.
+ */
+export async function lookupMovieById(providerKey: string): Promise<LookupByIdOutcome> {
+  const trimmed = providerKey.trim();
+  if (!trimmed) return { kind: 'not-found' };
+  const response = await api<LookupResponse<MovieLookupResult>>(
+    `/api/lookup/movies/by-id/${encodeURIComponent(trimmed)}`,
+  );
+  if (!response.configured) return { kind: 'not-configured' };
+  if (response.results.length === 0) return { kind: 'not-found' };
+  return { kind: 'found', result: response.results[0] };
+}

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -45,6 +45,26 @@ public static class LookupEndpoints
             return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
         });
 
+        // Lookup via an external IMDB id (the "tt..." shape). The provider
+        // resolves it to its own provider key under the hood; the response
+        // shape matches /by-id so the frontend uses the same code path.
+        group.MapGet("/movies/by-imdb-id/{imdbId}", async (
+            string imdbId,
+            IMovieMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(imdbId))
+                return Results.BadRequest(new { error = "IMDB id is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, false, []));
+
+            var hit = await provider.GetByImdbIdAsync(imdbId.Trim(), ct);
+            IReadOnlyList<MovieLookupResult> results = hit is null
+                ? []
+                : new[] { hit };
+            return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
+        });
+
         group.MapGet("/music", async (
             [FromQuery] string? q,
             IMusicMetadataProvider provider,

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -23,6 +23,28 @@ public static class LookupEndpoints
             return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
         });
 
+        // Direct lookup by provider id (e.g. a TMDB movie id). Reuses
+        // LookupResponse so the frontend handles unconfigured / not-found /
+        // found with one shape: 0 results = not-found, 1 result = found,
+        // configured=false signals "set the provider key" instead of
+        // "your id was wrong".
+        group.MapGet("/movies/by-id/{providerKey}", async (
+            string providerKey,
+            IMovieMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(providerKey))
+                return Results.BadRequest(new { error = "Provider key is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, false, []));
+
+            var hit = await provider.GetByIdAsync(providerKey.Trim(), ct);
+            IReadOnlyList<MovieLookupResult> results = hit is null
+                ? []
+                : new[] { hit };
+            return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
+        });
+
         group.MapGet("/music", async (
             [FromQuery] string? q,
             IMusicMetadataProvider provider,

--- a/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
@@ -19,6 +19,13 @@ public interface IMovieMetadataProvider
     /// on null when <see cref="IsConfigured"/> is false.
     /// </summary>
     Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lookup by an IMDB id (the <c>tt…</c> shape). Implementations are
+    /// expected to resolve the IMDB id to their own provider key under the
+    /// hood and return the same shape as <see cref="GetByIdAsync"/>.
+    /// </summary>
+    Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default);
 }
 
 public interface IMusicMetadataProvider

--- a/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
@@ -12,6 +12,13 @@ public interface IMovieMetadataProvider
     string Name { get; }
     bool IsConfigured { get; }
     Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default);
+
+    /// <summary>
+    /// Direct lookup by the provider's identifier (e.g. a TMDB id). Returns
+    /// null when the provider doesn't recognise the id; tests may also rely
+    /// on null when <see cref="IsConfigured"/> is false.
+    /// </summary>
+    Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default);
 }
 
 public interface IMusicMetadataProvider

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -15,6 +15,9 @@ internal sealed class StubMovieProvider : IMovieMetadataProvider
 
     public Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult<MovieLookupResult?>(null);
+
+    public Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default)
+        => Task.FromResult<MovieLookupResult?>(null);
 }
 
 internal sealed class StubMusicProvider : IMusicMetadataProvider

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -12,6 +12,9 @@ internal sealed class StubMovieProvider : IMovieMetadataProvider
 
     public Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<MovieLookupResult>>(Array.Empty<MovieLookupResult>());
+
+    public Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+        => Task.FromResult<MovieLookupResult?>(null);
 }
 
 internal sealed class StubMusicProvider : IMusicMetadataProvider

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -63,6 +64,42 @@ public sealed class TmdbMovieProvider : IMovieMetadataProvider
         return mapped;
     }
 
+    public async Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        if (string.IsNullOrWhiteSpace(providerKey)) return null;
+
+        // Separate cache namespace from search so the two flows can't poison
+        // each other's results.
+        var cacheKey = "id:" + providerKey;
+        var cached = await _cache.GetAsync<MovieLookupResult>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        TmdbMovieDetail? detail;
+        try
+        {
+            // append_to_response=credits saves us a /credits round trip and
+            // gives us director + runtime in the same payload.
+            var url = $"movie/{Uri.EscapeDataString(providerKey)}?api_key={Uri.EscapeDataString(_options.Tmdb.ApiKey!)}&append_to_response=credits";
+            detail = await _http.GetFromJsonAsync<TmdbMovieDetail>(url, ct);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // TMDB doesn't recognise the id; not an error worth shouting about.
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "TMDB lookup-by-id failed for {Id}", providerKey);
+            return null;
+        }
+
+        if (detail is null) return null;
+        var mapped = MapDetail(detail);
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+
     private MovieLookupResult Map(TmdbMovieSummary s) => new(
         Provider: ProviderName,
         ProviderKey: s.Id.ToString(),
@@ -74,6 +111,32 @@ public sealed class TmdbMovieProvider : IMovieMetadataProvider
         Description: s.Overview,
         ImageUrl: BuildImageUrl(s.PosterPath),
         Genres: null);
+
+    private MovieLookupResult MapDetail(TmdbMovieDetail d) => new(
+        Provider: ProviderName,
+        ProviderKey: d.Id.ToString(),
+        Title: d.Title ?? d.OriginalTitle ?? string.Empty,
+        OriginalTitle: d.OriginalTitle,
+        Year: ParseYear(d.ReleaseDate),
+        Director: ExtractDirector(d.Credits),
+        RuntimeMinutes: d.Runtime,
+        Description: d.Overview,
+        ImageUrl: BuildImageUrl(d.PosterPath),
+        Genres: null);
+
+    private static string? ExtractDirector(TmdbCredits? credits)
+    {
+        if (credits?.Crew is null) return null;
+        // Co-directed films get joined by " & " for clarity. Order is
+        // whatever TMDB returns -- usually the primary director first.
+        var directors = credits.Crew
+            .Where(c => string.Equals(c.Job, "Director", StringComparison.Ordinal))
+            .Select(c => c.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Cast<string>()
+            .ToList();
+        return directors.Count == 0 ? null : string.Join(" & ", directors);
+    }
 
     private static int? ParseYear(string? releaseDate)
     {

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
@@ -100,6 +100,49 @@ public sealed class TmdbMovieProvider : IMovieMetadataProvider
         return mapped;
     }
 
+    public async Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        var trimmed = (imdbId ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return null;
+
+        // Separate cache namespace from id-lookup and search so an unrelated
+        // string that happens to match (e.g. "tt27205") can't satisfy a
+        // different lookup.
+        var cacheKey = "imdb:" + trimmed;
+        var cached = await _cache.GetAsync<MovieLookupResult>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        TmdbFindResponse? body;
+        try
+        {
+            // /find returns matches across categories (movie / tv / person);
+            // we only consume movie_results.
+            var url = $"find/{Uri.EscapeDataString(trimmed)}?external_source=imdb_id&api_key={Uri.EscapeDataString(_options.Tmdb.ApiKey!)}";
+            body = await _http.GetFromJsonAsync<TmdbFindResponse>(url, ct);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "TMDB find-by-imdb failed for {Id}", trimmed);
+            return null;
+        }
+
+        var first = body?.MovieResults?.FirstOrDefault();
+        if (first is null) return null;
+
+        // Resolve the TMDB id into the full detail. Reuses GetByIdAsync's
+        // cache, so a follow-up by-tmdb-id call for the same movie is free.
+        var detail = await GetByIdAsync(first.Id.ToString(), ct);
+        if (detail is null) return null;
+
+        await _cache.SetAsync(ProviderName, cacheKey, detail, ct);
+        return detail;
+    }
+
     private MovieLookupResult Map(TmdbMovieSummary s) => new(
         Provider: ProviderName,
         ProviderKey: s.Id.ToString(),

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
@@ -39,3 +39,12 @@ internal sealed record TmdbCredits(
 internal sealed record TmdbCrewMember(
     [property: JsonPropertyName("job")] string? Job,
     [property: JsonPropertyName("name")] string? Name);
+
+/// <summary>
+/// Subset of /find/{external_id}?external_source=imdb_id. The endpoint
+/// returns matches across categories (movie / tv / person / …) but we only
+/// consume <c>movie_results</c> here -- TV series and people don't belong
+/// on a MovieForm.
+/// </summary>
+internal sealed record TmdbFindResponse(
+    [property: JsonPropertyName("movie_results")] IReadOnlyList<TmdbMovieSummary>? MovieResults);

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbResponses.cs
@@ -17,3 +17,25 @@ internal sealed record TmdbMovieSummary(
     [property: JsonPropertyName("release_date")] string? ReleaseDate,
     [property: JsonPropertyName("overview")] string? Overview,
     [property: JsonPropertyName("poster_path")] string? PosterPath);
+
+/// <summary>
+/// Subset of /movie/{id}?append_to_response=credits. The append_to_response
+/// trick saves us a second round trip while still giving us director +
+/// runtime which the search endpoint doesn't carry.
+/// </summary>
+internal sealed record TmdbMovieDetail(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("original_title")] string? OriginalTitle,
+    [property: JsonPropertyName("release_date")] string? ReleaseDate,
+    [property: JsonPropertyName("runtime")] int? Runtime,
+    [property: JsonPropertyName("overview")] string? Overview,
+    [property: JsonPropertyName("poster_path")] string? PosterPath,
+    [property: JsonPropertyName("credits")] TmdbCredits? Credits);
+
+internal sealed record TmdbCredits(
+    [property: JsonPropertyName("crew")] IReadOnlyList<TmdbCrewMember>? Crew);
+
+internal sealed record TmdbCrewMember(
+    [property: JsonPropertyName("job")] string? Job,
+    [property: JsonPropertyName("name")] string? Name);

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -80,4 +80,77 @@ public class LookupEndpointsTests
         Assert.False(body!.Configured);
         Assert.Empty(body.Results);
     }
+
+    // ---------- /api/lookup/movies/by-id/{providerKey} ----------
+
+    [Fact]
+    public async Task GetMovieById_Unauthenticated_ReturnsUnauthorized()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/lookup/movies/by-id/27205");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithoutConfiguredProvider_ReturnsConfiguredFalseAndEmpty()
+    {
+        // The default test factory leaves the TMDB API key unset so the
+        // registered provider reports IsConfigured = false. The endpoint
+        // must not 404; it returns the same shape as search so the
+        // frontend can hint "set the provider key".
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-id/27205");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithConfiguredProviderAndKnownId_ReturnsOneResult()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.MovieLookupResult(
+            Provider: "tmdb",
+            ProviderKey: "27205",
+            Title: "Inception",
+            OriginalTitle: "Inception",
+            Year: 2010,
+            Director: "Christopher Nolan",
+            RuntimeMinutes: 148,
+            Description: "A heist on the subconscious.",
+            ImageUrl: "https://image.tmdb.org/t/p/w342/poster123.jpg",
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { MovieProvider = ScriptedMovieProvider.WithFoundResult(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-id/27205");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("Inception", hit.Title);
+        Assert.Equal("Christopher Nolan", hit.Director);
+        Assert.Equal(148, hit.RuntimeMinutes);
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithConfiguredProviderAndUnknownId_ReturnsConfiguredTrueAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory { MovieProvider = ScriptedMovieProvider.NotFound() };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-id/9999999");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        Assert.Empty(body.Results);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -153,4 +153,73 @@ public class LookupEndpointsTests
         Assert.True(body!.Configured);
         Assert.Empty(body.Results);
     }
+
+    // ---------- /api/lookup/movies/by-imdb-id/{imdbId} ----------
+
+    [Fact]
+    public async Task GetMovieByImdbId_Unauthenticated_ReturnsUnauthorized()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/lookup/movies/by-imdb-id/tt1375666");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMovieByImdbId_WithoutConfiguredProvider_ReturnsConfiguredFalseAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-imdb-id/tt1375666");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task GetMovieByImdbId_WithConfiguredProviderAndKnownId_ReturnsOneResult()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.MovieLookupResult(
+            Provider: "tmdb",
+            ProviderKey: "27205",
+            Title: "Inception",
+            OriginalTitle: "Inception",
+            Year: 2010,
+            Director: "Christopher Nolan",
+            RuntimeMinutes: 148,
+            Description: "A heist on the subconscious.",
+            ImageUrl: "https://image.tmdb.org/t/p/w342/poster123.jpg",
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { MovieProvider = ScriptedMovieProvider.WithImdbResult(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-imdb-id/tt1375666");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("Inception", hit.Title);
+        Assert.Equal("Christopher Nolan", hit.Director);
+    }
+
+    [Fact]
+    public async Task GetMovieByImdbId_WithConfiguredProviderAndUnknownId_ReturnsConfiguredTrueAndEmpty()
+    {
+        // ScriptedMovieProvider.NotFound() leaves ByImdbId at its default null.
+        await using var factory = new CollectifyApiFactory { MovieProvider = ScriptedMovieProvider.NotFound() };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-imdb-id/tt9999999");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        Assert.Empty(body.Results);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -1,4 +1,5 @@
 using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -13,6 +14,13 @@ namespace Collectify.Tests.Infrastructure;
 public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
 {
     private readonly SqliteConnection _connection;
+
+    /// <summary>
+    /// Optional override for tests that want a scripted movie provider. Set
+    /// via init-only property so xUnit's IClassFixture (which requires a
+    /// single public parameterless ctor) still works.
+    /// </summary>
+    public IMovieMetadataProvider? MovieProvider { get; init; }
 
     public CollectifyApiFactory()
     {
@@ -47,6 +55,17 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
             // looks remote is replaced with "/covers/{12-hex}".
             services.RemoveAll<ICoverImageStore>();
             services.AddScoped<ICoverImageStore, FakeCoverImageStore>();
+
+            // Optional override for tests that want a scripted movie
+            // provider (e.g. lookup-by-id behaviour). Without this,
+            // production's TmdbMovieProvider is registered with an
+            // unset API key, which is fine for "configured: false"
+            // assertions.
+            if (MovieProvider is not null)
+            {
+                services.RemoveAll<IMovieMetadataProvider>();
+                services.AddSingleton(MovieProvider);
+            }
         });
     }
 

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
@@ -14,12 +14,16 @@ public sealed class ScriptedMovieProvider : IMovieMetadataProvider
     public bool IsConfigured { get; init; } = true;
     public IReadOnlyList<MovieLookupResult> SearchResults { get; init; } = [];
     public MovieLookupResult? ById { get; init; }
+    public MovieLookupResult? ByImdbId { get; init; }
 
     public Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default)
         => Task.FromResult(SearchResults);
 
     public Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult(ById);
+
+    public Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default)
+        => Task.FromResult(ByImdbId);
 
     /// <summary>Configured + by-id returns the supplied result.</summary>
     public static ScriptedMovieProvider WithFoundResult(MovieLookupResult result) =>
@@ -28,4 +32,8 @@ public sealed class ScriptedMovieProvider : IMovieMetadataProvider
     /// <summary>Configured + by-id returns null (TMDB 404 equivalent).</summary>
     public static ScriptedMovieProvider NotFound() =>
         new() { ById = null };
+
+    /// <summary>Configured + by-imdb-id returns the supplied result.</summary>
+    public static ScriptedMovieProvider WithImdbResult(MovieLookupResult result) =>
+        new() { ByImdbId = result };
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
@@ -1,0 +1,31 @@
+using Collectify.Infrastructure.Lookup;
+
+namespace Collectify.Tests.Infrastructure;
+
+/// <summary>
+/// Test double for <see cref="IMovieMetadataProvider"/>. Lets each endpoint
+/// test compose a deterministic provider response (configured / not, search
+/// result list, by-id result) without hitting the real TMDB provider or its
+/// HTTP client.
+/// </summary>
+public sealed class ScriptedMovieProvider : IMovieMetadataProvider
+{
+    public string Name { get; init; } = "tmdb";
+    public bool IsConfigured { get; init; } = true;
+    public IReadOnlyList<MovieLookupResult> SearchResults { get; init; } = [];
+    public MovieLookupResult? ById { get; init; }
+
+    public Task<IReadOnlyList<MovieLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+        => Task.FromResult(SearchResults);
+
+    public Task<MovieLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+        => Task.FromResult(ById);
+
+    /// <summary>Configured + by-id returns the supplied result.</summary>
+    public static ScriptedMovieProvider WithFoundResult(MovieLookupResult result) =>
+        new() { ById = result };
+
+    /// <summary>Configured + by-id returns null (TMDB 404 equivalent).</summary>
+    public static ScriptedMovieProvider NotFound() =>
+        new() { ById = null };
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
@@ -359,6 +359,117 @@ public class TmdbMovieProviderTests : IDisposable
         Assert.Single(idHandler.RequestedUrls); // not satisfied from the search cache
     }
 
+    // ---------- GetByImdbIdAsync ----------
+
+    [Fact]
+    public async Task GetByImdbIdAsync_WithoutApiKey_ShortCircuitsToNull()
+    {
+        var handler = new RoutingStubHandler();
+        var provider = NewProvider(handler, new MetadataLookupOptions());
+
+        Assert.Null(await provider.GetByImdbIdAsync("tt1375666"));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_WithBlankImdbId_ReturnsNullWithoutCalling()
+    {
+        var handler = new RoutingStubHandler();
+        var provider = NewProvider(handler);
+
+        Assert.Null(await provider.GetByImdbIdAsync(""));
+        Assert.Null(await provider.GetByImdbIdAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_HitsFindEndpoint_WithExternalSourceImdbId()
+    {
+        var handler = new RoutingStubHandler()
+            .When("find/", """{ "movie_results": [ { "id": 27205, "title": "Inception", "release_date": "2010-07-15" } ] }""")
+            .When("movie/", DetailJson);
+        var provider = NewProvider(handler);
+
+        await provider.GetByImdbIdAsync("tt1375666");
+
+        var findUrl = handler.RequestedUrls.First(u => u.Contains("find/"));
+        Assert.Contains("find/tt1375666", findUrl);
+        Assert.Contains("external_source=imdb_id", findUrl);
+        Assert.Contains("api_key=key-xyz", findUrl);
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_ResolvesToFullDetail_ViaChainedGetById()
+    {
+        var handler = new RoutingStubHandler()
+            .When("find/", """{ "movie_results": [ { "id": 27205, "title": "Inception", "release_date": "2010-07-15" } ] }""")
+            .When("movie/", DetailJson);
+        var provider = NewProvider(handler);
+
+        var result = await provider.GetByImdbIdAsync("tt1375666");
+
+        Assert.NotNull(result);
+        Assert.Equal("27205", result!.ProviderKey);
+        Assert.Equal("Inception", result.Title);
+        Assert.Equal("Christopher Nolan", result.Director);
+        Assert.Equal(148, result.RuntimeMinutes);
+
+        // Two upstream calls: /find then /movie/27205
+        Assert.Equal(2, handler.RequestedUrls.Count);
+        Assert.Contains(handler.RequestedUrls, u => u.Contains("find/"));
+        Assert.Contains(handler.RequestedUrls, u => u.Contains("movie/27205"));
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_WithEmptyMovieResults_ReturnsNullAndDoesNotResolve()
+    {
+        var handler = new RoutingStubHandler()
+            .When("find/", """{ "movie_results": [] }""");
+        var provider = NewProvider(handler);
+
+        Assert.Null(await provider.GetByImdbIdAsync("tt9999999"));
+        Assert.Single(handler.RequestedUrls); // no chained /movie/{id} call
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new RoutingStubHandler()
+            .When("find/", """{ "movie_results": [ { "id": 27205, "title": "Inception", "release_date": "2010-07-15" } ] }""")
+            .When("movie/", DetailJson);
+        var p1 = NewProvider(handler);
+        var p2 = NewProvider(handler);
+
+        var first = await p1.GetByImdbIdAsync("tt1375666");
+        var second = await p2.GetByImdbIdAsync("tt1375666");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(first!.ProviderKey, second!.ProviderKey);
+        // Initial call: /find + /movie. Second call served from the imdb
+        // cache namespace -- no additional upstream traffic.
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    [Fact]
+    public async Task GetByImdbIdAsync_ThenGetByIdAsync_ReusesTheChainedDetailCache()
+    {
+        // After resolving an IMDB id, the subsequent TMDB-id lookup for the
+        // same movie is free -- the chained GetByIdAsync call already wrote
+        // an "id:27205" cache entry.
+        var handler = new RoutingStubHandler()
+            .When("find/", """{ "movie_results": [ { "id": 27205, "title": "Inception", "release_date": "2010-07-15" } ] }""")
+            .When("movie/", DetailJson);
+        var provider = NewProvider(handler);
+
+        await provider.GetByImdbIdAsync("tt1375666");
+        Assert.Equal(2, handler.RequestedUrls.Count);
+
+        var byId = await provider.GetByIdAsync("27205");
+        Assert.NotNull(byId);
+        Assert.Equal(2, handler.RequestedUrls.Count); // still 2 -- served from cache
+    }
+
 
     private sealed class StubHandler : HttpMessageHandler
     {
@@ -381,5 +492,51 @@ public class TmdbMovieProviderTests : IDisposable
                 Content = new StringContent(_body, Encoding.UTF8, "application/json"),
             });
         }
+    }
+
+    /// <summary>
+    /// Stub that picks a response body by matching a substring of the
+    /// request URL. Used by the IMDB-lookup tests because that flow makes
+    /// two upstream calls (/find and /movie/{id}) in a single
+    /// GetByImdbIdAsync call and needs different payloads per URL.
+    /// </summary>
+    private sealed class RoutingStubHandler : HttpMessageHandler
+    {
+        private readonly List<(string urlContains, string body, HttpStatusCode status)> _routes = new();
+        public List<string> RequestedUrls { get; } = new();
+
+        public RoutingStubHandler When(string urlContains, string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _routes.Add((urlContains, body, status));
+            return this;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.AbsoluteUri;
+            RequestedUrls.Add(url);
+            foreach (var (contains, body, status) in _routes)
+            {
+                if (url.Contains(contains, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(new HttpResponseMessage(status)
+                    {
+                        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                    });
+                }
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private TmdbMovieProvider NewProvider(RoutingStubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.themoviedb.org/3/") };
+        var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
+        var options = overrideOptions ?? new MetadataLookupOptions
+        {
+            Tmdb = new TmdbOptions { ApiKey = "key-xyz" },
+        };
+        return new TmdbMovieProvider(http, cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
@@ -192,6 +192,174 @@ public class TmdbMovieProviderTests : IDisposable
         Assert.Equal(2, handler.RequestedUrls.Count);
     }
 
+    // ---------- GetByIdAsync ----------
+
+    private const string DetailJson = """
+        {
+          "id": 27205,
+          "title": "Inception",
+          "original_title": "Inception",
+          "release_date": "2010-07-15",
+          "runtime": 148,
+          "overview": "A heist on the subconscious.",
+          "poster_path": "/poster123.jpg",
+          "credits": {
+            "crew": [
+              { "job": "Director of Photography", "name": "Wally Pfister" },
+              { "job": "Director", "name": "Christopher Nolan" },
+              { "job": "Editor", "name": "Lee Smith" }
+            ]
+          }
+        }
+        """;
+
+    [Fact]
+    public async Task GetByIdAsync_WithoutApiKey_ShortCircuitsToNull_AndDoesNotCallTmdb()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, new MetadataLookupOptions());
+
+        var result = await provider.GetByIdAsync("27205");
+
+        Assert.Null(result);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithBlankProviderKey_ReturnsNullWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler);
+
+        Assert.Null(await provider.GetByIdAsync(""));
+        Assert.Null(await provider.GetByIdAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HitsTmdbWithAppendCredits_AndApiKey()
+    {
+        var handler = new StubHandler(DetailJson);
+        var provider = NewProvider(handler);
+
+        await provider.GetByIdAsync("27205");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("movie/27205", url);
+        Assert.Contains("api_key=key-xyz", url);
+        Assert.Contains("append_to_response=credits", url);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_MapsDetailIncludingDirectorAndRuntime()
+    {
+        var provider = NewProvider(new StubHandler(DetailJson));
+
+        var result = await provider.GetByIdAsync("27205");
+
+        Assert.NotNull(result);
+        Assert.Equal("tmdb", result!.Provider);
+        Assert.Equal("27205", result.ProviderKey);
+        Assert.Equal("Inception", result.Title);
+        Assert.Equal("Inception", result.OriginalTitle);
+        Assert.Equal(2010, result.Year);
+        Assert.Equal(148, result.RuntimeMinutes);
+        Assert.Equal("Christopher Nolan", result.Director);
+        Assert.Equal("A heist on the subconscious.", result.Description);
+        Assert.Equal("https://image.tmdb.org/t/p/w342/poster123.jpg", result.ImageUrl);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithMultipleDirectors_JoinsThemWithAmpersand()
+    {
+        const string body = """
+            {
+              "id": 1,
+              "title": "X",
+              "release_date": "1999-01-01",
+              "credits": {
+                "crew": [
+                  { "job": "Director", "name": "Joel Coen" },
+                  { "job": "Director", "name": "Ethan Coen" }
+                ]
+              }
+            }
+            """;
+        var provider = NewProvider(new StubHandler(body));
+
+        var result = await provider.GetByIdAsync("1");
+
+        Assert.Equal("Joel Coen & Ethan Coen", result!.Director);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithoutDirectorInCrew_ReturnsNullDirector()
+    {
+        const string body = """
+            {
+              "id": 1,
+              "title": "X",
+              "release_date": "1999-01-01",
+              "credits": { "crew": [{ "job": "Editor", "name": "Some Editor" }] }
+            }
+            """;
+        var provider = NewProvider(new StubHandler(body));
+
+        var result = await provider.GetByIdAsync("1");
+
+        Assert.Null(result!.Director);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_With404FromTmdb_ReturnsNullWithoutCaching()
+    {
+        var handler = new StubHandler("not found", HttpStatusCode.NotFound);
+        var provider = NewProvider(handler);
+
+        Assert.Null(await provider.GetByIdAsync("999999"));
+
+        // Re-issue: should hit TMDB again rather than serve a cached null.
+        await provider.GetByIdAsync("999999");
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new StubHandler(DetailJson);
+        var p1 = NewProvider(handler);
+        var p2 = NewProvider(handler); // shared sqlite cache, fresh provider instance
+
+        var first = await p1.GetByIdAsync("27205");
+        var second = await p2.GetByIdAsync("27205");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(first!.Director, second!.Director);
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_AndSearchAsync_UseSeparateCacheNamespaces()
+    {
+        // A search for "27205" must not satisfy a by-id lookup for the
+        // movie whose TMDB id happens to be "27205".
+        var searchHandler = new StubHandler("""
+            { "results": [ { "id": 99, "title": "Different Movie", "release_date": "1990-01-01" } ] }
+            """);
+        var searchProvider = NewProvider(searchHandler);
+        await searchProvider.SearchAsync("27205");
+        Assert.Single(searchHandler.RequestedUrls);
+
+        var idHandler = new StubHandler(DetailJson);
+        var idProvider = NewProvider(idHandler);
+        var byId = await idProvider.GetByIdAsync("27205");
+
+        Assert.Equal("Inception", byId!.Title);
+        Assert.Single(idHandler.RequestedUrls); // not satisfied from the search cache
+    }
+
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly string _body;


### PR DESCRIPTION
Closes #16.

Three ways to populate movie metadata via TMDB on the form:

1. **Search by title** in `OnlineSearch` → click a result. Title / year / description / poster fill instantly; **director and runtime arrive via a follow-up `/movie/{id}` call** in the background and merge in (typically <300 ms).
2. **Paste a TMDB id** into the External IDs field → click *Fetch metadata*. Form fills with the full detail in one step.
3. **Paste an IMDB id** (the `tt…` form) → *Fetch metadata*. Server resolves IMDB → TMDB via `/find/{id}?external_source=imdb_id`, chains into the same detail call, fills the form.

All three share the same provider cache, so picking a movie via search and then pasting its TMDB id later is a free cache hit; ditto for IMDB id resolving to a TMDB id we've already fetched.

## Summary

### Lookup by TMDB id

- `IMovieMetadataProvider.GetByIdAsync`. `TmdbMovieProvider` calls `/movie/{id}?append_to_response=credits` — director + runtime in the same payload, no extra round trip.
- Cache key `"id:" + key` — separate namespace from `"search:"`.
- 404 from TMDB returns `null` and does not cache; the next call retries.
- Endpoint **`GET /api/lookup/movies/by-id/{providerKey}`**, auth-required.

### Lookup by IMDB id

- `IMovieMetadataProvider.GetByImdbIdAsync`. `TmdbMovieProvider` calls `/find/{id}?external_source=imdb_id`, takes the first `movie_results` entry, chains into `GetByIdAsync` for the full detail.
- Cache key `"imdb:" + id` — separate from the others; the chained call also writes the `"id:"` entry, so a follow-up by-TMDB-id lookup for the same movie is free.
- Endpoint **`GET /api/lookup/movies/by-imdb-id/{imdbId}`**.

### Search-pick enrichment

`OnlineSearch` (which is search-by-title) only had what `/search/movie` returns — no director, no runtime. After the synchronous patch in `importLookup`, the form now fires a follow-up `lookupMovieById(providerKey)` and merges director + runtime when it resolves. Two safeguards on the merge:

- **Functional `setM` with a `tmdbId` guard** so a newer pick (different movie) supersedes the in-flight enrichment instead of overwriting fresh fields with the previous movie's data.
- **Preserve the user's manual edits** during the in-flight window (`prev.director ?? outcome.result.director`).

Status line cycles "Loading director and runtime…" → "Populated from TMDB." so the user sees the second stage land.

### Frontend

- `services/lookup.ts` adds `lookupMovieById` and `lookupMovieByImdbId`. Both imperative (button-triggered) and return a `LookupByIdOutcome` discriminated union (`found` / `not-found` / `not-configured`).
- `MovieForm` gets two **Fetch metadata** buttons (next to TMDB ID and IMDB ID) sharing a `runLookup` helper and a single inline status line. Each button has an aria-label so role-based queries can disambiguate.
- `importLookup` (the search-pick handler) populates the synchronous fields and then fires the enrichment follow-up.

### Test infrastructure

- `ScriptedMovieProvider` — deterministic `IMovieMetadataProvider` for endpoint tests. `ById`, `ByImdbId`, `SearchResults` slots; factories `WithFoundResult`, `WithImdbResult`, `NotFound`.
- `CollectifyApiFactory.MovieProvider` — init-only property that swaps the registered provider in `ConfigureServices`.
- `RoutingStubHandler` in `TmdbMovieProviderTests` — picks a response body by URL substring (the IMDB flow makes two upstream calls in one invocation).

## Test plan

### CI

- [x] `./scripts/ci-local.sh` — server **154/154**, client **32/32**, both builds clean.
- [x] `dotnet test --filter TmdbMovieProviderTests` — 16 cases (search + by-id + by-imdb-id), incl. cache-namespace separation, chained-detail reuse, 404-no-cache.
- [x] `dotnet test --filter LookupEndpointsTests` — 8 lookup cases (auth, configured-false, found, not-found across both id types).
- [x] `npm test -- MovieForm.test` — 7 cases: TMDB Fetch button (disabled / found / not-configured / not-found), IMDB Fetch button (found / not-found), and the new **search-pick enriches director + runtime via the chained by-id call**.

### Manual

(needs `Collectify__Metadata__Tmdb__ApiKey` set, then both servers running)

- [x] **Search picks now enrich**: type "Inception" in *Search online (TMDB)*, click the suggestion. Title/Year/Description fill immediately; status line says "Loading director and runtime…"; ~300 ms later Director → "Christopher Nolan", Runtime → 148.
- [x] **TMDB ID Fetch**: paste `27205` into the **TMDB ID** field and click. Same fields populate in one step (no two-stage flicker).
- [x] **IMDB ID Fetch**: paste `tt0133093`, click. Title → "The Matrix", Director → "Lana Wachowski & Lilly Wachowski", Runtime → 136. The TMDB ID field also fills (the resolver wrote it), so a subsequent TMDB-id Fetch is a free cache hit.
- [x] Bad IDs / unconfigured key produce the expected inline messages without touching existing fields.
- [x] Quickly pick search result A, then immediately pick result B before the first enrichment lands. The form ends up showing B's director and runtime — the in-flight enrichment for A is dropped (tmdbId guard).

## Out of scope

- **Music / games equivalents** — slices 3 (MusicBrainz) and 4 (IGDB) follow the same pattern with their own provider PRs.
- **Image-only refresh** — re-fetching the poster without overwriting the rest of the form.
- **Bulk import by id list** — paste a CSV of TMDB / IMDB ids and create N movies.