### PR TITLE
feat: MusicBrainz lookup for music (Phase 2 slice 3)

### DIFF
--- a/src/client/components/AlbumForm.test.tsx
+++ b/src/client/components/AlbumForm.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AlbumForm from './AlbumForm';
+
+const mockLookupAlbumByMbid = vi.fn();
+const mockUseLookup = vi.fn().mockReturnValue({ data: undefined, isLoading: false, error: null });
+vi.mock('../services/lookup', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../services/lookup')>();
+  return {
+    ...original,
+    lookupAlbumByMbid: (id: string) => mockLookupAlbumByMbid(id),
+    useLookup: () => mockUseLookup(),
+  };
+});
+vi.mock('../services/tags', () => ({
+  useTags: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+function renderForm(onSubmit = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <AlbumForm onSubmit={onSubmit} />
+    </QueryClientProvider>,
+  );
+  return { onSubmit };
+}
+
+describe('AlbumForm — Fetch metadata by MusicBrainz Release ID', () => {
+  beforeEach(() => {
+    mockLookupAlbumByMbid.mockReset();
+    mockUseLookup.mockReset();
+    mockUseLookup.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disables the fetch button when the MBID field is empty', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /fetch metadata by musicbrainz release id/i })).toBeDisabled();
+  });
+
+  it('populates form fields when the lookup returns a found result', async () => {
+    mockLookupAlbumByMbid.mockResolvedValue({
+      kind: 'found',
+      result: {
+        provider: 'musicbrainz',
+        providerKey: 'f4e51c80-99e2-39e1-8062-c9b8e2685bdf',
+        title: 'OK Computer',
+        artistName: 'Radiohead',
+        year: 1997,
+        label: 'Parlophone',
+        description: null,
+        imageUrl: 'https://coverartarchive.org/release/f4e51c80-99e2-39e1-8062-c9b8e2685bdf/front-500',
+        genres: null,
+      },
+    });
+
+    renderForm();
+    const user = userEvent.setup();
+
+    const mbidInput = screen.getByPlaceholderText('e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf');
+    await user.type(mbidInput, 'f4e51c80-99e2-39e1-8062-c9b8e2685bdf');
+    await user.click(screen.getByRole('button', { name: /fetch metadata by musicbrainz release id/i }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('OK Computer')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('Radiohead')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1997')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Parlophone')).toBeInTheDocument();
+    expect(mockLookupAlbumByMbid).toHaveBeenCalledWith('f4e51c80-99e2-39e1-8062-c9b8e2685bdf');
+  });
+
+  it('shows a hint when the provider reports not-configured', async () => {
+    mockLookupAlbumByMbid.mockResolvedValue({ kind: 'not-configured' });
+
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf'), 'abc');
+    await user.click(screen.getByRole('button', { name: /fetch metadata by musicbrainz release id/i }));
+
+    expect(await screen.findByText(/not configured/i)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('OK Computer')).not.toBeInTheDocument();
+  });
+
+  it('shows a not-found hint when the lookup misses', async () => {
+    mockLookupAlbumByMbid.mockResolvedValue({ kind: 'not-found' });
+
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf'), '00000000-0000-0000-0000-000000000000');
+    await user.click(screen.getByRole('button', { name: /fetch metadata by musicbrainz release id/i }));
+
+    expect(
+      await screen.findByText(/no release with musicbrainz release id/i),
+    ).toBeInTheDocument();
+  });
+
+  it('picking an OnlineSearch result populates fields and stores the MBID', async () => {
+    mockUseLookup.mockReturnValue({
+      data: {
+        provider: 'musicbrainz',
+        configured: true,
+        results: [
+          {
+            provider: 'musicbrainz',
+            providerKey: 'f4e51c80-99e2-39e1-8062-c9b8e2685bdf',
+            title: 'OK Computer',
+            artistName: 'Radiohead',
+            year: 1997,
+            label: 'Parlophone',
+            description: null,
+            imageUrl: null,
+            genres: null,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderForm();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('e.g. OK Computer'), 'ok');
+    await user.click(await screen.findByText('OK Computer (1997)'));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('OK Computer')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('Radiohead')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('f4e51c80-99e2-39e1-8062-c9b8e2685bdf')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Button, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
+import OnlineSearch from './OnlineSearch';
 import { MUSIC_FORMATS, type Album } from '../services/types';
+import { lookupAlbumByMbid, type LookupByIdOutcome, type MusicLookupResult } from '../services/lookup';
 
 interface Props {
   initial?: Album;
@@ -22,10 +24,50 @@ const empty: Album = {
 
 export default function AlbumForm({ initial, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [a, setA] = useState<Album>(initial ?? empty);
+  const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setA(initial); }, [initial]);
 
   const set = <K extends keyof Album>(k: K, v: Album[K]) => setA((prev) => ({ ...prev, [k]: v }));
   const patch = (p: Partial<Album>) => setA((prev) => ({ ...prev, ...p }));
+
+  const importLookup = (r: MusicLookupResult) => {
+    patch({
+      title: r.title,
+      artistName: r.artistName,
+      year: r.year ?? null,
+      label: r.label ?? null,
+      imagePath: r.imageUrl ?? null,
+      musicBrainzReleaseId: r.provider === 'musicbrainz' ? r.providerKey : a.musicBrainzReleaseId ?? null,
+    });
+  };
+
+  const runLookup = async (
+    id: string,
+    label: string,
+    lookup: (id: string) => Promise<LookupByIdOutcome<MusicLookupResult>>,
+  ) => {
+    const trimmed = id.trim();
+    if (!trimmed) {
+      setFetchState({ status: 'idle', message: `Enter a ${label} first.` });
+      return;
+    }
+    setFetchState({ status: 'loading' });
+    try {
+      const outcome = await lookup(trimmed);
+      if (outcome.kind === 'found') {
+        importLookup(outcome.result);
+        setFetchState({ status: 'idle', message: 'Populated from MusicBrainz.' });
+      } else if (outcome.kind === 'not-configured') {
+        setFetchState({ status: 'idle', message: 'MusicBrainz lookup not configured. Set the User-Agent.' });
+      } else {
+        setFetchState({ status: 'idle', message: `No release with ${label} ${trimmed}.` });
+      }
+    } catch (err) {
+      setFetchState({ status: 'idle', message: (err as Error).message ?? 'Lookup failed.' });
+    }
+  };
+
+  const fetchByMbid = () => runLookup(a.musicBrainzReleaseId ?? '', 'MusicBrainz Release ID', lookupAlbumByMbid);
 
   return (
     <form
@@ -35,6 +77,18 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
         onSubmit({ ...a, title: a.title.trim(), artistName: a.artistName.trim() });
       }}
     >
+      <OnlineSearch
+        type="music"
+        label="Search online (MusicBrainz)"
+        placeholder="e.g. OK Computer"
+        onPick={importLookup}
+        renderItem={(r) => ({
+          primary: r.title + (r.year ? ` (${r.year})` : ''),
+          secondary: r.artistName + (r.label ? ` · ${r.label}` : ''),
+          image: r.imageUrl,
+        })}
+      />
+
       <div className="grid sm:grid-cols-2 gap-4">
         <Field label="Title">
           <Input value={a.title} onChange={(e) => set('title', e.target.value)} required />
@@ -86,13 +140,26 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
 
       <SectionHeading>External IDs</SectionHeading>
       <div className="grid sm:grid-cols-2 gap-4">
-        <ExternalIdField
-          label="MusicBrainz release ID"
-          value={a.musicBrainzReleaseId}
-          onChange={(v) => set('musicBrainzReleaseId', v)}
-          urlPrefix="https://musicbrainz.org/release/"
-          placeholder="e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf"
-        />
+        <div className="space-y-1">
+          <ExternalIdField
+            label="MusicBrainz release ID"
+            value={a.musicBrainzReleaseId}
+            onChange={(v) => set('musicBrainzReleaseId', v)}
+            urlPrefix="https://musicbrainz.org/release/"
+            placeholder="e.g. f4e51c80-99e2-39e1-8062-c9b8e2685bdf"
+          />
+          <div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={fetchByMbid}
+              disabled={fetchState.status === 'loading' || !(a.musicBrainzReleaseId ?? '').trim()}
+              aria-label="Fetch metadata by MusicBrainz Release ID"
+            >
+              {fetchState.status === 'loading' ? 'Fetching…' : 'Fetch metadata'}
+            </Button>
+          </div>
+        </div>
         <ExternalIdField
           label="Discogs ID"
           value={a.discogsId}
@@ -101,6 +168,9 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
           placeholder="e.g. 12345"
         />
       </div>
+      {fetchState.message && (
+        <div className="text-xs text-slate-400">{fetchState.message}</div>
+      )}
 
       <Field label="Notes">
         <Textarea rows={3} value={a.notes ?? ''} onChange={(e) => set('notes', e.target.value || null)} />

--- a/src/client/services/lookup.ts
+++ b/src/client/services/lookup.ts
@@ -73,27 +73,33 @@ export function useLookup<T extends MediaType>(type: T, query: string) {
   });
 }
 
-export type LookupByIdOutcome =
-  | { kind: 'found'; result: MovieLookupResult }
+/**
+ * Three-way outcome for an imperative direct-lookup call. Lets the caller
+ * branch on unconfigured vs not-found without sniffing array lengths.
+ * Generic over the result type so movie / music / game lookups share it.
+ * Defaults to MovieLookupResult so existing callers don't need updates.
+ */
+export type LookupByIdOutcome<T = MovieLookupResult> =
+  | { kind: 'found'; result: T }
   | { kind: 'not-found' }
   | { kind: 'not-configured' };
+
+async function lookupOneOf<T>(url: string): Promise<LookupByIdOutcome<T>> {
+  const response = await api<LookupResponse<T>>(url);
+  if (!response.configured) return { kind: 'not-configured' };
+  if (response.results.length === 0) return { kind: 'not-found' };
+  return { kind: 'found', result: response.results[0] };
+}
 
 /**
  * Direct lookup of a movie by its provider id (e.g. a TMDB id). Imperative
  * by design -- the user clicks a button to trigger a single fetch, no
- * debouncing or background revalidation needed. Returns a discriminated
- * union so the caller can render distinct UX for unconfigured vs unknown
- * id without sniffing array lengths.
+ * debouncing or background revalidation needed.
  */
-export async function lookupMovieById(providerKey: string): Promise<LookupByIdOutcome> {
+export async function lookupMovieById(providerKey: string): Promise<LookupByIdOutcome<MovieLookupResult>> {
   const trimmed = providerKey.trim();
   if (!trimmed) return { kind: 'not-found' };
-  const response = await api<LookupResponse<MovieLookupResult>>(
-    `/api/lookup/movies/by-id/${encodeURIComponent(trimmed)}`,
-  );
-  if (!response.configured) return { kind: 'not-configured' };
-  if (response.results.length === 0) return { kind: 'not-found' };
-  return { kind: 'found', result: response.results[0] };
+  return lookupOneOf<MovieLookupResult>(`/api/lookup/movies/by-id/${encodeURIComponent(trimmed)}`);
 }
 
 /**
@@ -101,13 +107,18 @@ export async function lookupMovieById(providerKey: string): Promise<LookupByIdOu
  * The server resolves it to a TMDB id under the hood; the response shape is
  * identical so the same caller code handles both flows.
  */
-export async function lookupMovieByImdbId(imdbId: string): Promise<LookupByIdOutcome> {
+export async function lookupMovieByImdbId(imdbId: string): Promise<LookupByIdOutcome<MovieLookupResult>> {
   const trimmed = imdbId.trim();
   if (!trimmed) return { kind: 'not-found' };
-  const response = await api<LookupResponse<MovieLookupResult>>(
-    `/api/lookup/movies/by-imdb-id/${encodeURIComponent(trimmed)}`,
-  );
-  if (!response.configured) return { kind: 'not-configured' };
-  if (response.results.length === 0) return { kind: 'not-found' };
-  return { kind: 'found', result: response.results[0] };
+  return lookupOneOf<MovieLookupResult>(`/api/lookup/movies/by-imdb-id/${encodeURIComponent(trimmed)}`);
+}
+
+/**
+ * Direct lookup of a music release by its provider id (a MusicBrainz MBID).
+ * Mirrors {@link lookupMovieById} for the music form's Fetch metadata button.
+ */
+export async function lookupAlbumByMbid(mbid: string): Promise<LookupByIdOutcome<MusicLookupResult>> {
+  const trimmed = mbid.trim();
+  if (!trimmed) return { kind: 'not-found' };
+  return lookupOneOf<MusicLookupResult>(`/api/lookup/music/by-id/${encodeURIComponent(trimmed)}`);
 }

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -77,6 +77,26 @@ public static class LookupEndpoints
             return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
         });
 
+        // Direct lookup by provider id (e.g. a MusicBrainz release MBID).
+        // Same response shape as /movies/by-id so the frontend can use
+        // one code path.
+        group.MapGet("/music/by-id/{providerKey}", async (
+            string providerKey,
+            IMusicMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(providerKey))
+                return Results.BadRequest(new { error = "Provider key is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, false, []));
+
+            var hit = await provider.GetByIdAsync(providerKey.Trim(), ct);
+            IReadOnlyList<MusicLookupResult> results = hit is null
+                ? []
+                : new[] { hit };
+            return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
+        });
+
         group.MapGet("/games", async (
             [FromQuery] string? q,
             IGameMetadataProvider provider,

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -4,6 +4,7 @@ using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Lookup.Images;
+using Collectify.Infrastructure.Lookup.MusicBrainz;
 using Collectify.Infrastructure.Lookup.Tmdb;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -66,6 +67,7 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 
 builder.Services.AddMetadataLookup(builder.Configuration);
 builder.Services.AddTmdbMovieProvider(builder.Configuration);
+builder.Services.AddMusicBrainzMusicProvider(builder.Configuration);
 
 // Cover-image cache. Bytes live in the CoverImages table alongside the
 // rest of the data so a backup of collectify.db is a complete snapshot.

--- a/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
@@ -33,6 +33,13 @@ public interface IMusicMetadataProvider
     string Name { get; }
     bool IsConfigured { get; }
     Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default);
+
+    /// <summary>
+    /// Direct lookup by the provider's identifier (e.g. a MusicBrainz
+    /// release MBID). Returns null when the provider doesn't recognise
+    /// the id.
+    /// </summary>
+    Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default);
 }
 
 public interface IGameMetadataProvider

--- a/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzMusicProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzMusicProvider.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.MusicBrainz;
+
+/// <summary>
+/// IMusicMetadataProvider backed by musicbrainz.org's web service. MB has
+/// no API key; instead it requires a contact-bearing User-Agent on every
+/// request -- the User-Agent is the rate-limit identity. If the option
+/// isn't configured, every entry point short-circuits and the lookup
+/// endpoint reports configured=false.
+///
+/// Cover art comes from the Cover Art Archive at
+/// <c>coverartarchive.org/release/{mbid}/front-500</c>. Not every release
+/// has art there; the URL is returned regardless and the browser falls
+/// back to the placeholder when the image 404s -- no extra round trip.
+/// </summary>
+public sealed class MusicBrainzMusicProvider : IMusicMetadataProvider
+{
+    public const string ProviderName = "musicbrainz";
+    public const string HttpClientName = "musicbrainz";
+    private const string CoverArtBase = "https://coverartarchive.org/release";
+
+    private readonly HttpClient _http;
+    private readonly ILookupCache _cache;
+    private readonly MetadataLookupOptions _options;
+    private readonly ILogger<MusicBrainzMusicProvider> _log;
+
+    public MusicBrainzMusicProvider(
+        HttpClient http,
+        ILookupCache cache,
+        IOptions<MetadataLookupOptions> options,
+        ILogger<MusicBrainzMusicProvider> log)
+    {
+        _http = http;
+        _cache = cache;
+        _options = options.Value;
+        _log = log;
+    }
+
+    public string Name => ProviderName;
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_options.MusicBrainz.UserAgent);
+
+    public async Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return [];
+        var trimmed = query.Trim();
+        if (trimmed.Length == 0) return [];
+
+        var cacheKey = "search:" + trimmed.ToLowerInvariant();
+        var cached = await _cache.GetAsync<List<MusicLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        MbReleaseSearchResponse? body;
+        try
+        {
+            // limit=10 keeps the dropdown manageable; fmt=json picks the
+            // structured response over the default XML.
+            var url = $"release?query={Uri.EscapeDataString(trimmed)}&fmt=json&limit=10";
+            body = await _http.GetFromJsonAsync<MbReleaseSearchResponse>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "MusicBrainz search failed for {Query}", trimmed);
+            return [];
+        }
+
+        var mapped = (body?.Releases ?? []).Select(Map).ToList();
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+
+    public async Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        if (string.IsNullOrWhiteSpace(providerKey)) return null;
+
+        var cacheKey = "id:" + providerKey;
+        var cached = await _cache.GetAsync<MusicLookupResult>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        MbRelease? release;
+        try
+        {
+            // inc=artist-credits+labels gives us artist + label inline so we
+            // don't need a second call per result.
+            var url = $"release/{Uri.EscapeDataString(providerKey)}?inc=artist-credits+labels&fmt=json";
+            release = await _http.GetFromJsonAsync<MbRelease>(url, ct);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "MusicBrainz lookup-by-id failed for {Mbid}", providerKey);
+            return null;
+        }
+
+        if (release is null) return null;
+        var mapped = Map(release);
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+
+    private MusicLookupResult Map(MbRelease r) => new(
+        Provider: ProviderName,
+        ProviderKey: r.Id,
+        Title: r.Title ?? string.Empty,
+        ArtistName: JoinArtistCredits(r.ArtistCredit),
+        Year: ParseYear(r.Date),
+        Label: r.LabelInfo?.FirstOrDefault()?.Label?.Name,
+        Description: null,
+        ImageUrl: $"{CoverArtBase}/{r.Id}/front-500",
+        Genres: null);
+
+    private static string JoinArtistCredits(IReadOnlyList<MbArtistCredit>? credits)
+    {
+        if (credits is null || credits.Count == 0) return string.Empty;
+        // MB encodes "X feat. Y" / "X & Y" by emitting Name + JoinPhrase
+        // pairs. Concatenating in order gives the canonical display string.
+        return string.Concat(credits.Select(c => (c.Name ?? string.Empty) + (c.JoinPhrase ?? string.Empty))).Trim();
+    }
+
+    private static int? ParseYear(string? date)
+    {
+        if (string.IsNullOrWhiteSpace(date) || date.Length < 4) return null;
+        return int.TryParse(date.AsSpan(0, 4), out var year) ? year : null;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzResponses.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Collectify.Infrastructure.Lookup.MusicBrainz;
+
+/// <summary>
+/// Subset of the MusicBrainz /ws/2/release search response. The API
+/// returns a lot more (annotations, packaging, status, etc.) but only
+/// the fields we map into <see cref="MusicLookupResult"/> are kept so
+/// the JSON we cache stays compact.
+///
+/// MB returns artist + label data inline on search results when you
+/// request <c>?fmt=json</c>, so a single /release call covers the form's
+/// needs -- no need for the search-then-detail enrichment dance the
+/// TMDB flow requires.
+/// </summary>
+internal sealed record MbReleaseSearchResponse(
+    [property: JsonPropertyName("releases")] IReadOnlyList<MbRelease>? Releases);
+
+internal sealed record MbRelease(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("date")] string? Date,
+    [property: JsonPropertyName("artist-credit")] IReadOnlyList<MbArtistCredit>? ArtistCredit,
+    [property: JsonPropertyName("label-info")] IReadOnlyList<MbLabelInfo>? LabelInfo);
+
+internal sealed record MbArtistCredit(
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("joinphrase")] string? JoinPhrase);
+
+internal sealed record MbLabelInfo(
+    [property: JsonPropertyName("label")] MbLabel? Label);
+
+internal sealed record MbLabel(
+    [property: JsonPropertyName("name")] string? Name);

--- a/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.MusicBrainz;
+
+public static class MusicBrainzServiceCollectionExtensions
+{
+    /// <summary>
+    /// Replace the stub <see cref="IMusicMetadataProvider"/> with a real
+    /// MusicBrainz-backed one. Call after AddMetadataLookup so the options
+    /// are bound first; the typed HttpClient picks up
+    /// MetadataLookupOptions.MusicBrainz.BaseUrl + UserAgent from the same
+    /// Collectify:Metadata config block.
+    /// </summary>
+    public static IServiceCollection AddMusicBrainzMusicProvider(this IServiceCollection services, IConfiguration _)
+    {
+        services.AddHttpClient<MusicBrainzMusicProvider>((sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MetadataLookupOptions>>().Value;
+            client.BaseAddress = new Uri(opts.MusicBrainz.BaseUrl);
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+            // MB requires a contact-bearing User-Agent on every request
+            // and returns 503 without one. If unset, IsConfigured returns
+            // false and the provider short-circuits before ever calling
+            // the wire, so an empty header here is harmless.
+            if (!string.IsNullOrWhiteSpace(opts.MusicBrainz.UserAgent))
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(opts.MusicBrainz.UserAgent);
+        });
+
+        services.RemoveAll<IMusicMetadataProvider>();
+        services.AddScoped<IMusicMetadataProvider>(sp => sp.GetRequiredService<MusicBrainzMusicProvider>());
+
+        return services;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -27,6 +27,9 @@ internal sealed class StubMusicProvider : IMusicMetadataProvider
 
     public Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<MusicLookupResult>>(Array.Empty<MusicLookupResult>());
+
+    public Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+        => Task.FromResult<MusicLookupResult?>(null);
 }
 
 internal sealed class StubGameProvider : IGameMetadataProvider

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -222,4 +222,76 @@ public class LookupEndpointsTests
         Assert.True(body!.Configured);
         Assert.Empty(body.Results);
     }
+
+    // ---------- /api/lookup/music/by-id/{providerKey} ----------
+
+    private record MusicLookupResult(
+        string Provider, string ProviderKey, string Title, string ArtistName,
+        int? Year, string? Label, string? Description, string? ImageUrl, string? Genres);
+
+    [Fact]
+    public async Task GetMusicById_Unauthenticated_ReturnsUnauthorized()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/lookup/music/by-id/f4e51c80");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMusicById_WithoutConfiguredProvider_ReturnsConfiguredFalseAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MusicLookupResult>>(
+            "/api/lookup/music/by-id/f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task GetMusicById_WithConfiguredProviderAndKnownId_ReturnsOneResult()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.MusicLookupResult(
+            Provider: "musicbrainz",
+            ProviderKey: "f4e51c80-99e2-39e1-8062-c9b8e2685bdf",
+            Title: "OK Computer",
+            ArtistName: "Radiohead",
+            Year: 1997,
+            Label: "Parlophone",
+            Description: null,
+            ImageUrl: "https://coverartarchive.org/release/f4e51c80-99e2-39e1-8062-c9b8e2685bdf/front-500",
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { MusicProvider = ScriptedMusicProvider.WithFoundResult(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MusicLookupResult>>(
+            "/api/lookup/music/by-id/f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("OK Computer", hit.Title);
+        Assert.Equal("Radiohead", hit.ArtistName);
+        Assert.Equal("Parlophone", hit.Label);
+    }
+
+    [Fact]
+    public async Task GetMusicById_WithConfiguredProviderAndUnknownId_ReturnsConfiguredTrueAndEmpty()
+    {
+        await using var factory = new CollectifyApiFactory { MusicProvider = ScriptedMusicProvider.NotFound() };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MusicLookupResult>>(
+            "/api/lookup/music/by-id/00000000-0000-0000-0000-000000000000");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        Assert.Empty(body.Results);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -22,6 +22,9 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     /// </summary>
     public IMovieMetadataProvider? MovieProvider { get; init; }
 
+    /// <summary>Optional override for tests that want a scripted music provider.</summary>
+    public IMusicMetadataProvider? MusicProvider { get; init; }
+
     public CollectifyApiFactory()
     {
         _connection = new SqliteConnection("DataSource=:memory:");
@@ -65,6 +68,11 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
             {
                 services.RemoveAll<IMovieMetadataProvider>();
                 services.AddSingleton(MovieProvider);
+            }
+            if (MusicProvider is not null)
+            {
+                services.RemoveAll<IMusicMetadataProvider>();
+                services.AddSingleton(MusicProvider);
             }
         });
     }

--- a/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Text;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.MusicBrainz;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class MusicBrainzMusicProviderTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _dbOptions;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    public MusicBrainzMusicProviderTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbOptions = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_dbOptions);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private MusicBrainzMusicProvider NewProvider(StubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://musicbrainz.org/ws/2/") };
+        var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
+        var options = overrideOptions ?? new MetadataLookupOptions
+        {
+            MusicBrainz = new MusicBrainzOptions { UserAgent = "Collectify/1.0 (test@example.com)" },
+        };
+        return new MusicBrainzMusicProvider(http, cache, Options.Create(options), NullLogger<MusicBrainzMusicProvider>.Instance);
+    }
+
+    private const string SearchJson = """
+        {
+          "releases": [
+            {
+              "id": "f4e51c80-99e2-39e1-8062-c9b8e2685bdf",
+              "title": "OK Computer",
+              "date": "1997-05-21",
+              "artist-credit": [
+                { "name": "Radiohead" }
+              ],
+              "label-info": [
+                { "label": { "name": "Parlophone" } }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private const string ReleaseJson = """
+        {
+          "id": "f4e51c80-99e2-39e1-8062-c9b8e2685bdf",
+          "title": "OK Computer",
+          "date": "1997-05-21",
+          "artist-credit": [
+            { "name": "Radiohead" }
+          ],
+          "label-info": [
+            { "label": { "name": "Parlophone" } }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task IsConfigured_ReflectsUserAgentPresence()
+    {
+        var configured = NewProvider(new StubHandler("{ \"releases\": [] }"));
+        var unconfigured = NewProvider(new StubHandler("never called"), new MetadataLookupOptions());
+
+        Assert.True(configured.IsConfigured);
+        Assert.False(unconfigured.IsConfigured);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithoutUserAgent_ShortCircuitsToEmpty_AndDoesNotCallMb()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, new MetadataLookupOptions());
+
+        var results = await provider.SearchAsync("ok computer");
+
+        Assert.Empty(results);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithBlankQuery_ReturnsEmptyWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler);
+
+        Assert.Empty(await provider.SearchAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_HitsReleaseEndpoint_WithFmtJsonAndLimit()
+    {
+        var handler = new StubHandler(SearchJson);
+        var provider = NewProvider(handler);
+
+        await provider.SearchAsync("ok computer");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("release?", url);
+        Assert.Contains("query=ok%20computer", url);
+        Assert.Contains("fmt=json", url);
+        Assert.Contains("limit=10", url);
+    }
+
+    [Fact]
+    public async Task SearchAsync_MapsRelease_IncludingArtistAndLabelAndCoverArtUrl()
+    {
+        var provider = NewProvider(new StubHandler(SearchJson));
+
+        var results = await provider.SearchAsync("ok computer");
+
+        var hit = Assert.Single(results);
+        Assert.Equal("musicbrainz", hit.Provider);
+        Assert.Equal("f4e51c80-99e2-39e1-8062-c9b8e2685bdf", hit.ProviderKey);
+        Assert.Equal("OK Computer", hit.Title);
+        Assert.Equal("Radiohead", hit.ArtistName);
+        Assert.Equal(1997, hit.Year);
+        Assert.Equal("Parlophone", hit.Label);
+        Assert.Equal(
+            "https://coverartarchive.org/release/f4e51c80-99e2-39e1-8062-c9b8e2685bdf/front-500",
+            hit.ImageUrl);
+    }
+
+    [Fact]
+    public async Task SearchAsync_JoinsCollaboratingArtistsViaJoinPhrases()
+    {
+        const string body = """
+            {
+              "releases": [
+                {
+                  "id": "abc",
+                  "title": "Watch the Throne",
+                  "date": "2011-08-08",
+                  "artist-credit": [
+                    { "name": "Jay-Z", "joinphrase": " & " },
+                    { "name": "Kanye West" }
+                  ]
+                }
+              ]
+            }
+            """;
+        var provider = NewProvider(new StubHandler(body));
+
+        var hit = (await provider.SearchAsync("watch")).Single();
+
+        Assert.Equal("Jay-Z & Kanye West", hit.ArtistName);
+    }
+
+    [Fact]
+    public async Task SearchAsync_RepeatedQuery_ServesFromCache()
+    {
+        var handler = new StubHandler(SearchJson);
+        var p1 = NewProvider(handler);
+        var p2 = NewProvider(handler); // shared sqlite cache
+
+        await p1.SearchAsync("ok computer");
+        await p2.SearchAsync("OK Computer"); // case-insensitive cache key
+
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_OnUpstreamFailure_ReturnsEmptyAndDoesNotCache()
+    {
+        var handler = new StubHandler("nope", HttpStatusCode.InternalServerError);
+        var provider = NewProvider(handler);
+
+        Assert.Empty(await provider.SearchAsync("x"));
+        await provider.SearchAsync("x"); // should retry, not serve a cached []
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HitsReleaseEndpoint_WithIncArtistAndLabels()
+    {
+        var handler = new StubHandler(ReleaseJson);
+        var provider = NewProvider(handler);
+
+        await provider.GetByIdAsync("f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("release/f4e51c80-99e2-39e1-8062-c9b8e2685bdf", url);
+        // MusicBrainz docs spell the inc list with literal '+' separators,
+        // not URL-encoded "%2B"; we match their convention.
+        Assert.Contains("inc=artist-credits+labels", url);
+        Assert.Contains("fmt=json", url);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_With404FromMb_ReturnsNullWithoutCaching()
+    {
+        var handler = new StubHandler("not found", HttpStatusCode.NotFound);
+        var provider = NewProvider(handler);
+
+        Assert.Null(await provider.GetByIdAsync("00000000-0000-0000-0000-000000000000"));
+        await provider.GetByIdAsync("00000000-0000-0000-0000-000000000000");
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new StubHandler(ReleaseJson);
+        var p1 = NewProvider(handler);
+        var p2 = NewProvider(handler);
+
+        var first = await p1.GetByIdAsync("f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+        var second = await p2.GetByIdAsync("f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal("OK Computer", second!.Title);
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_AndSearchAsync_UseSeparateCacheNamespaces()
+    {
+        // A search whose query happens to equal an MBID must not satisfy a
+        // by-id lookup for that MBID.
+        var searchHandler = new StubHandler("""
+            { "releases": [ { "id": "different", "title": "Other", "date": "1990-01-01" } ] }
+            """);
+        await NewProvider(searchHandler).SearchAsync("f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+        Assert.Single(searchHandler.RequestedUrls);
+
+        var idHandler = new StubHandler(ReleaseJson);
+        var byId = await NewProvider(idHandler).GetByIdAsync("f4e51c80-99e2-39e1-8062-c9b8e2685bdf");
+
+        Assert.Equal("OK Computer", byId!.Title);
+        Assert.Single(idHandler.RequestedUrls);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly HttpStatusCode _status;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMusicProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMusicProvider.cs
@@ -1,0 +1,29 @@
+using Collectify.Infrastructure.Lookup;
+
+namespace Collectify.Tests.Infrastructure;
+
+/// <summary>
+/// Test double for <see cref="IMusicMetadataProvider"/>. Lets each endpoint
+/// test compose a deterministic provider response (configured / not, search
+/// result list, by-id result) without hitting the real MusicBrainz provider
+/// or its HTTP client.
+/// </summary>
+public sealed class ScriptedMusicProvider : IMusicMetadataProvider
+{
+    public string Name { get; init; } = "musicbrainz";
+    public bool IsConfigured { get; init; } = true;
+    public IReadOnlyList<MusicLookupResult> SearchResults { get; init; } = [];
+    public MusicLookupResult? ById { get; init; }
+
+    public Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default)
+        => Task.FromResult(SearchResults);
+
+    public Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
+        => Task.FromResult(ById);
+
+    public static ScriptedMusicProvider WithFoundResult(MusicLookupResult result) =>
+        new() { ById = result };
+
+    public static ScriptedMusicProvider NotFound() =>
+        new() { ById = null };
+}


### PR DESCRIPTION
**Phase 2 slice 3.** Same shape as TMDB-for-movies: search-by-title in `OnlineSearch`, paste-and-fetch by MusicBrainz Release ID via a *Fetch metadata* button on `AlbumForm`. **No API key** — MusicBrainz requires a contact-bearing User-Agent on every request and that header is the rate-limit identity. Set `Collectify__Metadata__MusicBrainz__UserAgent` (e.g. `Collectify/1.0 (you@example.com)`) and the provider goes live; leave it unset and `IsConfigured = false` so the endpoint reports `configured: false` exactly like the unconfigured TMDB path.

## Summary

### Server

- `IMusicMetadataProvider.GetByIdAsync` — new method (matches the movie shape); `StubMusicProvider` returns null.
- `Lookup/MusicBrainz/MusicBrainzResponses.cs` — minimal DTOs for `/ws/2/release` search + lookup.
- `Lookup/MusicBrainz/MusicBrainzMusicProvider.cs`:
  - **Search** — `GET /release?query=…&fmt=json&limit=10`.
  - **GetByIdAsync** — `GET /release/{mbid}?inc=artist-credits+labels&fmt=json`. Inc-list keeps it to one round trip per id.
  - Cache namespaces `"search:"` and `"id:"` are separate.
  - Artist credits joined via name + `joinphrase` → "Jay-Z & Kanye West", "Kendrick Lamar feat. SZA", etc.
  - Cover URL is the [Cover Art Archive](https://coverartarchive.org/) `front-500` for the same MBID — browser falls back to placeholder when CAA 404s, no extra round trip.
  - 404 / upstream failure returns empty without poisoning the cache.
- `AddMusicBrainzMusicProvider` DI extension registers a typed `HttpClient` with the User-Agent on `DefaultRequestHeaders`, then `RemoveAll` + `AddScoped` for the music provider slot.
- `Program.cs` wires it after `AddMetadataLookup`.
- New endpoint **`GET /api/lookup/music/by-id/{providerKey}`**, same `LookupResponse<T>` shape as the movie route.

### Frontend

- `services/lookup.ts`: `LookupByIdOutcome` is now **generic** over the result type (defaulted to `MovieLookupResult` so existing callers compile unchanged). New `lookupAlbumByMbid` mirrors `lookupMovieById`.
- `AlbumForm`:
  - Drops in `<OnlineSearch type="music" label="Search online (MusicBrainz)" />` at the top.
  - Adds a *Fetch metadata* button next to the **MusicBrainz release ID** field (aria-label `Fetch metadata by MusicBrainz Release ID` so role-based queries can disambiguate).
  - `importLookup` populates title / artist / year / label / image / `musicBrainzReleaseId` from picked results.
  - Inline status line reuses the same `runLookup` pattern as `MovieForm` — "Populated from MusicBrainz." / "MusicBrainz lookup not configured. Set the User-Agent." / "No release with MusicBrainz Release ID …".

### Test infrastructure

- `ScriptedMusicProvider` — analog of `ScriptedMovieProvider`, with a `ById` slot and `WithFoundResult`/`NotFound` factories.
- `CollectifyApiFactory.MusicProvider` — init-only override mirroring `MovieProvider`.

## Test plan

### CI

- [x] `./scripts/ci-local.sh` — server **170/170**, client **37/37**, both builds clean. ~55s.
- [x] `dotnet test --filter MusicBrainzMusicProviderTests` — 12 cases:
  1. `IsConfigured` reflects User-Agent presence.
  2. Unconfigured search short-circuits (no network call).
  3. Blank query short-circuits.
  4. Search URL shape: `release?…fmt=json&limit=10` + URL-encoded query.
  5. Search maps title / artist / year / label / CAA cover URL.
  6. Multi-credit join via `joinphrase` ("Jay-Z & Kanye West").
  7. Repeated query is cache-served (case-insensitive key).
  8. Upstream 500 returns `[]` and retries on the next call.
  9. `GetByIdAsync` URL: `release/{mbid}?inc=artist-credits+labels&fmt=json` (literal `+`, per MB convention).
  10. 404 returns null without caching.
  11. Repeated by-id hits cache.
  12. Search and by-id use separate cache namespaces.
- [x] `dotnet test --filter LookupEndpointsTests` — 4 new music-by-id cases (auth / configured-false / scripted-found / scripted-not-found).
- [x] `npm test -- AlbumForm.test` — 5 cases: button disabled when MBID empty, by-MBID lookup populates fields, not-configured hint, not-found hint, `OnlineSearch` pick populates fields **and stores the MBID** in the External IDs section.

### Manual

(needs `Collectify__Metadata__MusicBrainz__UserAgent` set — e.g. `Collectify/1.0 (you@example.com)`)

- [x] Open `/music/new`. Type "OK Computer" in *Search online (MusicBrainz)*. Suggestions show with cover thumbnails. Click one → Title / Artist / Year / Label fill; MusicBrainz release ID auto-populates in the External IDs section.
- [x] Paste a known MBID (e.g. `f4e51c80-99e2-39e1-8062-c9b8e2685bdf`) into the **MusicBrainz release ID** field, click *Fetch metadata*. Same fields populate.
- [x] Paste an unknown MBID (`00000000-0000-0000-0000-000000000000`), click. Inline message reads "No release with MusicBrainz Release ID …".
- [x] Without the env var, click *Fetch metadata*. Inline message: "MusicBrainz lookup not configured. Set the User-Agent."
- [x] Save the album → cover-image cache pulls the CAA URL into `/covers/{hash}` (existing behaviour from PR #14, no music-specific work needed).

## Out of scope

- **IGDB for games** (Phase 2 slice 4) — same shape, Twitch OAuth client-credentials flow.
- **Rate limiting** — MusicBrainz's etiquette is 1 req/sec. The 30-day server cache + 60s TanStack Query stale time + 300ms debounce on `OnlineSearch` mean realistic single-user load is well under the limit. A delegating-handler-based throttle is a follow-up if multi-user (Phase 4) lands.
- **Discogs as a secondary music provider** — out of scope; we only need one provider per media type for now.
- **Search-pick enrichment** — MB returns enough on the search response that we don't need a follow-up call. The TMDB-style enrichment was specifically because `/search/movie` doesn't carry director / runtime; MB's `/release` carries everything we map.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_