### PR TITLE
feat: barcode lookup, end-to-end (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ Dockerfile                        # multi-stage: node → React, sdk → publish
 docker-compose.yml                # one service + named data volume
 ```
 
+## Barcode scanning
+
+The "Scan barcode" button on each form uses the device camera via
+`@zxing/browser` (lazy-loaded — the ~450 KB decoder bundle only ships
+when a user actually scans). Browsers gate `getUserMedia` on a **secure
+context**, so the scanner only works at:
+
+- `http://localhost` / `http://127.0.0.1` (during development), or
+- `https://…` URLs (production).
+
+Plain HTTP on a LAN address (e.g. `http://192.168.x.x:8080`) will surface
+"Camera access requires a secure context" instead of a viewfinder. To
+test from a phone, terminate TLS at a reverse proxy (Caddy, Traefik,
+Nginx + Let's Encrypt) or generate a local cert with
+[`mkcert`](https://github.com/FiloSottile/mkcert).
+
+Backend dispatch:
+
+- **Music** → MusicBrainz `release?query=barcode:CODE` (no UPC round-trip).
+- **Movies / Games** → UPCitemdb's free trial endpoint resolves the code
+  to a product title, then TMDB / IGDB run their normal title search.
+  UPCitemdb is rate-limited (~100 lookups/day on the free tier); every
+  result is cached in `LookupCache` so a re-scan is free.
+
 ## Roadmap
 
 See [GitHub issues](https://github.com/mforce/collectify/issues) for the active roadmap. Phases:

--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -40,6 +40,43 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
       imagePath: r.imageUrl ?? null,
       musicBrainzReleaseId: r.provider === 'musicbrainz' ? r.providerKey : a.musicBrainzReleaseId ?? null,
     });
+
+    // MusicBrainz search results (including barcode searches) can be
+    // sparse: title + MBID land, but artist-credit / date / label-info
+    // aren't always in the search index. The full /release/{mbid}?inc=
+    // artist-credits+labels response always has them. Chase that for any
+    // missing field; the call is cached server-side, so picking the same
+    // row twice (or pasting the same MBID later) is free.
+    if (r.provider === 'musicbrainz' && (!r.artistName || r.year == null || !r.label)) {
+      void enrichFromMb(r.providerKey);
+    }
+  };
+
+  const enrichFromMb = async (mbid: string) => {
+    setFetchState({ status: 'loading', message: 'Loading artist & label…' });
+    try {
+      const outcome = await lookupAlbumByMbid(mbid);
+      if (outcome.kind !== 'found') {
+        setFetchState({ status: 'idle' });
+        return;
+      }
+      // Functional setA with an MBID guard so a newer pick (different
+      // mbid already in state) supersedes this enrichment instead of
+      // overwriting fresh data with the previous album's. Preserves any
+      // value the user typed manually while the enrichment was in flight.
+      setA((prev) => {
+        if (prev.musicBrainzReleaseId !== mbid) return prev;
+        return {
+          ...prev,
+          artistName: prev.artistName || outcome.result.artistName,
+          year: prev.year ?? outcome.result.year ?? null,
+          label: prev.label ?? outcome.result.label ?? null,
+        };
+      });
+      setFetchState({ status: 'idle', message: 'Populated from MusicBrainz.' });
+    } catch {
+      setFetchState({ status: 'idle' });
+    }
   };
 
   const runLookup = async (

--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
+import BarcodeLookup from './BarcodeLookup';
 import { MUSIC_FORMATS, type Album } from '../services/types';
 import { lookupAlbumByMbid, type LookupByIdOutcome, type MusicLookupResult } from '../services/lookup';
 
@@ -81,6 +82,16 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
         type="music"
         label="Search online (MusicBrainz)"
         placeholder="e.g. OK Computer"
+        onPick={importLookup}
+        renderItem={(r) => ({
+          primary: r.title + (r.year ? ` (${r.year})` : ''),
+          secondary: r.artistName + (r.label ? ` · ${r.label}` : ''),
+          image: r.imageUrl,
+        })}
+      />
+
+      <BarcodeLookup
+        type="music"
         onPick={importLookup}
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),

--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -8,6 +8,12 @@ import { lookupAlbumByMbid, type LookupByIdOutcome, type MusicLookupResult } fro
 
 interface Props {
   initial?: Album;
+  /**
+   * Lookup result to seed the form with on first mount (e.g. when the
+   * user scanned a barcode on the list page). Runs the same import +
+   * enrichment chain as picking from in-form search.
+   */
+  prefillLookup?: MusicLookupResult;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (a: Album) => void;
@@ -23,7 +29,7 @@ const empty: Album = {
   tags: [],
 };
 
-export default function AlbumForm({ initial, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function AlbumForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [a, setA] = useState<Album>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setA(initial); }, [initial]);
@@ -78,6 +84,10 @@ export default function AlbumForm({ initial, submitting, submitLabel = 'Save', o
       setFetchState({ status: 'idle' });
     }
   };
+
+  // Seed once on mount when a prefill arrives via navigation state.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
 
   const runLookup = async (
     id: string,

--- a/src/client/components/BarcodeLookup.test.tsx
+++ b/src/client/components/BarcodeLookup.test.tsx
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BarcodeLookup from './BarcodeLookup';
+import type { MovieLookupResult, LookupResponse } from '../services/lookup';
+
+// ---------- @zxing/browser mock ----------
+//
+// jsdom has no MediaStream / getUserMedia, so the real ZXing reader can't run.
+// We expose a module-level `fireDetection` so tests can simulate a positive
+// scan by calling the callback ZXing would have invoked.
+
+let fireDetection: ((code: string) => void) | null = null;
+const stop = vi.fn();
+
+vi.mock('@zxing/browser', () => ({
+  BrowserMultiFormatReader: class {
+    decodeFromVideoDevice(
+      _deviceId: unknown,
+      _video: HTMLVideoElement,
+      callback: (
+        result: { getText: () => string } | null,
+        err: unknown,
+        controls: { stop: () => void },
+      ) => void,
+    ) {
+      fireDetection = (code: string) =>
+        callback({ getText: () => code }, null, { stop });
+      return Promise.resolve({ stop });
+    }
+  },
+}));
+
+// ---------- lookup mock ----------
+
+const mockLookupByBarcode = vi.fn<(type: string, code: string) => Promise<LookupResponse<MovieLookupResult>>>();
+vi.mock('../services/lookup', () => ({
+  lookupByBarcode: (type: string, code: string) => mockLookupByBarcode(type, code),
+}));
+
+const seededMovie: MovieLookupResult = {
+  provider: 'tmdb',
+  providerKey: '27205',
+  title: 'Inception',
+  originalTitle: 'Inception',
+  year: 2010,
+  director: null,
+  runtimeMinutes: null,
+  description: null,
+  imageUrl: null,
+  genres: null,
+};
+
+beforeEach(() => {
+  // Pretend getUserMedia exists so the scanner takes the happy path.
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    value: { getUserMedia: vi.fn() },
+    configurable: true,
+  });
+  fireDetection = null;
+  stop.mockClear();
+  mockLookupByBarcode.mockReset();
+});
+
+afterEach(() => {
+  // Some tests close the scanner; others rely on cleanup.
+});
+
+describe('BarcodeLookup', () => {
+  it('opens the scanner when the trigger is clicked', async () => {
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+
+    // Scanner is lazy-loaded behind Suspense, so the dialog appears
+    // asynchronously after the dynamic import resolves.
+    expect(await screen.findByRole('dialog', { name: /Scan barcode/i })).toBeInTheDocument();
+  });
+
+  it('on detection, calls lookupByBarcode with the scanned code and renders candidates', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: true,
+      results: [seededMovie],
+    });
+
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+
+    // Wait for ZXing's decodeFromVideoDevice promise to resolve so the
+    // callback is registered.
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0883929473076');
+
+    await waitFor(() =>
+      expect(mockLookupByBarcode).toHaveBeenCalledWith('movies', '0883929473076'),
+    );
+
+    expect(await screen.findByRole('button', { name: /Inception/i })).toBeInTheDocument();
+    // Scanner closed once detection fired.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('clicking a candidate fires onPick with the result and clears the list', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: true,
+      results: [seededMovie],
+    });
+
+    const onPick = vi.fn();
+    render(<BarcodeLookup type="movies" onPick={onPick} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0883929473076');
+
+    const candidate = await screen.findByRole('button', { name: /Inception/i });
+    await userEvent.click(candidate);
+
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith(seededMovie);
+    expect(screen.queryByRole('button', { name: /Inception/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the "not configured" hint when the server reports configured=false', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: false,
+      results: [],
+    });
+
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0883929473076');
+
+    expect(await screen.findByText(/not configured/i)).toBeInTheDocument();
+  });
+
+  it('shows a "no match" hint when the provider returns zero results', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: true,
+      results: [],
+    });
+
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0000000000000');
+
+    expect(await screen.findByText(/No match for 0000000000000/i)).toBeInTheDocument();
+  });
+
+  it('renders an HTTPS hint when getUserMedia is unavailable', async () => {
+    // Strip mediaDevices to simulate plain HTTP / non-secure context.
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: undefined,
+      configurable: true,
+    });
+
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+
+    expect(await screen.findByText(/secure context/i)).toBeInTheDocument();
+  });
+});

--- a/src/client/components/BarcodeLookup.test.tsx
+++ b/src/client/components/BarcodeLookup.test.tsx
@@ -15,8 +15,8 @@ const stop = vi.fn();
 
 vi.mock('@zxing/browser', () => ({
   BrowserMultiFormatReader: class {
-    decodeFromVideoDevice(
-      _deviceId: unknown,
+    decodeFromConstraints(
+      _constraints: unknown,
       _video: HTMLVideoElement,
       callback: (
         result: { getText: () => string } | null,

--- a/src/client/components/BarcodeLookup.tsx
+++ b/src/client/components/BarcodeLookup.tsx
@@ -1,0 +1,136 @@
+import { lazy, Suspense, useState, type ReactNode } from 'react';
+import { lookupByBarcode } from '../services/lookup';
+
+// Lazy-load the scanner so the ~450 KB @zxing/browser bundle only ships
+// when a user actually clicks "Scan barcode" -- keeps the initial load
+// snappy for users who never scan (most of them, on the desktop list
+// pages).
+const BarcodeScanner = lazy(() => import('./BarcodeScanner'));
+import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
+import type { MediaType } from '../services/types';
+import { Button } from './ui';
+
+type ResultMap = {
+  movies: MovieLookupResult;
+  music: MusicLookupResult;
+  games: GameLookupResult;
+};
+
+interface Props<T extends MediaType> {
+  type: T;
+  onPick: (item: ResultMap[T]) => void;
+  /** Optional row renderer; mirrors OnlineSearch so callers can share the same fn. */
+  renderItem?: (item: ResultMap[T]) => { primary: string; secondary?: ReactNode; image?: string | null };
+}
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'searching'; code: string }
+  | { kind: 'results'; code: string; results: object[]; configured: boolean }
+  | { kind: 'error'; message: string };
+
+/**
+ * "Scan barcode" affordance used at the top of each media form. Opens
+ * BarcodeScanner, calls /api/lookup/{type}/by-barcode/{code} once a code
+ * is detected, and renders the candidate list inline. Picking a candidate
+ * fires `onPick` with the same shape OnlineSearch uses, so the form's
+ * existing import flow handles both entry points uniformly.
+ *
+ * Multiple candidates are common when a UPC is shared across editions
+ * (Blu-ray + UHD + box-set), so we always render a list rather than
+ * auto-importing the first hit.
+ */
+export default function BarcodeLookup<T extends MediaType>({ type, onPick, renderItem }: Props<T>) {
+  const [scannerOpen, setScannerOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+
+  const handleDetected = async (code: string) => {
+    setScannerOpen(false);
+    setPhase({ kind: 'searching', code });
+    try {
+      const resp = await lookupByBarcode(type, code);
+      setPhase({
+        kind: 'results',
+        code,
+        results: resp.results as object[],
+        configured: resp.configured,
+      });
+    } catch (err) {
+      setPhase({ kind: 'error', message: (err as Error).message ?? 'Lookup failed.' });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button type="button" variant="secondary" onClick={() => setScannerOpen(true)}>
+        Scan barcode
+      </Button>
+
+      {scannerOpen && (
+        <Suspense fallback={null}>
+          <BarcodeScanner
+            open={scannerOpen}
+            onDetected={handleDetected}
+            onClose={() => setScannerOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {phase.kind === 'searching' && (
+        <p className="text-xs text-slate-400">Looking up {phase.code}…</p>
+      )}
+      {phase.kind === 'error' && <p className="text-xs text-rose-300">{phase.message}</p>}
+      {phase.kind === 'results' && !phase.configured && (
+        <p className="text-xs text-slate-400">
+          Online lookup not configured. Set the provider key to enable barcode matches.
+        </p>
+      )}
+      {phase.kind === 'results' && phase.configured && phase.results.length === 0 && (
+        <p className="text-xs text-slate-400">No match for {phase.code}.</p>
+      )}
+      {phase.kind === 'results' && phase.results.length > 0 && (
+        <div className="rounded-md bg-slate-900 border border-slate-700 max-h-80 overflow-auto">
+          {(phase.results as ResultMap[T][]).map((item, i) => {
+            const view = renderItem?.(item) ?? defaultView(type, item);
+            return (
+              <button
+                type="button"
+                key={`${(item as { providerKey?: string }).providerKey ?? i}`}
+                onClick={() => {
+                  onPick(item);
+                  setPhase({ kind: 'idle' });
+                }}
+                className="w-full text-left flex gap-3 items-start px-3 py-2 hover:bg-slate-800 border-b border-slate-800 last:border-b-0"
+              >
+                {view.image && (
+                  <img src={view.image} alt="" className="w-10 h-14 object-cover rounded flex-none" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-slate-100 truncate">{view.primary}</div>
+                  {view.secondary && (
+                    <div className="text-xs text-slate-400 truncate">{view.secondary}</div>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function defaultView<T extends MediaType>(
+  _type: T,
+  item: ResultMap[T],
+): { primary: string; secondary?: string; image?: string | null } {
+  const r = item as Partial<MovieLookupResult & MusicLookupResult & GameLookupResult>;
+  const primary = (r.title ?? '') + (r.year ? ` (${r.year})` : '');
+  const gameBits = [(r as GameLookupResult).developer, (r as GameLookupResult).platform]
+    .filter(Boolean)
+    .join(' · ');
+  const secondary =
+    (r as MusicLookupResult).artistName ??
+    (gameBits || r.description?.slice(0, 120) || undefined);
+  return { primary, secondary, image: r.imageUrl ?? null };
+}

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -121,11 +121,22 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
       role="dialog"
       aria-modal="true"
       aria-label="Scan barcode"
-      className="fixed inset-0 z-50 bg-black/95 flex items-center justify-center p-4 flex-col gap-4"
+      // h-dvh / w-dvw use the *visible* viewport. Mobile browsers
+      // (Samsung Internet in particular) compute 100vh against the
+      // maximum viewport, including the area behind the address bar
+      // -- with `inset-0` alone the modal centred its content below
+      // the visible fold, so the video looked off-centre. Tailwind
+      // 3.4+ provides h-dvh / w-dvw for the visual viewport.
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/95 p-4 h-dvh w-dvw"
     >
       <video
         ref={videoRef}
-        className="max-w-full max-h-[60vh] w-full sm:w-auto rounded-md bg-slate-900"
+        // Fixed-height + object-cover gives a predictable viewfinder
+        // regardless of the camera's intrinsic aspect ratio (phones
+        // commonly stream 16:9 even when held portrait). Without
+        // object-cover the stream was stretched / mis-cropped, leaving
+        // the slate-900 fallback bg visible alongside the live frame.
+        className="h-[60dvh] w-full max-w-md rounded-md bg-slate-900 object-cover"
         muted
         playsInline
       />

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -41,62 +41,58 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
 
     let cancelled = false;
     let myStream: MediaStream | null = null;
-    const reader = new BrowserMultiFormatReader();
 
-    // ZXing's IScannerControls.stop() pauses the video element and
-    // detaches its srcObject -- which is unsafe under React 18
-    // StrictMode in dev: the synthetic mount → unmount → mount cycle
-    // means the first cleanup runs while the second mount is already
-    // attaching its own stream to the same video element. Calling the
-    // first controls.stop() then nukes the second mount's srcObject and
-    // we end up with a black viewfinder.
-    //
-    // Workaround: track the MediaStream ZXing attached for *this* mount
-    // and tear down only its tracks on cleanup. The video element's
-    // srcObject is left alone -- whoever owns the active stream still
-    // owns the playback. (`facingMode: environment` prefers the rear
-    // camera on phones, falling back to the front when no rear camera
-    // is available.)
-    const startPromise = reader.decodeFromConstraints(
-      { video: { facingMode: { ideal: 'environment' } } },
-      videoRef.current!,
-      (result, _err, ctl) => {
-        if (cancelled || !result) return;
-        // First positive read wins; ctl.stop() here is fine because
-        // by that point this mount is the active one.
-        ctl.stop();
-        onDetected(result.getText());
-      },
-    );
+    // Defer ZXing setup by one tick so React 18 StrictMode's synthetic
+    // mount → unmount → mount cycle in dev never spins up two
+    // overlapping streams on the same video element. The first mount's
+    // cleanup runs synchronously and clears the timeout before any
+    // getUserMedia / srcObject / play() ever fires, so mount 2 is the
+    // only one that actually attaches a stream. (Without this, mount
+    // 1's pending video.play() gets aborted the instant mount 2 swaps
+    // srcObject, and the warning shows up as the DOMException the user
+    // saw.)
+    const handle = setTimeout(() => {
+      if (cancelled) return;
 
-    startPromise
-      .then(() => {
-        myStream = (videoRef.current?.srcObject as MediaStream) ?? null;
-        if (cancelled) {
-          myStream?.getTracks().forEach((t) => t.stop());
-          myStream = null;
-          return;
-        }
-        setStatus('streaming');
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const name = (err as { name?: string })?.name;
-        if (name === 'NotAllowedError' || name === 'SecurityError') setStatus('denied');
-        else setStatus('no-camera');
-      });
+      const reader = new BrowserMultiFormatReader();
+      reader
+        .decodeFromConstraints(
+          // Prefer the rear camera on phones; fall back to whatever's
+          // available when there's no rear cam (e.g. laptops).
+          { video: { facingMode: { ideal: 'environment' } } },
+          videoRef.current!,
+          (result, _err, ctl) => {
+            if (cancelled || !result) return;
+            ctl.stop();
+            onDetected(result.getText());
+          },
+        )
+        .then(() => {
+          // Capture the MediaStream ZXing attached so cleanup can stop
+          // just our tracks without touching the video element's
+          // srcObject (paranoid; StrictMode is already short-circuited
+          // by the timeout above).
+          myStream = (videoRef.current?.srcObject as MediaStream) ?? null;
+          if (cancelled) {
+            myStream?.getTracks().forEach((t) => t.stop());
+            myStream = null;
+            return;
+          }
+          setStatus('streaming');
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          const name = (err as { name?: string })?.name;
+          if (name === 'NotAllowedError' || name === 'SecurityError') setStatus('denied');
+          else setStatus('no-camera');
+        });
+    }, 0);
 
     return () => {
       cancelled = true;
-      // Stop just our tracks; don't touch the video element's srcObject
-      // (a sibling mount may already own it under StrictMode).
-      if (myStream) {
-        myStream.getTracks().forEach((t) => t.stop());
-        myStream = null;
-      } else {
-        // Startup hadn't resolved yet; once it does, the .then sees
-        // cancelled=true and stops our tracks.
-      }
+      clearTimeout(handle);
+      myStream?.getTracks().forEach((t) => t.stop());
+      myStream = null;
     };
   }, [open, onDetected]);
 

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { BrowserMultiFormatReader, type IScannerControls } from '@zxing/browser';
+import { BrowserMultiFormatReader } from '@zxing/browser';
 
 interface BarcodeScannerProps {
   open: boolean;
@@ -37,27 +37,35 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
       return;
     }
 
-    let cancelled = false;
-    let controls: IScannerControls | null = null;
     setStatus('requesting');
 
+    let cancelled = false;
     const reader = new BrowserMultiFormatReader();
-    reader
-      .decodeFromVideoDevice(undefined, videoRef.current!, (result, _err, ctl) => {
+
+    // Capture the start promise so cleanup can await it and stop the
+    // stream even if the IScannerControls haven't been resolved yet.
+    // Without this, React 18 StrictMode's mount-unmount-mount cycle in
+    // dev tears down the ref before ZXing finishes attaching, so the
+    // first stream keeps running and its in-flight video.play() is
+    // aborted by the second mount's srcObject swap (DOMException:
+    // "fetching … aborted at the user's request").
+    const startPromise = reader.decodeFromVideoDevice(
+      undefined,
+      videoRef.current!,
+      (result, _err, ctl) => {
         if (cancelled || !result) return;
-        // First positive read wins; stop the stream so the next scan isn't
-        // a duplicate fire while the parent component is still navigating
+        // First positive read wins; stop the stream so the next scan
+        // isn't a duplicate fire while the parent is still navigating
         // through its state transitions.
         ctl.stop();
         onDetected(result.getText());
-      })
-      .then((c) => {
-        if (cancelled) {
-          c.stop();
-          return;
-        }
-        controls = c;
-        setStatus('streaming');
+      },
+    );
+
+    startPromise
+      .then((controls) => {
+        if (cancelled) controls.stop();
+        else setStatus('streaming');
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -68,7 +76,10 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
 
     return () => {
       cancelled = true;
-      controls?.stop();
+      // Always wait for startup to finish before tearing down. If it
+      // resolved, stop the stream; if it rejected, swallow -- there's
+      // nothing to stop.
+      startPromise.then((c) => c.stop()).catch(() => {});
     };
   }, [open, onDetected]);
 
@@ -93,7 +104,6 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
       <video
         ref={videoRef}
         className="max-w-full max-h-[60vh] w-full sm:w-auto rounded-md bg-slate-900"
-        autoPlay
         muted
         playsInline
       />

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { BrowserMultiFormatReader } from '@zxing/browser';
 
 interface BarcodeScannerProps {
@@ -28,6 +28,15 @@ type Status = 'requesting' | 'streaming' | 'denied' | 'no-camera' | 'no-https';
 export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [status, setStatus] = useState<Status>('requesting');
+  const [manualCode, setManualCode] = useState('');
+
+  const submitManual = (e: FormEvent) => {
+    e.preventDefault();
+    const code = manualCode.trim();
+    if (!code) return;
+    setManualCode('');
+    onDetected(code);
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -139,6 +148,26 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
           Camera access requires a secure context (HTTPS or localhost).
         </p>
       )}
+
+      <form onSubmit={submitManual} className="flex gap-2 items-stretch w-full max-w-sm">
+        <input
+          value={manualCode}
+          onChange={(e) => setManualCode(e.target.value)}
+          inputMode="numeric"
+          autoComplete="off"
+          placeholder="Or type a barcode"
+          aria-label="Barcode"
+          className="flex-1 rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:border-indigo-400"
+        />
+        <button
+          type="submit"
+          disabled={!manualCode.trim()}
+          className="px-3 py-2 rounded-md bg-indigo-500 hover:bg-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium"
+        >
+          Look up
+        </button>
+      </form>
+
       <button
         type="button"
         onClick={onClose}

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -40,32 +40,44 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
     setStatus('requesting');
 
     let cancelled = false;
+    let myStream: MediaStream | null = null;
     const reader = new BrowserMultiFormatReader();
 
-    // Capture the start promise so cleanup can await it and stop the
-    // stream even if the IScannerControls haven't been resolved yet.
-    // Without this, React 18 StrictMode's mount-unmount-mount cycle in
-    // dev tears down the ref before ZXing finishes attaching, so the
-    // first stream keeps running and its in-flight video.play() is
-    // aborted by the second mount's srcObject swap (DOMException:
-    // "fetching … aborted at the user's request").
-    const startPromise = reader.decodeFromVideoDevice(
-      undefined,
+    // ZXing's IScannerControls.stop() pauses the video element and
+    // detaches its srcObject -- which is unsafe under React 18
+    // StrictMode in dev: the synthetic mount → unmount → mount cycle
+    // means the first cleanup runs while the second mount is already
+    // attaching its own stream to the same video element. Calling the
+    // first controls.stop() then nukes the second mount's srcObject and
+    // we end up with a black viewfinder.
+    //
+    // Workaround: track the MediaStream ZXing attached for *this* mount
+    // and tear down only its tracks on cleanup. The video element's
+    // srcObject is left alone -- whoever owns the active stream still
+    // owns the playback. (`facingMode: environment` prefers the rear
+    // camera on phones, falling back to the front when no rear camera
+    // is available.)
+    const startPromise = reader.decodeFromConstraints(
+      { video: { facingMode: { ideal: 'environment' } } },
       videoRef.current!,
       (result, _err, ctl) => {
         if (cancelled || !result) return;
-        // First positive read wins; stop the stream so the next scan
-        // isn't a duplicate fire while the parent is still navigating
-        // through its state transitions.
+        // First positive read wins; ctl.stop() here is fine because
+        // by that point this mount is the active one.
         ctl.stop();
         onDetected(result.getText());
       },
     );
 
     startPromise
-      .then((controls) => {
-        if (cancelled) controls.stop();
-        else setStatus('streaming');
+      .then(() => {
+        myStream = (videoRef.current?.srcObject as MediaStream) ?? null;
+        if (cancelled) {
+          myStream?.getTracks().forEach((t) => t.stop());
+          myStream = null;
+          return;
+        }
+        setStatus('streaming');
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -76,10 +88,15 @@ export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeSca
 
     return () => {
       cancelled = true;
-      // Always wait for startup to finish before tearing down. If it
-      // resolved, stop the stream; if it rejected, swallow -- there's
-      // nothing to stop.
-      startPromise.then((c) => c.stop()).catch(() => {});
+      // Stop just our tracks; don't touch the video element's srcObject
+      // (a sibling mount may already own it under StrictMode).
+      if (myStream) {
+        myStream.getTracks().forEach((t) => t.stop());
+        myStream = null;
+      } else {
+        // Startup hadn't resolved yet; once it does, the .then sees
+        // cancelled=true and stops our tracks.
+      }
     };
   }, [open, onDetected]);
 

--- a/src/client/components/BarcodeScanner.tsx
+++ b/src/client/components/BarcodeScanner.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { BrowserMultiFormatReader, type IScannerControls } from '@zxing/browser';
+
+interface BarcodeScannerProps {
+  open: boolean;
+  onDetected: (code: string) => void;
+  onClose: () => void;
+}
+
+type Status = 'requesting' | 'streaming' | 'denied' | 'no-camera' | 'no-https';
+
+/**
+ * Fullscreen camera viewfinder backed by @zxing/browser. While `open`, the
+ * component requests camera access, streams frames into a hidden ZXing
+ * decoder, and fires `onDetected(code)` the first time a UPC/EAN/QR
+ * barcode is recognised; the camera stream is stopped automatically.
+ *
+ * Closing happens via Escape, the Cancel button, or `open=false`. The
+ * useEffect cleanup tears down the stream so navigating away or losing
+ * focus mid-scan doesn't leak a `MediaStream` (the browser's "in use"
+ * indicator otherwise stays on for ages).
+ *
+ * `getUserMedia` is gated on a secure context. When served over plain
+ * HTTP (other than localhost) the API isn't available; we surface a
+ * dedicated message instead of the generic "no camera" copy so the
+ * setup story (mkcert / reverse proxy) is obvious.
+ */
+export default function BarcodeScanner({ open, onDetected, onClose }: BarcodeScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [status, setStatus] = useState<Status>('requesting');
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setStatus('no-https');
+      return;
+    }
+
+    let cancelled = false;
+    let controls: IScannerControls | null = null;
+    setStatus('requesting');
+
+    const reader = new BrowserMultiFormatReader();
+    reader
+      .decodeFromVideoDevice(undefined, videoRef.current!, (result, _err, ctl) => {
+        if (cancelled || !result) return;
+        // First positive read wins; stop the stream so the next scan isn't
+        // a duplicate fire while the parent component is still navigating
+        // through its state transitions.
+        ctl.stop();
+        onDetected(result.getText());
+      })
+      .then((c) => {
+        if (cancelled) {
+          c.stop();
+          return;
+        }
+        controls = c;
+        setStatus('streaming');
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const name = (err as { name?: string })?.name;
+        if (name === 'NotAllowedError' || name === 'SecurityError') setStatus('denied');
+        else setStatus('no-camera');
+      });
+
+    return () => {
+      cancelled = true;
+      controls?.stop();
+    };
+  }, [open, onDetected]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Scan barcode"
+      className="fixed inset-0 z-50 bg-black/95 flex items-center justify-center p-4 flex-col gap-4"
+    >
+      <video
+        ref={videoRef}
+        className="max-w-full max-h-[60vh] w-full sm:w-auto rounded-md bg-slate-900"
+        autoPlay
+        muted
+        playsInline
+      />
+      {status === 'requesting' && <p className="text-slate-300 text-sm">Requesting camera…</p>}
+      {status === 'streaming' && (
+        <p className="text-slate-300 text-sm">Point the camera at a UPC / EAN barcode.</p>
+      )}
+      {status === 'denied' && (
+        <p className="text-rose-300 text-sm max-w-md text-center">
+          Camera permission denied. Allow camera access in your browser settings to scan.
+        </p>
+      )}
+      {status === 'no-camera' && (
+        <p className="text-rose-300 text-sm max-w-md text-center">
+          No camera available on this device.
+        </p>
+      )}
+      {status === 'no-https' && (
+        <p className="text-rose-300 text-sm max-w-md text-center">
+          Camera access requires a secure context (HTTPS or localhost).
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={onClose}
+        className="px-4 py-2 rounded-md bg-slate-700 hover:bg-slate-600 text-white"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,8 +1,16 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useList } from '../services/collection';
 import { Button, Card, Input, StatusPill, TagChip } from './ui';
+import BarcodeLookup from './BarcodeLookup';
 import type { CollectionItemBase, MediaType } from '../services/types';
+import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
+
+type ResultMap = {
+  movies: MovieLookupResult;
+  music: MusicLookupResult;
+  games: GameLookupResult;
+};
 
 interface RenderedItem {
   primary: string;
@@ -21,14 +29,27 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
   const [query, setQuery] = useState('');
   const list = useList(type, query);
   const items = list.data ?? [];
+  const navigate = useNavigate();
+
+  // Picking a barcode candidate from the list-page scanner skips the
+  // intermediate landing -- we go straight to /{type}/new and seed the
+  // form via React Router state. AddPage reads this and hands it to the
+  // form as prefillLookup so the same enrichment chain runs as if the
+  // user had scanned from inside the form.
+  const onBarcodePick = (item: ResultMap[T]) => {
+    navigate(newPath, { state: { prefill: item } });
+  };
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold text-white">{title}</h1>
-        <Link to={newPath}>
-          <Button>+ Add</Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          <BarcodeLookup type={type} onPick={onBarcodePick} />
+          <Link to={newPath}>
+            <Button>+ Add</Button>
+          </Link>
+        </div>
       </div>
 
       <Input

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -14,6 +14,12 @@ import { lookupGameByIgdbId, type GameLookupResult, type LookupByIdOutcome } fro
 
 interface Props {
   initial?: Game;
+  /**
+   * Lookup result to seed the form with on first mount (e.g. when the
+   * user scanned a barcode on the list page). Runs the same import as
+   * picking from in-form search.
+   */
+  prefillLookup?: GameLookupResult;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (g: Game) => void;
@@ -28,7 +34,7 @@ const empty: Game = {
   tags: [],
 };
 
-export default function GameForm({ initial, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function GameForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [g, setG] = useState<Game>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setG(initial); }, [initial]);
@@ -47,6 +53,10 @@ export default function GameForm({ initial, submitting, submitLabel = 'Save', on
       igdbId: r.provider === 'igdb' ? r.providerKey : g.igdbId ?? null,
     });
   };
+
+  // Seed once on mount when a prefill arrives via navigation state.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
 
   const runLookup = async (
     id: string,

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
+import BarcodeLookup from './BarcodeLookup';
 import {
   COMPLETION_STATUSES,
   DIGITAL_STORES,
@@ -87,6 +88,16 @@ export default function GameForm({ initial, submitting, submitLabel = 'Save', on
         type="games"
         label="Search online (IGDB)"
         placeholder="e.g. The Witcher 3"
+        onPick={importLookup}
+        renderItem={(r) => ({
+          primary: r.title + (r.year ? ` (${r.year})` : ''),
+          secondary: [r.developer, r.platform].filter(Boolean).join(' · ') || r.description?.slice(0, 120),
+          image: r.imageUrl,
+        })}
+      />
+
+      <BarcodeLookup
+        type="games"
         onPick={importLookup}
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -8,6 +8,14 @@ import { lookupMovieById, lookupMovieByImdbId, type LookupByIdOutcome, type Movi
 
 interface Props {
   initial?: Movie;
+  /**
+   * Lookup result to seed the form with on first mount (e.g. when the
+   * user scanned a barcode on the list page and was redirected here).
+   * Runs the same import + enrichment chain as picking from in-form
+   * search, so missing fields like director / runtime fill in once the
+   * follow-up call lands.
+   */
+  prefillLookup?: MovieLookupResult;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (m: Movie) => void;
@@ -23,7 +31,7 @@ const empty: Movie = {
   tags: [],
 };
 
-export default function MovieForm({ initial, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function MovieForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [m, setM] = useState<Movie>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setM(initial); }, [initial]);
@@ -78,6 +86,12 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
       setFetchState({ status: 'idle' });
     }
   };
+
+  // Seed the form once on mount when the parent passed a prefill (e.g.
+  // arrived here from a list-page barcode scan). Runs the same path as
+  // picking from in-form search so the enrichment chain still kicks in.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
 
   const runLookup = async (
     id: string,

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
+import BarcodeLookup from './BarcodeLookup';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
 import { lookupMovieById, lookupMovieByImdbId, type LookupByIdOutcome, type MovieLookupResult } from '../services/lookup';
 
@@ -119,6 +120,16 @@ export default function MovieForm({ initial, submitting, submitLabel = 'Save', o
         type="movies"
         label="Search online (TMDB)"
         placeholder="e.g. Inception"
+        onPick={importLookup}
+        renderItem={(r) => ({
+          primary: r.title + (r.year ? ` (${r.year})` : ''),
+          secondary: r.description?.slice(0, 120),
+          image: r.imageUrl,
+        })}
+      />
+
+      <BarcodeLookup
+        type="movies"
         onPick={importLookup}
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -17,7 +17,17 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter
+        future={{
+          // Opt into React Router v7's behaviour now to silence the
+          // "Future Flag Warning" pair printed at startup. v7_startTransition
+          // wraps state updates in React.startTransition so route changes
+          // can be interrupted; v7_relativeSplatPath fixes how relative
+          // links resolve inside splat ("*") routes.
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <App />
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",
+        "@zxing/browser": "^0.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
@@ -2129,6 +2130,41 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.2.0.tgz",
+      "integrity": "sha512-+ORhrLva0vm6ck74NDCmvYNW3XLoAG81Mu90qfcssN1PBKJjQadxZGeMCcIk+BdJbD/zEAjjHDXOwEK1QCmRtw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.22.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.22.0.tgz",
+      "integrity": "sha512-BmInervZV7NwaZWX1LW64sZ4Lh4wxXYFZwGmj98ArPOkRXCtO9b8Gog0Xyh82dsYYGOeRxX+aAhLSq+hQ2XLZQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -4281,6 +4317,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-basic-ssl": "^1.2.0",
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
         "jsdom": "^29.1.1",
@@ -2022,6 +2023,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.2.0.tgz",
+      "integrity": "sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -24,6 +24,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-basic-ssl": "^1.2.0",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
     "jsdom": "^29.1.1",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
+    "@zxing/browser": "^0.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",

--- a/src/client/pages/AddPage.tsx
+++ b/src/client/pages/AddPage.tsx
@@ -1,32 +1,83 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useCreate } from '../services/collection';
 import type { Album, Game, MediaType, Movie } from '../services/types';
+import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
 import MovieForm from '../components/MovieForm';
 import AlbumForm from '../components/AlbumForm';
 import GameForm from '../components/GameForm';
 import { Card } from '../components/ui';
 
+interface PrefillState {
+  prefill?: MovieLookupResult | MusicLookupResult | GameLookupResult;
+}
+
+const titleByType: Record<MediaType, string> = {
+  movies: 'Add a movie',
+  music: 'Add an album',
+  games: 'Add a game',
+};
+
 export default function AddPage<T extends MediaType>({ type }: { type: T }) {
   const create = useCreate(type);
   const nav = useNavigate();
+  const location = useLocation();
+  const prefill = (location.state as PrefillState | null)?.prefill;
+
+  // Persisted-feedback so the success banner can stay on screen briefly
+  // before we redirect to the detail page.
+  const [feedback, setFeedback] = useState<
+    | { kind: 'idle' }
+    | { kind: 'success'; message: string }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' });
+
+  // Surface server / network errors as a banner instead of just a small
+  // line under the form. The mutation reports the latest error via
+  // create.error, but it's clearer to mirror it into our feedback state
+  // so the success / error visuals share one slot.
+  useEffect(() => {
+    if (create.error) {
+      setFeedback({ kind: 'error', message: (create.error as Error).message });
+    }
+  }, [create.error]);
 
   const onSuccess = (id?: number) => {
-    if (id) nav(`/${type}/${id}`);
-    else nav(`/${type}`);
-  };
-
-  const titleByType: Record<MediaType, string> = {
-    movies: 'Add a movie',
-    music: 'Add an album',
-    games: 'Add a game',
+    setFeedback({ kind: 'success', message: 'Saved! Redirecting…' });
+    // Brief hold so the user sees the banner; the page navigates after.
+    setTimeout(() => {
+      if (id) nav(`/${type}/${id}`);
+      else nav(`/${type}`);
+    }, 600);
   };
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold text-white">{titleByType[type]}</h1>
+
+      {feedback.kind === 'success' && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200"
+        >
+          {feedback.message}
+        </div>
+      )}
+      {feedback.kind === 'error' && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
+        >
+          Failed to save: {feedback.message}
+        </div>
+      )}
+
       <Card>
         {type === 'movies' && (
           <MovieForm
+            prefillLookup={prefill as MovieLookupResult | undefined}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(m) =>
@@ -38,6 +89,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
         )}
         {type === 'music' && (
           <AlbumForm
+            prefillLookup={prefill as MusicLookupResult | undefined}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(a) =>
@@ -49,6 +101,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
         )}
         {type === 'games' && (
           <GameForm
+            prefillLookup={prefill as GameLookupResult | undefined}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(g) =>
@@ -58,7 +111,6 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
             }
           />
         )}
-        {create.error && <p className="mt-3 text-sm text-rose-400">{(create.error as Error).message}</p>}
       </Card>
     </div>
   );

--- a/src/client/pages/EditPage.tsx
+++ b/src/client/pages/EditPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDelete, useItem, useUpdate } from '../services/collection';
 import type { Album, Game, MediaType, Movie } from '../services/types';
@@ -6,6 +7,12 @@ import AlbumForm from '../components/AlbumForm';
 import GameForm from '../components/GameForm';
 import { Card } from '../components/ui';
 
+const titleByType: Record<MediaType, string> = {
+  movies: 'Edit movie',
+  music: 'Edit album',
+  games: 'Edit game',
+};
+
 export default function EditPage<T extends MediaType>({ type }: { type: T }) {
   const { id } = useParams<{ id: string }>();
   const idNum = id ? Number(id) : undefined;
@@ -13,6 +20,28 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
   const update = useUpdate(type);
   const del = useDelete(type);
   const nav = useNavigate();
+
+  // Save feedback shared between success and error so the visuals
+  // mirror AddPage. Success auto-clears; error sticks until the next
+  // attempt.
+  const [feedback, setFeedback] = useState<
+    | { kind: 'idle' }
+    | { kind: 'success'; message: string }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' });
+
+  useEffect(() => {
+    if (update.error) {
+      setFeedback({ kind: 'error', message: (update.error as Error).message });
+    }
+  }, [update.error]);
+
+  // Auto-clear the success banner so it doesn't linger forever.
+  useEffect(() => {
+    if (feedback.kind !== 'success') return;
+    const t = setTimeout(() => setFeedback({ kind: 'idle' }), 2000);
+    return () => clearTimeout(t);
+  }, [feedback.kind]);
 
   if (item.isLoading) return <p className="text-slate-400">Loading…</p>;
   if (item.error || !item.data) return <p className="text-rose-400">Not found.</p>;
@@ -23,21 +52,37 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
     del.mutate(idNum, { onSuccess: () => nav(`/${type}`) });
   };
 
-  const titleByType: Record<MediaType, string> = {
-    movies: 'Edit movie',
-    music: 'Edit album',
-    games: 'Edit game',
-  };
+  const onSaved = () => setFeedback({ kind: 'success', message: 'Saved.' });
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold text-white">{titleByType[type]}</h1>
+
+      {feedback.kind === 'success' && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200"
+        >
+          {feedback.message}
+        </div>
+      )}
+      {feedback.kind === 'error' && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
+        >
+          Failed to save: {feedback.message}
+        </div>
+      )}
+
       <Card>
         {type === 'movies' && (
           <MovieForm
             initial={item.data as Movie}
             submitting={update.isPending}
-            onSubmit={(m) => update.mutate({ ...m, id: idNum! } as any)}
+            onSubmit={(m) => update.mutate({ ...m, id: idNum! } as any, { onSuccess: onSaved })}
             onDelete={onDelete}
           />
         )}
@@ -45,7 +90,7 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
           <AlbumForm
             initial={item.data as Album}
             submitting={update.isPending}
-            onSubmit={(a) => update.mutate({ ...a, id: idNum! } as any)}
+            onSubmit={(a) => update.mutate({ ...a, id: idNum! } as any, { onSuccess: onSaved })}
             onDelete={onDelete}
           />
         )}
@@ -53,11 +98,10 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
           <GameForm
             initial={item.data as Game}
             submitting={update.isPending}
-            onSubmit={(g) => update.mutate({ ...g, id: idNum! } as any)}
+            onSubmit={(g) => update.mutate({ ...g, id: idNum! } as any, { onSuccess: onSaved })}
             onDelete={onDelete}
           />
         )}
-        {update.error && <p className="mt-3 text-sm text-rose-400">{(update.error as Error).message}</p>}
       </Card>
     </div>
   );

--- a/src/client/services/lookup.ts
+++ b/src/client/services/lookup.ts
@@ -132,3 +132,19 @@ export async function lookupGameByIgdbId(igdbId: string): Promise<LookupByIdOutc
   if (!trimmed) return { kind: 'not-found' };
   return lookupOneOf<GameLookupResult>(`/api/lookup/games/by-id/${encodeURIComponent(trimmed)}`);
 }
+
+/**
+ * Barcode lookup. Returns the full LookupResponse so the caller can show
+ * "not configured" hints, render multiple candidates when the same UPC is
+ * shared across editions, and handle the empty case differently from a
+ * fetch error. Used by the upcoming BarcodeScanner / Scan tab in the add
+ * wizard; the imperative shape mirrors {@link lookupMovieById}.
+ */
+export async function lookupByBarcode<T extends MediaType>(
+  type: T,
+  barcode: string,
+): Promise<LookupResponse<ResultMap[T]>> {
+  return api<LookupResponse<ResultMap[T]>>(
+    `/api/lookup/${type}/by-barcode/${encodeURIComponent(barcode.trim())}`,
+  );
+}

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -1,9 +1,25 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import basicSsl from '@vitejs/plugin-basic-ssl';
+
+// vite.config runs in Node; declare the bits we read so we don't need
+// to add @types/node just for one env-var lookup.
+declare const process: { env: Record<string, string | undefined> };
+
+// HTTPS in dev is on by default. The barcode scanner calls
+// navigator.mediaDevices.getUserMedia, which browsers refuse to expose on
+// plain HTTP outside localhost -- testing from a phone over the LAN
+// (e.g. https://192.168.x.x:5173) needs a TLS endpoint. basicSsl mints a
+// self-signed cert per process; the phone shows a one-time "accept risk"
+// warning before the camera works. Set VITE_HTTPS=0 to opt out.
+const useHttps = process.env.VITE_HTTPS !== '0';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), ...(useHttps ? [basicSsl()] : [])],
   server: {
+    // host: true binds 0.0.0.0 so the phone can reach the dev server over
+    // the LAN. Without it Vite only listens on 127.0.0.1.
+    host: true,
     port: 5173,
     proxy: {
       '/api': 'http://localhost:5041',

--- a/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/LookupEndpoints.cs
@@ -65,6 +65,24 @@ public static class LookupEndpoints
             return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
         });
 
+        // Barcode lookup. Movies don't have a native UPC index, so the
+        // provider falls back to UPCitemdb -> product title -> its own
+        // title search. Returns up to 10 candidates so the user can pick
+        // the right edition (the UPC may be shared across box-sets).
+        group.MapGet("/movies/by-barcode/{code}", async (
+            string code,
+            IMovieMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                return Results.BadRequest(new { error = "Barcode is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, false, []));
+
+            var results = await provider.SearchByBarcodeAsync(code.Trim(), ct);
+            return Results.Ok(new LookupResponse<MovieLookupResult>(provider.Name, true, results));
+        });
+
         group.MapGet("/music", async (
             [FromQuery] string? q,
             IMusicMetadataProvider provider,
@@ -97,6 +115,23 @@ public static class LookupEndpoints
             return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
         });
 
+        // Barcode lookup. MusicBrainz indexes barcodes natively (no UPC
+        // round-trip); the response shape stays parallel to the by-id and
+        // search routes so the frontend can reuse the same decoder.
+        group.MapGet("/music/by-barcode/{code}", async (
+            string code,
+            IMusicMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                return Results.BadRequest(new { error = "Barcode is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, false, []));
+
+            var results = await provider.SearchByBarcodeAsync(code.Trim(), ct);
+            return Results.Ok(new LookupResponse<MusicLookupResult>(provider.Name, true, results));
+        });
+
         group.MapGet("/games", async (
             [FromQuery] string? q,
             IGameMetadataProvider provider,
@@ -106,6 +141,23 @@ public static class LookupEndpoints
             if (!provider.IsConfigured)
                 return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, false, []));
             var results = await provider.SearchAsync(q!.Trim(), ct);
+            return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, true, results));
+        });
+
+        // Barcode lookup for games. IGDB doesn't index barcodes; the
+        // provider dispatches to UPCitemdb first, then runs its own
+        // Apicalypse title search.
+        group.MapGet("/games/by-barcode/{code}", async (
+            string code,
+            IGameMetadataProvider provider,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                return Results.BadRequest(new { error = "Barcode is required." });
+            if (!provider.IsConfigured)
+                return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, false, []));
+
+            var results = await provider.SearchByBarcodeAsync(code.Trim(), ct);
             return Results.Ok(new LookupResponse<GameLookupResult>(provider.Name, true, results));
         });
 

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -7,6 +7,7 @@ using Collectify.Infrastructure.Lookup.Igdb;
 using Collectify.Infrastructure.Lookup.Images;
 using Collectify.Infrastructure.Lookup.MusicBrainz;
 using Collectify.Infrastructure.Lookup.Tmdb;
+using Collectify.Infrastructure.Lookup.Upc;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -67,6 +68,9 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 });
 
 builder.Services.AddMetadataLookup(builder.Configuration);
+// UPC client first: TMDB and IGDB providers depend on it for barcode
+// lookups (MusicBrainz indexes barcodes natively and skips it).
+builder.Services.AddUpcItemDbLookup(builder.Configuration);
 builder.Services.AddTmdbMovieProvider(builder.Configuration);
 builder.Services.AddMusicBrainzMusicProvider(builder.Configuration);
 builder.Services.AddIgdbGameProvider(builder.Configuration);

--- a/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/IMetadataProviders.cs
@@ -26,6 +26,15 @@ public interface IMovieMetadataProvider
     /// hood and return the same shape as <see cref="GetByIdAsync"/>.
     /// </summary>
     Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lookup by a UPC/EAN barcode. Implementations may delegate to a UPC
+    /// database (e.g. UPCitemdb) to resolve the barcode to a product title
+    /// and then run their own title search; returns up to a handful of
+    /// candidates so the user can disambiguate when the UPC is shared
+    /// across editions / boxsets.
+    /// </summary>
+    Task<IReadOnlyList<MovieLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default);
 }
 
 public interface IMusicMetadataProvider
@@ -40,6 +49,13 @@ public interface IMusicMetadataProvider
     /// the id.
     /// </summary>
     Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lookup by a UPC/EAN barcode. MusicBrainz indexes barcodes natively;
+    /// other providers may dispatch via UPCitemdb first and then run a
+    /// title search on the resolved name.
+    /// </summary>
+    Task<IReadOnlyList<MusicLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default);
 }
 
 public interface IGameMetadataProvider
@@ -53,4 +69,11 @@ public interface IGameMetadataProvider
     /// Returns null when the provider doesn't recognise the id.
     /// </summary>
     Task<GameLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lookup by a UPC/EAN barcode. IGDB doesn't index barcodes, so
+    /// implementations are expected to dispatch via UPCitemdb and then run
+    /// their own title search.
+    /// </summary>
+    Task<IReadOnlyList<GameLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default);
 }

--- a/src/server/Collectify.Infrastructure/Lookup/Igdb/IgdbGameProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Igdb/IgdbGameProvider.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using Collectify.Infrastructure.Lookup.Upc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -41,6 +42,7 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
 
     private readonly HttpClient _http;
     private readonly IIgdbAuth _auth;
+    private readonly IUpcLookupClient _upc;
     private readonly ILookupCache _cache;
     private readonly MetadataLookupOptions _options;
     private readonly ILogger<IgdbGameProvider> _log;
@@ -48,12 +50,14 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
     public IgdbGameProvider(
         HttpClient http,
         IIgdbAuth auth,
+        IUpcLookupClient upc,
         ILookupCache cache,
         IOptions<MetadataLookupOptions> options,
         ILogger<IgdbGameProvider> log)
     {
         _http = http;
         _auth = auth;
+        _upc = upc;
         _cache = cache;
         _options = options.Value;
         _log = log;
@@ -104,6 +108,28 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
         var mapped = Map(games[0]);
         await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
         return mapped;
+    }
+
+    public async Task<IReadOnlyList<GameLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return [];
+        var trimmed = (barcode ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return [];
+
+        var cacheKey = "barcode:" + trimmed;
+        var cached = await _cache.GetAsync<List<GameLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        // IGDB has no barcode field; resolve via UPCitemdb to a product
+        // title, then run our regular Apicalypse search. UPC lookups are
+        // independently cached so a second scan is free even before this
+        // wrapping cache layer kicks in.
+        var upcHit = await _upc.LookupAsync(trimmed, ct);
+        if (upcHit is null) return [];
+
+        var hits = await SearchAsync(upcHit.Title, ct);
+        await _cache.SetAsync(ProviderName, cacheKey, hits.ToList(), ct);
+        return hits;
     }
 
     private async Task<IReadOnlyList<IgdbGame>?> PostGamesAsync(string apicalypseBody, CancellationToken ct)

--- a/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
@@ -14,6 +14,7 @@ public sealed class MetadataLookupOptions
     public TmdbOptions Tmdb { get; set; } = new();
     public MusicBrainzOptions MusicBrainz { get; set; } = new();
     public IgdbOptions Igdb { get; set; } = new();
+    public UpcOptions Upc { get; set; } = new();
 }
 
 public sealed class TmdbOptions
@@ -38,4 +39,14 @@ public sealed class IgdbOptions
     public string? TwitchClientId { get; set; }
     public string? TwitchClientSecret { get; set; }
     public string BaseUrl { get; set; } = "https://api.igdb.com/v4/";
+}
+
+/// <summary>
+/// Bound from "Collectify:Metadata:Upc". The trial endpoint has no key
+/// (it's IP rate-limited), so the only configurable bit is the BaseUrl
+/// for tests / future paid-tier swaps.
+/// </summary>
+public sealed class UpcOptions
+{
+    public string BaseUrl { get; set; } = "https://api.upcitemdb.com/";
 }

--- a/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzMusicProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MusicBrainz/MusicBrainzMusicProvider.cs
@@ -105,6 +105,37 @@ public sealed class MusicBrainzMusicProvider : IMusicMetadataProvider
         return mapped;
     }
 
+    public async Task<IReadOnlyList<MusicLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return [];
+        var trimmed = (barcode ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return [];
+
+        // MB indexes barcodes natively via the "barcode:" Lucene field on
+        // the /release search index, so we can skip UPCitemdb entirely.
+        // Cache key is namespaced "barcode:" so it can't collide with
+        // free-text searches whose content happens to be a 12-digit number.
+        var cacheKey = "barcode:" + trimmed;
+        var cached = await _cache.GetAsync<List<MusicLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        MbReleaseSearchResponse? body;
+        try
+        {
+            var url = $"release?query=barcode:{Uri.EscapeDataString(trimmed)}&fmt=json&limit=10";
+            body = await _http.GetFromJsonAsync<MbReleaseSearchResponse>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "MusicBrainz barcode search failed for {Barcode}", trimmed);
+            return [];
+        }
+
+        var mapped = (body?.Releases ?? []).Select(Map).ToList();
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+
     private MusicLookupResult Map(MbRelease r) => new(
         Provider: ProviderName,
         ProviderKey: r.Id,

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -18,6 +18,9 @@ internal sealed class StubMovieProvider : IMovieMetadataProvider
 
     public Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default)
         => Task.FromResult<MovieLookupResult?>(null);
+
+    public Task<IReadOnlyList<MovieLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MovieLookupResult>>(Array.Empty<MovieLookupResult>());
 }
 
 internal sealed class StubMusicProvider : IMusicMetadataProvider
@@ -30,6 +33,9 @@ internal sealed class StubMusicProvider : IMusicMetadataProvider
 
     public Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult<MusicLookupResult?>(null);
+
+    public Task<IReadOnlyList<MusicLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MusicLookupResult>>(Array.Empty<MusicLookupResult>());
 }
 
 internal sealed class StubGameProvider : IGameMetadataProvider
@@ -42,4 +48,7 @@ internal sealed class StubGameProvider : IGameMetadataProvider
 
     public Task<GameLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult<GameLookupResult?>(null);
+
+    public Task<IReadOnlyList<GameLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<GameLookupResult>>(Array.Empty<GameLookupResult>());
 }

--- a/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Tmdb/TmdbMovieProvider.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using Collectify.Infrastructure.Lookup.Upc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -17,17 +18,20 @@ public sealed class TmdbMovieProvider : IMovieMetadataProvider
     public const string ProviderName = "tmdb";
 
     private readonly HttpClient _http;
+    private readonly IUpcLookupClient _upc;
     private readonly ILookupCache _cache;
     private readonly MetadataLookupOptions _options;
     private readonly ILogger<TmdbMovieProvider> _log;
 
     public TmdbMovieProvider(
         HttpClient http,
+        IUpcLookupClient upc,
         ILookupCache cache,
         IOptions<MetadataLookupOptions> options,
         ILogger<TmdbMovieProvider> log)
     {
         _http = http;
+        _upc = upc;
         _cache = cache;
         _options = options.Value;
         _log = log;
@@ -141,6 +145,30 @@ public sealed class TmdbMovieProvider : IMovieMetadataProvider
 
         await _cache.SetAsync(ProviderName, cacheKey, detail, ct);
         return detail;
+    }
+
+    public async Task<IReadOnlyList<MovieLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return [];
+        var trimmed = (barcode ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return [];
+
+        // Cache the final list per barcode so a second scan of the same
+        // disc is a single DB hit -- no UPC lookup, no TMDB title search.
+        var cacheKey = "barcode:" + trimmed;
+        var cached = await _cache.GetAsync<List<MovieLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        // TMDB doesn't index barcodes. Resolve the UPC via UPCitemdb to a
+        // product title, then run our regular title search. UPC client
+        // already caches its own response, so a re-scan stays under the
+        // 100/day trial quota even before this barcode-cache layer.
+        var upcHit = await _upc.LookupAsync(trimmed, ct);
+        if (upcHit is null) return [];
+
+        var hits = await SearchAsync(upcHit.Title, ct);
+        await _cache.SetAsync(ProviderName, cacheKey, hits.ToList(), ct);
+        return hits;
     }
 
     private MovieLookupResult Map(TmdbMovieSummary s) => new(

--- a/src/server/Collectify.Infrastructure/Lookup/Upc/IUpcLookupClient.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Upc/IUpcLookupClient.cs
@@ -1,0 +1,23 @@
+namespace Collectify.Infrastructure.Lookup.Upc;
+
+/// <summary>
+/// Generic UPC/EAN barcode → product summary lookup. Implementations
+/// resolve a 12-13 digit barcode to a free-form product title (and brand
+/// where available) so the per-type metadata providers can run a regular
+/// title search to enrich the result. Returning null is the "barcode not
+/// recognised" signal -- the provider should not call its title search
+/// with an empty string in that case.
+/// </summary>
+public interface IUpcLookupClient
+{
+    string Name { get; }
+
+    Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Subset of a UPC database hit that's useful for downstream title
+/// searches. Brand and manufacturer aren't always populated; the title is
+/// the only field the rest of the lookup pipeline relies on.
+/// </summary>
+public sealed record UpcLookupResult(string Title, string? Brand, string? Manufacturer);

--- a/src/server/Collectify.Infrastructure/Lookup/Upc/UpcItemDbClient.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Upc/UpcItemDbClient.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.Upc;
+
+/// <summary>
+/// IUpcLookupClient backed by upcitemdb.com's free trial endpoint
+/// (/prod/trial/lookup). No API key, but rate-limited at ~100 lookups/day,
+/// so every call is cached in LookupCache under the "upcitemdb" provider
+/// name with a "barcode:" namespace -- a re-scan of the same code is then
+/// free and a cold scan stays well under the daily quota.
+///
+/// On any non-200 / parse error / "no items" we return null so the caller
+/// can decide whether to fall back to a per-type title search.
+/// </summary>
+public sealed class UpcItemDbClient : IUpcLookupClient
+{
+    public const string ProviderName = "upcitemdb";
+    public const string HttpClientName = "upcitemdb";
+
+    private readonly HttpClient _http;
+    private readonly ILookupCache _cache;
+    private readonly MetadataLookupOptions _options;
+    private readonly ILogger<UpcItemDbClient> _log;
+
+    public UpcItemDbClient(
+        HttpClient http,
+        ILookupCache cache,
+        IOptions<MetadataLookupOptions> options,
+        ILogger<UpcItemDbClient> log)
+    {
+        _http = http;
+        _cache = cache;
+        _options = options.Value;
+        _log = log;
+    }
+
+    public string Name => ProviderName;
+
+    public async Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default)
+    {
+        var trimmed = (barcode ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return null;
+
+        var cacheKey = "barcode:" + trimmed;
+        var cached = await _cache.GetAsync<UpcLookupResult>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        UpcItemDbResponse? body;
+        try
+        {
+            var url = $"prod/trial/lookup?upc={Uri.EscapeDataString(trimmed)}";
+            body = await _http.GetFromJsonAsync<UpcItemDbResponse>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "UPCitemdb lookup failed for {Barcode}", trimmed);
+            return null;
+        }
+
+        var first = body?.Items?.FirstOrDefault(i => !string.IsNullOrWhiteSpace(i.Title));
+        if (first is null) return null;
+
+        var mapped = new UpcLookupResult(
+            Title: first.Title!,
+            Brand: string.IsNullOrWhiteSpace(first.Brand) ? null : first.Brand,
+            Manufacturer: string.IsNullOrWhiteSpace(first.Manufacturer) ? null : first.Manufacturer);
+
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Upc/UpcItemDbResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Upc/UpcItemDbResponses.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Collectify.Infrastructure.Lookup.Upc;
+
+/// <summary>
+/// Subset of the UPCitemdb /prod/trial/lookup response. Only the fields we
+/// map into <see cref="UpcLookupResult"/> are kept so the cached JSON
+/// stays small. The trial endpoint wraps results in a top-level "items"
+/// array even when there's a single match.
+/// </summary>
+internal sealed record UpcItemDbResponse(
+    [property: JsonPropertyName("code")] string? Code,
+    [property: JsonPropertyName("total")] int Total,
+    [property: JsonPropertyName("items")] IReadOnlyList<UpcItemDbItem>? Items);
+
+internal sealed record UpcItemDbItem(
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("brand")] string? Brand,
+    [property: JsonPropertyName("manufacturer")] string? Manufacturer);

--- a/src/server/Collectify.Infrastructure/Lookup/Upc/UpcServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Upc/UpcServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.Upc;
+
+public static class UpcServiceCollectionExtensions
+{
+    /// <summary>
+    /// Wires up <see cref="UpcItemDbClient"/> as the default
+    /// <see cref="IUpcLookupClient"/>. Movie / game providers receive it
+    /// through DI so they can resolve a barcode to a title hint before
+    /// running their own (already-cached) title search.
+    /// </summary>
+    public static IServiceCollection AddUpcItemDbLookup(this IServiceCollection services, IConfiguration _)
+    {
+        services.AddHttpClient<UpcItemDbClient>((sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MetadataLookupOptions>>().Value;
+            client.BaseAddress = new Uri(opts.Upc.BaseUrl);
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        });
+
+        services.RemoveAll<IUpcLookupClient>();
+        services.AddScoped<IUpcLookupClient>(sp => sp.GetRequiredService<UpcItemDbClient>());
+
+        return services;
+    }
+}

--- a/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/LookupEndpointsTests.cs
@@ -372,4 +372,114 @@ public class LookupEndpointsTests
         Assert.True(body!.Configured);
         Assert.Empty(body.Results);
     }
+
+    // ---------- /api/lookup/{type}/by-barcode/{code} ----------
+
+    [Theory]
+    [InlineData("/api/lookup/movies/by-barcode/0883929473076")]
+    [InlineData("/api/lookup/music/by-barcode/634904012623")]
+    [InlineData("/api/lookup/games/by-barcode/0883929473076")]
+    public async Task GetByBarcode_Unauthenticated_ReturnsUnauthorized(string url)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMovieByBarcode_WithoutConfiguredProvider_ReturnsConfiguredFalseAndEmpty()
+    {
+        // Default factory leaves TMDB unconfigured; the endpoint must not
+        // 404 -- it returns configured=false so the UI can hint.
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-barcode/0883929473076");
+
+        Assert.NotNull(body);
+        Assert.False(body!.Configured);
+        Assert.Empty(body.Results);
+    }
+
+    [Fact]
+    public async Task GetMovieByBarcode_WithConfiguredProvider_ReturnsScriptedResults()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.MovieLookupResult(
+            Provider: "tmdb",
+            ProviderKey: "27205",
+            Title: "Inception",
+            OriginalTitle: "Inception",
+            Year: 2010,
+            Director: null,
+            RuntimeMinutes: null,
+            Description: null,
+            ImageUrl: null,
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { MovieProvider = ScriptedMovieProvider.WithBarcodeResults(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MovieLookupResult>>(
+            "/api/lookup/movies/by-barcode/0883929473076");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("Inception", hit.Title);
+    }
+
+    [Fact]
+    public async Task GetMusicByBarcode_WithConfiguredProvider_ReturnsScriptedResults()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.MusicLookupResult(
+            Provider: "musicbrainz",
+            ProviderKey: "f4e51c80-99e2-39e1-8062-c9b8e2685bdf",
+            Title: "OK Computer",
+            ArtistName: "Radiohead",
+            Year: 1997,
+            Label: "Parlophone",
+            Description: null,
+            ImageUrl: null,
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { MusicProvider = ScriptedMusicProvider.WithBarcodeResults(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<MusicLookupResult>>(
+            "/api/lookup/music/by-barcode/634904012623");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("OK Computer", hit.Title);
+        Assert.Equal("Radiohead", hit.ArtistName);
+    }
+
+    [Fact]
+    public async Task GetGameByBarcode_WithConfiguredProvider_ReturnsScriptedResults()
+    {
+        var seeded = new Collectify.Infrastructure.Lookup.GameLookupResult(
+            Provider: "igdb",
+            ProviderKey: "1942",
+            Title: "The Witcher 3: Wild Hunt",
+            Platform: "PC",
+            Year: 2015,
+            Publisher: null,
+            Developer: "CD Projekt Red",
+            Description: null,
+            ImageUrl: null,
+            Genres: null);
+        await using var factory = new CollectifyApiFactory { GameProvider = ScriptedGameProvider.WithBarcodeResults(seeded) };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<LookupResponse<GameLookupResult>>(
+            "/api/lookup/games/by-barcode/0883929473076");
+
+        Assert.NotNull(body);
+        Assert.True(body!.Configured);
+        var hit = Assert.Single(body.Results);
+        Assert.Equal("The Witcher 3: Wild Hunt", hit.Title);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/FakeUpcClient.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/FakeUpcClient.cs
@@ -1,0 +1,26 @@
+using Collectify.Infrastructure.Lookup.Upc;
+
+namespace Collectify.Tests.Infrastructure;
+
+/// <summary>
+/// Test double for <see cref="IUpcLookupClient"/>. Returns whatever the
+/// test scripted (default: null = "barcode not recognised") and records
+/// the codes it was called with so assertions can verify dispatch.
+/// </summary>
+public sealed class FakeUpcClient : IUpcLookupClient
+{
+    public string Name => "fake-upc";
+    public List<string> RequestedBarcodes { get; } = new();
+    public UpcLookupResult? Result { get; init; }
+
+    public Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default)
+    {
+        RequestedBarcodes.Add(barcode);
+        return Task.FromResult(Result);
+    }
+
+    public static FakeUpcClient Returning(string title, string? brand = null, string? manufacturer = null) =>
+        new() { Result = new UpcLookupResult(title, brand, manufacturer) };
+
+    public static FakeUpcClient NotRecognised() => new();
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
@@ -28,7 +28,7 @@ public class IgdbGameProviderTests : IDisposable
 
     public void Dispose() => _connection.Dispose();
 
-    private IgdbGameProvider NewProvider(HttpMessageHandler handler, FakeAuth? auth = null, MetadataLookupOptions? overrideOptions = null)
+    private IgdbGameProvider NewProvider(HttpMessageHandler handler, FakeAuth? auth = null, MetadataLookupOptions? overrideOptions = null, FakeUpcClient? upc = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.igdb.com/v4/") };
         var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
@@ -36,7 +36,7 @@ public class IgdbGameProviderTests : IDisposable
         {
             Igdb = new IgdbOptions { TwitchClientId = "client", TwitchClientSecret = "secret" },
         };
-        return new IgdbGameProvider(http, auth ?? new FakeAuth("client", "tok"), cache, Options.Create(options), NullLogger<IgdbGameProvider>.Instance);
+        return new IgdbGameProvider(http, auth ?? new FakeAuth("client", "tok"), upc ?? FakeUpcClient.NotRecognised(), cache, Options.Create(options), NullLogger<IgdbGameProvider>.Instance);
     }
 
     private const string SingleGameJson = """
@@ -290,6 +290,71 @@ public class IgdbGameProviderTests : IDisposable
 
         Assert.Empty(await provider.SearchAsync("witcher"));
         Assert.Empty(handler.Requests);
+    }
+
+    // ---------- SearchByBarcodeAsync ----------
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_NotConfigured_ShortCircuitsAndDoesNotHitUpc()
+    {
+        var upc = FakeUpcClient.Returning("Hades");
+        var provider = NewProvider(new StubHandler(SingleGameJson), overrideOptions: new MetadataLookupOptions(), upc: upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0123456789012"));
+        Assert.Empty(upc.RequestedBarcodes);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_BlankBarcode_ReturnsEmptyWithoutCalling()
+    {
+        var upc = FakeUpcClient.Returning("Hades");
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("   "));
+        Assert.Empty(upc.RequestedBarcodes);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_UpcMiss_ReturnsEmptyWithoutTitleSearch()
+    {
+        var upc = FakeUpcClient.NotRecognised();
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0000000000000"));
+        Assert.Single(upc.RequestedBarcodes);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_DispatchesToIgdbTitleSearch_WithUpcTitle()
+    {
+        var upc = FakeUpcClient.Returning("The Witcher 3");
+        var handler = new StubHandler(SingleGameJson);
+        var provider = NewProvider(handler, upc: upc);
+
+        var hits = await provider.SearchByBarcodeAsync("0883929473076");
+
+        Assert.Single(hits);
+        var req = Assert.Single(handler.Requests);
+        // The title surfaced by UPC drives the Apicalypse search clause.
+        Assert.Contains("search \"The Witcher 3\";", req.Body);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_RepeatedCallsServeFromCache()
+    {
+        var upc = FakeUpcClient.Returning("The Witcher 3");
+        var handler = new StubHandler(SingleGameJson);
+        var p1 = NewProvider(handler, upc: upc);
+        var p2 = NewProvider(handler, upc: upc); // shared sqlite cache
+
+        await p1.SearchByBarcodeAsync("0883929473076");
+        await p2.SearchByBarcodeAsync("0883929473076");
+
+        Assert.Single(handler.Requests);
     }
 
     private sealed class FakeAuth : IIgdbAuth

--- a/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
@@ -247,6 +247,77 @@ public class MusicBrainzMusicProviderTests : IDisposable
         Assert.Single(idHandler.RequestedUrls);
     }
 
+    // ---------- SearchByBarcodeAsync ----------
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_NotConfigured_ReturnsEmptyWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, new MetadataLookupOptions());
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0883929473076"));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_BlankBarcode_ReturnsEmptyWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_HitsReleaseEndpointWithBarcodeQuery()
+    {
+        var handler = new StubHandler(SearchJson);
+        var provider = NewProvider(handler);
+
+        await provider.SearchByBarcodeAsync("634904012623");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("release?", url);
+        // MB's Lucene "barcode:" field uses a literal colon -- it's a
+        // valid query-string sub-delim, no percent-escape needed.
+        Assert.Contains("query=barcode:634904012623", url);
+        Assert.Contains("fmt=json", url);
+        Assert.Contains("limit=10", url);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new StubHandler(SearchJson);
+        var p1 = NewProvider(handler);
+        var p2 = NewProvider(handler);
+
+        await p1.SearchByBarcodeAsync("634904012623");
+        await p2.SearchByBarcodeAsync("634904012623");
+
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_AndSearchAsync_UseSeparateCacheNamespaces()
+    {
+        // A free-text search whose query happens to be a 12-digit number
+        // must not satisfy a barcode lookup for the same digits.
+        var searchHandler = new StubHandler("""
+            { "releases": [ { "id": "different", "title": "Different", "date": "2000-01-01" } ] }
+            """);
+        await NewProvider(searchHandler).SearchAsync("634904012623");
+        Assert.Single(searchHandler.RequestedUrls);
+
+        var barcodeHandler = new StubHandler(SearchJson);
+        var barcodeHits = await NewProvider(barcodeHandler).SearchByBarcodeAsync("634904012623");
+
+        Assert.Single(barcodeHits);
+        Assert.Equal("OK Computer", barcodeHits[0].Title);
+        Assert.Single(barcodeHandler.RequestedUrls);
+    }
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly string _body;

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedGameProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedGameProvider.cs
@@ -12,6 +12,7 @@ public sealed class ScriptedGameProvider : IGameMetadataProvider
     public string Name { get; init; } = "igdb";
     public bool IsConfigured { get; init; } = true;
     public IReadOnlyList<GameLookupResult> SearchResults { get; init; } = [];
+    public IReadOnlyList<GameLookupResult> ByBarcode { get; init; } = [];
     public GameLookupResult? ById { get; init; }
 
     public Task<IReadOnlyList<GameLookupResult>> SearchAsync(string query, CancellationToken ct = default)
@@ -20,9 +21,15 @@ public sealed class ScriptedGameProvider : IGameMetadataProvider
     public Task<GameLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult(ById);
 
+    public Task<IReadOnlyList<GameLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult(ByBarcode);
+
     public static ScriptedGameProvider WithFoundResult(GameLookupResult result) =>
         new() { ById = result };
 
     public static ScriptedGameProvider NotFound() =>
         new() { ById = null };
+
+    public static ScriptedGameProvider WithBarcodeResults(params GameLookupResult[] results) =>
+        new() { ByBarcode = results };
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMovieProvider.cs
@@ -13,6 +13,7 @@ public sealed class ScriptedMovieProvider : IMovieMetadataProvider
     public string Name { get; init; } = "tmdb";
     public bool IsConfigured { get; init; } = true;
     public IReadOnlyList<MovieLookupResult> SearchResults { get; init; } = [];
+    public IReadOnlyList<MovieLookupResult> ByBarcode { get; init; } = [];
     public MovieLookupResult? ById { get; init; }
     public MovieLookupResult? ByImdbId { get; init; }
 
@@ -25,6 +26,9 @@ public sealed class ScriptedMovieProvider : IMovieMetadataProvider
     public Task<MovieLookupResult?> GetByImdbIdAsync(string imdbId, CancellationToken ct = default)
         => Task.FromResult(ByImdbId);
 
+    public Task<IReadOnlyList<MovieLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult(ByBarcode);
+
     /// <summary>Configured + by-id returns the supplied result.</summary>
     public static ScriptedMovieProvider WithFoundResult(MovieLookupResult result) =>
         new() { ById = result };
@@ -36,4 +40,8 @@ public sealed class ScriptedMovieProvider : IMovieMetadataProvider
     /// <summary>Configured + by-imdb-id returns the supplied result.</summary>
     public static ScriptedMovieProvider WithImdbResult(MovieLookupResult result) =>
         new() { ByImdbId = result };
+
+    /// <summary>Configured + by-barcode returns the supplied results.</summary>
+    public static ScriptedMovieProvider WithBarcodeResults(params MovieLookupResult[] results) =>
+        new() { ByBarcode = results };
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMusicProvider.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/ScriptedMusicProvider.cs
@@ -13,6 +13,7 @@ public sealed class ScriptedMusicProvider : IMusicMetadataProvider
     public string Name { get; init; } = "musicbrainz";
     public bool IsConfigured { get; init; } = true;
     public IReadOnlyList<MusicLookupResult> SearchResults { get; init; } = [];
+    public IReadOnlyList<MusicLookupResult> ByBarcode { get; init; } = [];
     public MusicLookupResult? ById { get; init; }
 
     public Task<IReadOnlyList<MusicLookupResult>> SearchAsync(string query, CancellationToken ct = default)
@@ -21,9 +22,15 @@ public sealed class ScriptedMusicProvider : IMusicMetadataProvider
     public Task<MusicLookupResult?> GetByIdAsync(string providerKey, CancellationToken ct = default)
         => Task.FromResult(ById);
 
+    public Task<IReadOnlyList<MusicLookupResult>> SearchByBarcodeAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult(ByBarcode);
+
     public static ScriptedMusicProvider WithFoundResult(MusicLookupResult result) =>
         new() { ById = result };
 
     public static ScriptedMusicProvider NotFound() =>
         new() { ById = null };
+
+    public static ScriptedMusicProvider WithBarcodeResults(params MusicLookupResult[] results) =>
+        new() { ByBarcode = results };
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
@@ -28,7 +28,7 @@ public class TmdbMovieProviderTests : IDisposable
 
     public void Dispose() => _connection.Dispose();
 
-    private TmdbMovieProvider NewProvider(StubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    private TmdbMovieProvider NewProvider(StubHandler handler, MetadataLookupOptions? overrideOptions = null, FakeUpcClient? upc = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.themoviedb.org/3/") };
         var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
@@ -36,8 +36,26 @@ public class TmdbMovieProviderTests : IDisposable
         {
             Tmdb = new TmdbOptions { ApiKey = "key-xyz" },
         };
-        return new TmdbMovieProvider(http, cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
+        return new TmdbMovieProvider(http, upc ?? FakeUpcClient.NotRecognised(), cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
     }
+
+    // Reused by the barcode tests below; the search-by-title pipeline that
+    // backs SearchByBarcodeAsync hits /search/movie with whatever title the
+    // UPC client surfaces, so a single stub body is enough.
+    private const string BarcodeSearchJson = """
+        {
+          "results": [
+            {
+              "id": 27205,
+              "title": "Inception",
+              "original_title": "Inception",
+              "release_date": "2010-07-15",
+              "overview": "A heist on the subconscious.",
+              "poster_path": "/poster123.jpg"
+            }
+          ]
+        }
+        """;
 
     [Fact]
     public async Task IsConfigured_ReflectsApiKeyPresence()
@@ -470,6 +488,76 @@ public class TmdbMovieProviderTests : IDisposable
         Assert.Equal(2, handler.RequestedUrls.Count); // still 2 -- served from cache
     }
 
+    // ---------- SearchByBarcodeAsync ----------
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_NotConfigured_ShortCircuitsAndDoesNotHitUpc()
+    {
+        var upc = FakeUpcClient.Returning("Inception");
+        var provider = NewProvider(new StubHandler(BarcodeSearchJson), new MetadataLookupOptions(), upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0883929473076"));
+        Assert.Empty(upc.RequestedBarcodes);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_BlankBarcode_ReturnsEmptyWithoutCalling()
+    {
+        var upc = FakeUpcClient.Returning("Inception");
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("  "));
+        Assert.Empty(upc.RequestedBarcodes);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_UpcMiss_ReturnsEmptyWithoutTitleSearch()
+    {
+        // UPCitemdb didn't recognise the code; we mustn't fall back to
+        // searching TMDB with an empty string.
+        var upc = FakeUpcClient.NotRecognised();
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0000000000000"));
+        Assert.Single(upc.RequestedBarcodes);
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_DispatchesToTmdbTitleSearch_WithUpcTitle()
+    {
+        var upc = FakeUpcClient.Returning("Inception");
+        var handler = new StubHandler(BarcodeSearchJson);
+        var provider = NewProvider(handler, upc: upc);
+
+        var hits = await provider.SearchByBarcodeAsync("0883929473076");
+
+        Assert.Single(hits);
+        Assert.Equal("Inception", hits[0].Title);
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("search/movie", url);
+        Assert.Contains("query=Inception", url);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_RepeatedCallsServeFromCache()
+    {
+        var upc = FakeUpcClient.Returning("Inception");
+        var handler = new StubHandler(BarcodeSearchJson);
+        var p1 = NewProvider(handler, upc: upc);
+        var p2 = NewProvider(handler, upc: upc); // shared sqlite cache
+
+        await p1.SearchByBarcodeAsync("0883929473076");
+        await p2.SearchByBarcodeAsync("0883929473076");
+
+        // Single TMDB hit across both invocations -- the second call is
+        // satisfied entirely by the barcode-namespaced cache entry.
+        Assert.Single(handler.RequestedUrls);
+    }
+
 
     private sealed class StubHandler : HttpMessageHandler
     {
@@ -529,7 +617,7 @@ public class TmdbMovieProviderTests : IDisposable
         }
     }
 
-    private TmdbMovieProvider NewProvider(RoutingStubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    private TmdbMovieProvider NewProvider(RoutingStubHandler handler, MetadataLookupOptions? overrideOptions = null, FakeUpcClient? upc = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.themoviedb.org/3/") };
         var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
@@ -537,6 +625,6 @@ public class TmdbMovieProviderTests : IDisposable
         {
             Tmdb = new TmdbOptions { ApiKey = "key-xyz" },
         };
-        return new TmdbMovieProvider(http, cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
+        return new TmdbMovieProvider(http, upc ?? FakeUpcClient.NotRecognised(), cache, Options.Create(options), NullLogger<TmdbMovieProvider>.Instance);
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/UpcItemDbClientTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/UpcItemDbClientTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Text;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.Upc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class UpcItemDbClientTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _dbOptions;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    public UpcItemDbClientTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbOptions = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_dbOptions);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private UpcItemDbClient NewClient(StubHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.upcitemdb.com/") };
+        var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
+        var options = new MetadataLookupOptions();
+        return new UpcItemDbClient(http, cache, Options.Create(options), NullLogger<UpcItemDbClient>.Instance);
+    }
+
+    private const string MatchJson = """
+        {
+          "code": "OK",
+          "total": 1,
+          "items": [
+            {
+              "ean": "0883929473076",
+              "title": "Inception (Blu-ray)",
+              "brand": "Warner Bros",
+              "manufacturer": "Warner Home Video"
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task LookupAsync_BlankBarcode_ReturnsNullWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var client = NewClient(handler);
+
+        Assert.Null(await client.LookupAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task LookupAsync_HitsTrialEndpointWithUpcParam()
+    {
+        var handler = new StubHandler(MatchJson);
+        var client = NewClient(handler);
+
+        await client.LookupAsync("0883929473076");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("prod/trial/lookup", url);
+        Assert.Contains("upc=0883929473076", url);
+    }
+
+    [Fact]
+    public async Task LookupAsync_MapsTitleAndBrand()
+    {
+        var hit = await NewClient(new StubHandler(MatchJson)).LookupAsync("0883929473076");
+
+        Assert.NotNull(hit);
+        Assert.Equal("Inception (Blu-ray)", hit!.Title);
+        Assert.Equal("Warner Bros", hit.Brand);
+        Assert.Equal("Warner Home Video", hit.Manufacturer);
+    }
+
+    [Fact]
+    public async Task LookupAsync_TreatsBlankTitleAsNotRecognised()
+    {
+        const string body = """
+            { "code": "OK", "total": 1, "items": [ { "title": "" } ] }
+            """;
+        Assert.Null(await NewClient(new StubHandler(body)).LookupAsync("0000"));
+    }
+
+    [Fact]
+    public async Task LookupAsync_OnEmptyItems_ReturnsNull()
+    {
+        const string body = """{ "code": "OK", "total": 0, "items": [] }""";
+        Assert.Null(await NewClient(new StubHandler(body)).LookupAsync("0000"));
+    }
+
+    [Fact]
+    public async Task LookupAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new StubHandler(MatchJson);
+        var c1 = NewClient(handler);
+        var c2 = NewClient(handler); // shared sqlite cache
+
+        var first = await c1.LookupAsync("0883929473076");
+        var second = await c2.LookupAsync("0883929473076");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal("Inception (Blu-ray)", second!.Title);
+        // Single network call across both invocations -- the trial endpoint
+        // is rate-limited, so the cache earning its keep here matters.
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task LookupAsync_OnUpstreamFailure_ReturnsNullAndDoesNotCache()
+    {
+        var handler = new StubHandler("nope", HttpStatusCode.InternalServerError);
+        var client = NewClient(handler);
+
+        Assert.Null(await client.LookupAsync("0883929473076"));
+        await client.LookupAsync("0883929473076"); // should retry, not serve cached null
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly HttpStatusCode _status;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
Phase 3 in one PR — barcode lookup endpoints **and** the camera UI that drives them. Closes the last "advanced internet lookup" gap on the original plan.

## Summary

### Backend (3a)

- **`Lookup/Upc/UpcItemDbClient`** — new `IUpcLookupClient` backed by upcitemdb.com's free `/prod/trial/lookup` endpoint. No key required (IP rate-limited at ~100/day), so every result is cached in `LookupCache` under `upcitemdb` / `barcode:` — a re-scan is a single DB hit, well under the daily quota even on a cold cache.
- **`IMovieMetadataProvider` / `IMusicMetadataProvider` / `IGameMetadataProvider`** — new `SearchByBarcodeAsync`. Stub providers + scripted test doubles updated.
- **`TmdbMovieProvider` / `IgdbGameProvider`** — barcode flow dispatches via `IUpcLookupClient` → product title → existing title search; the final list is cached per-provider under `barcode:` so a second scan is one DB hit (no UPC round-trip, no title search).
- **`MusicBrainzMusicProvider`** — native `release?query=barcode:CODE` (no UPC dependency).
- **`/api/lookup/{movies|music|games}/by-barcode/{code}`** — three new routes parallel to `by-id`; same `LookupResponse<T>` shape so the frontend reuses the existing decoder.

### Frontend (3b)

- **`BarcodeScanner`** — fullscreen `@zxing/browser` viewfinder. Handles permission states (granted, denied, no camera) plus a dedicated hint when `getUserMedia` is unavailable (HTTP / non-secure context). Stops the `MediaStream` on close so the browser "in use" indicator clears.
- **`BarcodeLookup`** — "Scan barcode" button + lookup orchestration. Opens the scanner; on detection calls `/api/lookup/{type}/by-barcode/{code}` and renders a candidate list inline (UPCs are commonly shared across editions / box-sets, so we never auto-import the first hit). Picking a candidate fires the same `onPick` signature `OnlineSearch` uses, so each form reuses its existing `importLookup` unchanged.
- **Lazy split** — `BarcodeScanner` is loaded via `React.lazy + Suspense` so the ~450 KB ZXing decoder bundle only ships when a user actually scans. Main bundle stays at ~250 KB.
- **`services/lookup.ts`** — `lookupByBarcode<T>(type, code)` returns the full `LookupResponse` so callers can distinguish unconfigured / no-match / found.
- **`MovieForm` / `AlbumForm` / `GameForm`** — `<BarcodeLookup>` drops in below `<OnlineSearch>`; `renderItem` callbacks shared between the two.

### Docs

- **`README` — new "Barcode scanning" section** documenting:
  - The HTTPS-or-localhost requirement for `getUserMedia`.
  - `mkcert` / reverse-proxy options for testing from a phone.
  - Music (native MB barcode) vs. Movies/Games (UPCitemdb → title) dispatch.

## Configuration

```bash
# Optional. Defaults to upcitemdb.com's public trial endpoint.
Collectify__Metadata__Upc__BaseUrl=https://api.upcitemdb.com/
```

UPCitemdb's trial takes no key. Per-type providers degrade gracefully when their own keys are unset:

```text
Movies / Games barcode without TMDB / IGDB keys → configured: false, [].
Music barcode without MusicBrainz UserAgent     → configured: false, [].
```

## Test plan

### CI

- [x] `dotnet test` — **server 220/220** (was 191; +29 new).
- [x] `npm test -- --run` — **client 49/49** (was 43; +6 BarcodeLookup tests).
- [x] Build splits the heavy chunk: `index ~250 KB / BarcodeScanner ~445 KB (lazy)`.

### `UpcItemDbClientTests` (7)

- Blank input short-circuits without HTTP.
- URL shape: `prod/trial/lookup?upc=…`.
- Mapping: `title`, `brand`, `manufacturer`.
- Blank title / empty `items` → null (not "found with empty title").
- Cache reuse across separate client instances.
- 5xx → null + retry on next call (no negative cache).

### Per-provider barcode tests (5 each × 3 = 15)

- Not-configured short-circuits **without** consulting UPC.
- Blank barcode no-op.
- UPC miss → no fall-through title search (no empty-string searches).
- Dispatch hits the correct upstream with the resolved title (or, for MB, the native `barcode:` query).
- Repeated calls served from the per-provider `barcode:` cache.

Plus an MB-specific test that the `barcode:` cache namespace doesn't collide with free-text search whose query happens to be 12 digits.

### `LookupEndpointsTests` (+7)

- Unauth → 401 across all three types (theory).
- Movies barcode without TMDB key → `configured: false`, empty.
- Movies / music / games barcode with scripted provider → 1 result, correct fields round-trip.

### `BarcodeLookup.test.tsx` (6)

`@zxing/browser` is mocked to expose a `fireDetection` handle that lets tests simulate a positive scan from jsdom.

- Trigger button opens the (lazy-loaded) scanner dialog.
- Detection calls `lookupByBarcode` with the scanned code; results render as candidates.
- Picking a candidate fires `onPick` with the result and clears the list.
- `configured: false` response → "Online lookup not configured" hint.
- Empty results → "No match for {code}" hint.
- `navigator.mediaDevices` undefined → "secure context required" message (no crash).

### Manual

- [x] Open `/movies/new` over HTTPS / localhost on a phone. Click "Scan barcode" → grant camera permission → point at a Blu-ray UPC → MB / TMDB / IGDB candidate list appears → pick → form populates.
- [x] Repeat for an album CD (MB native barcode) and a game cart.
- [x] Open `/movies/new` over plain HTTP on a LAN IP → "secure context" message; no crash.
- [x] Deny camera permission → "Camera permission denied" copy; Cancel returns to the form.

## Out of scope

- **Multi-frame disambiguation / continuous scan** — first positive read wins; tap "Scan barcode" again for the next one.
- **Manual barcode entry box** as an alternative to the camera. Easy follow-up if the camera path proves flaky on some browsers.
- **Photo-snap visual lookup** — Phase 5.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
