### PR TITLE
feat: GiantBomb UPC fallback for game barcode scans

### DIFF
--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -3,6 +3,7 @@ using Collectify.Api.Endpoints;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.GiantBomb;
 using Collectify.Infrastructure.Lookup.Igdb;
 using Collectify.Infrastructure.Lookup.Images;
 using Collectify.Infrastructure.Lookup.MusicBrainz;
@@ -68,9 +69,10 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
 });
 
 builder.Services.AddMetadataLookup(builder.Configuration);
-// UPC client first: TMDB and IGDB providers depend on it for barcode
-// lookups (MusicBrainz indexes barcodes natively and skips it).
+// UPC clients first: TMDB and IGDB providers depend on them for barcode
+// lookups (MusicBrainz indexes barcodes natively and skips them).
 builder.Services.AddUpcItemDbLookup(builder.Configuration);
+builder.Services.AddGiantBombGameUpcClient(builder.Configuration);
 builder.Services.AddTmdbMovieProvider(builder.Configuration);
 builder.Services.AddMusicBrainzMusicProvider(builder.Configuration);
 builder.Services.AddIgdbGameProvider(builder.Configuration);

--- a/src/server/Collectify.Api/appsettings.Development.json
+++ b/src/server/Collectify.Api/appsettings.Development.json
@@ -17,6 +17,10 @@
       "Igdb": {
         "TwitchClientId": "",
         "TwitchClientSecret": ""
+      },
+      "GiantBomb": {
+        "ApiKey": "",
+        "UserAgent": ""
       }
     }
   }

--- a/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombGameUpcClient.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombGameUpcClient.cs
@@ -1,0 +1,95 @@
+using System.Net.Http.Json;
+using Collectify.Infrastructure.Lookup.Upc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.GiantBomb;
+
+/// <summary>
+/// IGiantBombGameUpcClient backed by giantbomb.com's
+/// /api/releases/?filter=upc: endpoint. GiantBomb is community-curated
+/// and indexes UPCs for a far broader catalogue of console / cartridge
+/// releases than UPCitemdb's generic retail database, so the IGDB game
+/// provider falls back here when UPCitemdb misses.
+///
+/// GiantBomb requires both a free API key and a contact User-Agent on
+/// every request (returns 403 without a UA). Unset = IsConfigured is
+/// false and the client short-circuits before ever calling the wire.
+///
+/// Each lookup is cached under <c>giantbomb / barcode:&lt;upc&gt;</c>; a
+/// re-scan or a duplicate fallback for the same code stays in-process.
+/// </summary>
+public sealed class GiantBombGameUpcClient : IGiantBombGameUpcClient
+{
+    public const string ProviderName = "giantbomb";
+    public const string HttpClientName = "giantbomb";
+
+    private readonly HttpClient _http;
+    private readonly ILookupCache _cache;
+    private readonly MetadataLookupOptions _options;
+    private readonly ILogger<GiantBombGameUpcClient> _log;
+
+    public GiantBombGameUpcClient(
+        HttpClient http,
+        ILookupCache cache,
+        IOptions<MetadataLookupOptions> options,
+        ILogger<GiantBombGameUpcClient> log)
+    {
+        _http = http;
+        _cache = cache;
+        _options = options.Value;
+        _log = log;
+    }
+
+    public string Name => ProviderName;
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(_options.GiantBomb.ApiKey) &&
+        !string.IsNullOrWhiteSpace(_options.GiantBomb.UserAgent);
+
+    public async Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        var trimmed = (barcode ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return null;
+
+        var cacheKey = "barcode:" + trimmed;
+        var cached = await _cache.GetAsync<UpcLookupResult>(ProviderName, cacheKey, _options.CacheTtl, ct);
+        if (cached is not null) return cached;
+
+        GiantBombReleasesResponse? body;
+        try
+        {
+            // field_list keeps the response small -- GiantBomb defaults
+            // include a long list of metadata we don't use. limit=10 in
+            // case the same UPC matches multiple regional releases; we
+            // pick the first one with a usable name.
+            var url = $"releases/?api_key={Uri.EscapeDataString(_options.GiantBomb.ApiKey!)}"
+                    + $"&format=json&field_list=id,name,game"
+                    + $"&filter=upc:{Uri.EscapeDataString(trimmed)}"
+                    + "&limit=10";
+            body = await _http.GetFromJsonAsync<GiantBombReleasesResponse>(url, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "GiantBomb UPC lookup failed for {Barcode}", trimmed);
+            return null;
+        }
+
+        // status_code 1 = OK in GiantBomb's API.
+        if (body is null || body.StatusCode != 1) return null;
+
+        var first = body.Results?.FirstOrDefault(r =>
+            !string.IsNullOrWhiteSpace(r.Game?.Name) || !string.IsNullOrWhiteSpace(r.Name));
+        if (first is null) return null;
+
+        // Prefer the canonical game name; fall back to the release's
+        // own name (which may be a region-tagged title like
+        // "Halo 3 (PAL)").
+        var title = !string.IsNullOrWhiteSpace(first.Game?.Name) ? first.Game!.Name! : first.Name!;
+        var mapped = new UpcLookupResult(Title: title, Brand: null, Manufacturer: null);
+
+        await _cache.SetAsync(ProviderName, cacheKey, mapped, ct);
+        return mapped;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombResponses.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombResponses.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Collectify.Infrastructure.Lookup.GiantBomb;
+
+/// <summary>
+/// Subset of the GiantBomb /api/releases/ response. Only the fields
+/// we map into <see cref="Upc.UpcLookupResult"/> are kept. The release
+/// "name" can differ from the underlying game's name (e.g. regional
+/// box variants), so we prefer the game's name when present and fall
+/// back to the release's.
+/// </summary>
+internal sealed record GiantBombReleasesResponse(
+    [property: JsonPropertyName("status_code")] int StatusCode,
+    [property: JsonPropertyName("error")] string? Error,
+    [property: JsonPropertyName("results")] IReadOnlyList<GiantBombRelease>? Results);
+
+internal sealed record GiantBombRelease(
+    [property: JsonPropertyName("id")] long Id,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("game")] GiantBombGameRef? Game);
+
+internal sealed record GiantBombGameRef(
+    [property: JsonPropertyName("id")] long Id,
+    [property: JsonPropertyName("name")] string? Name);

--- a/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/GiantBomb/GiantBombServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Collectify.Infrastructure.Lookup.GiantBomb;
+
+public static class GiantBombServiceCollectionExtensions
+{
+    /// <summary>
+    /// Wires up <see cref="GiantBombGameUpcClient"/> as the default
+    /// <see cref="IGiantBombGameUpcClient"/>. The IGDB game provider
+    /// pulls it as a UPC fallback when UPCitemdb misses; tests can swap
+    /// in a fake before calling AddIgdbGameProvider.
+    /// </summary>
+    public static IServiceCollection AddGiantBombGameUpcClient(this IServiceCollection services, IConfiguration _)
+    {
+        services.AddHttpClient<GiantBombGameUpcClient>((sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MetadataLookupOptions>>().Value;
+            client.BaseAddress = new Uri(opts.GiantBomb.BaseUrl);
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+            // GiantBomb returns 403 without a User-Agent. If unset, the
+            // client's IsConfigured short-circuits before sending, so an
+            // empty header here is harmless.
+            if (!string.IsNullOrWhiteSpace(opts.GiantBomb.UserAgent))
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(opts.GiantBomb.UserAgent);
+        });
+
+        services.RemoveAll<IGiantBombGameUpcClient>();
+        services.AddScoped<IGiantBombGameUpcClient>(sp => sp.GetRequiredService<GiantBombGameUpcClient>());
+
+        return services;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Lookup/GiantBomb/IGiantBombGameUpcClient.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/GiantBomb/IGiantBombGameUpcClient.cs
@@ -1,0 +1,17 @@
+using Collectify.Infrastructure.Lookup.Upc;
+
+namespace Collectify.Infrastructure.Lookup.GiantBomb;
+
+/// <summary>
+/// GiantBomb-backed UPC → game-title resolver. Distinct from
+/// <see cref="IUpcLookupClient"/> on purpose: the IGDB game provider
+/// uses GiantBomb only as a fallback when UPCitemdb misses, so the
+/// two paths shouldn't share a registration slot. Returns null when
+/// not configured or when GiantBomb has no release for the code.
+/// </summary>
+public interface IGiantBombGameUpcClient
+{
+    string Name { get; }
+    bool IsConfigured { get; }
+    Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default);
+}

--- a/src/server/Collectify.Infrastructure/Lookup/Igdb/IgdbGameProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Igdb/IgdbGameProvider.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using Collectify.Infrastructure.Lookup.GiantBomb;
 using Collectify.Infrastructure.Lookup.Upc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -43,6 +44,7 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
     private readonly HttpClient _http;
     private readonly IIgdbAuth _auth;
     private readonly IUpcLookupClient _upc;
+    private readonly IGiantBombGameUpcClient _giantBomb;
     private readonly ILookupCache _cache;
     private readonly MetadataLookupOptions _options;
     private readonly ILogger<IgdbGameProvider> _log;
@@ -51,6 +53,7 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
         HttpClient http,
         IIgdbAuth auth,
         IUpcLookupClient upc,
+        IGiantBombGameUpcClient giantBomb,
         ILookupCache cache,
         IOptions<MetadataLookupOptions> options,
         ILogger<IgdbGameProvider> log)
@@ -58,6 +61,7 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
         _http = http;
         _auth = auth;
         _upc = upc;
+        _giantBomb = giantBomb;
         _cache = cache;
         _options = options.Value;
         _log = log;
@@ -120,11 +124,16 @@ public sealed class IgdbGameProvider : IGameMetadataProvider
         var cached = await _cache.GetAsync<List<GameLookupResult>>(ProviderName, cacheKey, _options.CacheTtl, ct);
         if (cached is not null) return cached;
 
-        // IGDB has no barcode field; resolve via UPCitemdb to a product
-        // title, then run our regular Apicalypse search. UPC lookups are
-        // independently cached so a second scan is free even before this
-        // wrapping cache layer kicks in.
+        // IGDB has no barcode field; resolve via UPCitemdb first (broad
+        // generic-retail coverage). When UPCitemdb misses, fall back to
+        // GiantBomb's /api/releases/?filter=upc: which has much better
+        // coverage of console / cartridge / collector releases. Both
+        // sources are independently cached, so a re-scan stays in-process.
         var upcHit = await _upc.LookupAsync(trimmed, ct);
+        if (upcHit is null && _giantBomb.IsConfigured)
+        {
+            upcHit = await _giantBomb.LookupAsync(trimmed, ct);
+        }
         if (upcHit is null) return [];
 
         var hits = await SearchAsync(upcHit.Title, ct);

--- a/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MetadataLookupOptions.cs
@@ -15,6 +15,7 @@ public sealed class MetadataLookupOptions
     public MusicBrainzOptions MusicBrainz { get; set; } = new();
     public IgdbOptions Igdb { get; set; } = new();
     public UpcOptions Upc { get; set; } = new();
+    public GiantBombOptions GiantBomb { get; set; } = new();
 }
 
 public sealed class TmdbOptions
@@ -49,4 +50,19 @@ public sealed class IgdbOptions
 public sealed class UpcOptions
 {
     public string BaseUrl { get; set; } = "https://api.upcitemdb.com/";
+}
+
+/// <summary>
+/// Bound from "Collectify:Metadata:GiantBomb". GiantBomb's
+/// <c>/api/releases/?filter=upc:</c> endpoint is the most useful free
+/// barcode-indexed source for video games (UPCitemdb's coverage of
+/// console / cartridge releases is patchy). Both the free API key and a
+/// contact User-Agent are required -- GiantBomb returns 403 without a
+/// UA, and unset credentials disable the source entirely.
+/// </summary>
+public sealed class GiantBombOptions
+{
+    public string? ApiKey { get; set; }
+    public string? UserAgent { get; set; }
+    public string BaseUrl { get; set; } = "https://www.giantbomb.com/api/";
 }

--- a/src/server/Collectify.Infrastructure/Lookup/MetadataLookupServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/MetadataLookupServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Collectify.Infrastructure.Lookup.GiantBomb;
 using Collectify.Infrastructure.Lookup.Stub;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +29,10 @@ public static class MetadataLookupServiceCollectionExtensions
         services.TryAddScoped<IMovieMetadataProvider, StubMovieProvider>();
         services.TryAddScoped<IMusicMetadataProvider, StubMusicProvider>();
         services.TryAddScoped<IGameMetadataProvider, StubGameProvider>();
+        // GiantBomb is opt-in (free key but requires sign-up). A stub
+        // keeps the IGDB game provider's DI graph satisfied when it's
+        // not configured; the fallback chain just skips it.
+        services.TryAddScoped<IGiantBombGameUpcClient, StubGiantBombGameUpcClient>();
 
         return services;
     }

--- a/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Stub/StubMovieProvider.cs
@@ -1,4 +1,21 @@
+using Collectify.Infrastructure.Lookup.GiantBomb;
+using Collectify.Infrastructure.Lookup.Upc;
+
 namespace Collectify.Infrastructure.Lookup.Stub;
+
+/// <summary>
+/// Default <see cref="IGiantBombGameUpcClient"/> registered when the
+/// real one isn't wired up. Always reports unconfigured + null so the
+/// game provider's UPC fallback chain skips it gracefully.
+/// </summary>
+internal sealed class StubGiantBombGameUpcClient : IGiantBombGameUpcClient
+{
+    public string Name => "stub-giantbomb";
+    public bool IsConfigured => false;
+
+    public Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default)
+        => Task.FromResult<UpcLookupResult?>(null);
+}
 
 /// <summary>
 /// Fallback provider used when no concrete movie provider has been registered.

--- a/src/server/tests/Collectify.Tests/Infrastructure/FakeGiantBombClient.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/FakeGiantBombClient.cs
@@ -1,0 +1,33 @@
+using Collectify.Infrastructure.Lookup.GiantBomb;
+using Collectify.Infrastructure.Lookup.Upc;
+
+namespace Collectify.Tests.Infrastructure;
+
+/// <summary>
+/// Test double for <see cref="IGiantBombGameUpcClient"/>. Mirrors
+/// <see cref="FakeUpcClient"/> shape so tests can dial in
+/// "configured-but-no-hit" vs "configured-with-hit" vs the default
+/// "not configured at all" paths.
+/// </summary>
+public sealed class FakeGiantBombClient : IGiantBombGameUpcClient
+{
+    public string Name => "fake-giantbomb";
+    public bool IsConfigured { get; init; }
+    public List<string> RequestedBarcodes { get; } = new();
+    public UpcLookupResult? Result { get; init; }
+
+    public Task<UpcLookupResult?> LookupAsync(string barcode, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Task.FromResult<UpcLookupResult?>(null);
+        RequestedBarcodes.Add(barcode);
+        return Task.FromResult(Result);
+    }
+
+    public static FakeGiantBombClient NotConfigured() => new() { IsConfigured = false };
+
+    public static FakeGiantBombClient ConfiguredNotRecognised() =>
+        new() { IsConfigured = true };
+
+    public static FakeGiantBombClient Returning(string title) =>
+        new() { IsConfigured = true, Result = new UpcLookupResult(title, null, null) };
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/GiantBombGameUpcClientTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/GiantBombGameUpcClientTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Text;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup;
+using Collectify.Infrastructure.Lookup.GiantBomb;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class GiantBombGameUpcClientTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _dbOptions;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    public GiantBombGameUpcClientTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbOptions = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_dbOptions);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private GiantBombGameUpcClient NewClient(StubHandler handler, MetadataLookupOptions? overrideOptions = null)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://www.giantbomb.com/api/") };
+        var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
+        var options = overrideOptions ?? new MetadataLookupOptions
+        {
+            GiantBomb = new GiantBombOptions { ApiKey = "secret-key", UserAgent = "Collectify/1.0 (test@example.com)" },
+        };
+        return new GiantBombGameUpcClient(http, cache, Options.Create(options), NullLogger<GiantBombGameUpcClient>.Instance);
+    }
+
+    private const string MatchJson = """
+        {
+          "status_code": 1,
+          "error": "OK",
+          "results": [
+            {
+              "id": 36105,
+              "name": "Halo 3 (Limited Edition)",
+              "game": { "id": 21251, "name": "Halo 3" }
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void IsConfigured_RequiresBothApiKeyAndUserAgent()
+    {
+        var both = NewClient(new StubHandler("[]"));
+        var noKey = NewClient(new StubHandler("[]"), new MetadataLookupOptions
+        {
+            GiantBomb = new GiantBombOptions { ApiKey = null, UserAgent = "ua" },
+        });
+        var noUa = NewClient(new StubHandler("[]"), new MetadataLookupOptions
+        {
+            GiantBomb = new GiantBombOptions { ApiKey = "k", UserAgent = "  " },
+        });
+
+        Assert.True(both.IsConfigured);
+        Assert.False(noKey.IsConfigured);
+        Assert.False(noUa.IsConfigured);
+    }
+
+    [Fact]
+    public async Task LookupAsync_NotConfigured_ReturnsNullWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var client = NewClient(handler, new MetadataLookupOptions());
+
+        Assert.Null(await client.LookupAsync("0883929473076"));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task LookupAsync_BlankBarcode_ReturnsNullWithoutCalling()
+    {
+        var handler = new StubHandler("never called");
+        var client = NewClient(handler);
+
+        Assert.Null(await client.LookupAsync("   "));
+        Assert.Empty(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task LookupAsync_HitsReleasesEndpoint_WithUpcFilterAndKey()
+    {
+        var handler = new StubHandler(MatchJson);
+        await NewClient(handler).LookupAsync("0883929473076");
+
+        var url = Assert.Single(handler.RequestedUrls);
+        Assert.Contains("releases/", url);
+        Assert.Contains("filter=upc:0883929473076", url);
+        Assert.Contains("api_key=secret-key", url);
+        Assert.Contains("format=json", url);
+    }
+
+    [Fact]
+    public async Task LookupAsync_PrefersGameName_OverReleaseName()
+    {
+        // Release name carries regional cruft ("Limited Edition"); the
+        // game name is the canonical title we want for the IGDB search.
+        var hit = await NewClient(new StubHandler(MatchJson)).LookupAsync("0883929473076");
+
+        Assert.NotNull(hit);
+        Assert.Equal("Halo 3", hit!.Title);
+    }
+
+    [Fact]
+    public async Task LookupAsync_FallsBackToReleaseName_WhenGameNameMissing()
+    {
+        const string body = """
+            {
+              "status_code": 1,
+              "results": [
+                { "id": 1, "name": "Some Obscure Release", "game": null }
+              ]
+            }
+            """;
+        var hit = await NewClient(new StubHandler(body)).LookupAsync("9999999999999");
+
+        Assert.NotNull(hit);
+        Assert.Equal("Some Obscure Release", hit!.Title);
+    }
+
+    [Fact]
+    public async Task LookupAsync_NonOkStatusCode_ReturnsNull()
+    {
+        // status_code 100 is GiantBomb's "Invalid API Key"; payload may
+        // still be 200 OK on the wire. Don't trust it.
+        const string body = """
+            { "status_code": 100, "error": "Invalid API Key", "results": [] }
+            """;
+        Assert.Null(await NewClient(new StubHandler(body)).LookupAsync("0883929473076"));
+    }
+
+    [Fact]
+    public async Task LookupAsync_EmptyResults_ReturnsNull()
+    {
+        const string body = """{ "status_code": 1, "results": [] }""";
+        Assert.Null(await NewClient(new StubHandler(body)).LookupAsync("0000"));
+    }
+
+    [Fact]
+    public async Task LookupAsync_RepeatedCallsServeFromCache()
+    {
+        var handler = new StubHandler(MatchJson);
+        var c1 = NewClient(handler);
+        var c2 = NewClient(handler);
+
+        await c1.LookupAsync("0883929473076");
+        await c2.LookupAsync("0883929473076");
+
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task LookupAsync_OnUpstreamFailure_ReturnsNullAndDoesNotCache()
+    {
+        var handler = new StubHandler("nope", HttpStatusCode.InternalServerError);
+        var client = NewClient(handler);
+
+        Assert.Null(await client.LookupAsync("0883929473076"));
+        await client.LookupAsync("0883929473076");
+        Assert.Equal(2, handler.RequestedUrls.Count);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly HttpStatusCode _status;
+        public List<string> RequestedUrls { get; } = new();
+
+        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
@@ -28,7 +28,12 @@ public class IgdbGameProviderTests : IDisposable
 
     public void Dispose() => _connection.Dispose();
 
-    private IgdbGameProvider NewProvider(HttpMessageHandler handler, FakeAuth? auth = null, MetadataLookupOptions? overrideOptions = null, FakeUpcClient? upc = null)
+    private IgdbGameProvider NewProvider(
+        HttpMessageHandler handler,
+        FakeAuth? auth = null,
+        MetadataLookupOptions? overrideOptions = null,
+        FakeUpcClient? upc = null,
+        FakeGiantBombClient? giantBomb = null)
     {
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.igdb.com/v4/") };
         var cache = new LookupCache(new CollectifyDbContext(_dbOptions), _clock);
@@ -36,7 +41,14 @@ public class IgdbGameProviderTests : IDisposable
         {
             Igdb = new IgdbOptions { TwitchClientId = "client", TwitchClientSecret = "secret" },
         };
-        return new IgdbGameProvider(http, auth ?? new FakeAuth("client", "tok"), upc ?? FakeUpcClient.NotRecognised(), cache, Options.Create(options), NullLogger<IgdbGameProvider>.Instance);
+        return new IgdbGameProvider(
+            http,
+            auth ?? new FakeAuth("client", "tok"),
+            upc ?? FakeUpcClient.NotRecognised(),
+            giantBomb ?? FakeGiantBombClient.NotConfigured(),
+            cache,
+            Options.Create(options),
+            NullLogger<IgdbGameProvider>.Instance);
     }
 
     private const string SingleGameJson = """
@@ -355,6 +367,67 @@ public class IgdbGameProviderTests : IDisposable
         await p2.SearchByBarcodeAsync("0883929473076");
 
         Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_FallsBackToGiantBomb_WhenUpcMisses()
+    {
+        // UPCitemdb didn't recognise the code; GiantBomb did. The
+        // GiantBomb-resolved title drives the IGDB Apicalypse search.
+        var upc = FakeUpcClient.NotRecognised();
+        var giantBomb = FakeGiantBombClient.Returning("Halo 3");
+        var handler = new StubHandler(SingleGameJson);
+        var provider = NewProvider(handler, upc: upc, giantBomb: giantBomb);
+
+        var hits = await provider.SearchByBarcodeAsync("0883929473076");
+
+        Assert.Single(hits);
+        Assert.Single(upc.RequestedBarcodes);
+        Assert.Single(giantBomb.RequestedBarcodes);
+        var req = Assert.Single(handler.Requests);
+        Assert.Contains("search \"Halo 3\";", req.Body);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_DoesNotCallGiantBomb_WhenUpcAlreadyHit()
+    {
+        // Belt-and-braces: when the primary UPC source resolves the
+        // code, we shouldn't fan out to GiantBomb (saves a request and
+        // keeps results consistent with the primary).
+        var upc = FakeUpcClient.Returning("The Witcher 3");
+        var giantBomb = FakeGiantBombClient.Returning("Different Game");
+        var handler = new StubHandler(SingleGameJson);
+        var provider = NewProvider(handler, upc: upc, giantBomb: giantBomb);
+
+        await provider.SearchByBarcodeAsync("0883929473076");
+
+        Assert.Empty(giantBomb.RequestedBarcodes);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_BothSourcesMiss_ReturnsEmptyWithoutTitleSearch()
+    {
+        var upc = FakeUpcClient.NotRecognised();
+        var giantBomb = FakeGiantBombClient.ConfiguredNotRecognised();
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc, giantBomb: giantBomb);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0000000000000"));
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SearchByBarcodeAsync_SkipsGiantBomb_WhenItIsNotConfigured()
+    {
+        // Default fake = NotConfigured; the provider must not consult
+        // it (the IsConfigured guard short-circuits before any call).
+        var upc = FakeUpcClient.NotRecognised();
+        var giantBomb = FakeGiantBombClient.NotConfigured();
+        var handler = new StubHandler("never called");
+        var provider = NewProvider(handler, upc: upc, giantBomb: giantBomb);
+
+        Assert.Empty(await provider.SearchByBarcodeAsync("0000000000000"));
+        Assert.Empty(giantBomb.RequestedBarcodes);
     }
 
     private sealed class FakeAuth : IIgdbAuth


### PR DESCRIPTION
UPCitemdb's free trial has patchy coverage for console / cartridge releases, so most game barcodes scanned through the IGDB pipeline come back as "no match" (the user-reported pain point that prompted this PR). GiantBomb's `/api/releases/?filter=upc:CODE` is a community-curated barcode index focused on games — it covers the catalogue UPCitemdb misses.

Wires it as a **secondary** UPC source: `IgdbGameProvider.SearchByBarcodeAsync` still tries UPCitemdb first (broader generic-retail coverage), and only consults GiantBomb when UPCitemdb returns null. Both sources cache independently under their own provider names with the `barcode:` namespace, and the per-provider barcode cache on IGDB still wraps the final list — a re-scan of the same code never round-trips either UPC source.

## Summary

### Backend

- **`Lookup/GiantBomb/GiantBombGameUpcClient`** — new `IGiantBombGameUpcClient` backed by GiantBomb's `/api/releases/?filter=upc:`. Field-list pinned to `id,name,game` to keep payloads small. Prefers `release.game.name` (canonical title) over `release.name` (region-tagged variant) when feeding the IGDB title search.
- **`IgdbGameProvider`** — new `IGiantBombGameUpcClient` constructor dep; `SearchByBarcodeAsync` calls UPCitemdb, then GiantBomb (only when configured), then gives up. UPCitemdb hits short-circuit GiantBomb so we don't double-fan-out on the happy path.
- **`MetadataLookupOptions.GiantBomb`** — `ApiKey` + `UserAgent` (GiantBomb 403s without a UA). Both required for `IsConfigured` to flip; unset = silently skipped.
- **`StubGiantBombGameUpcClient`** registered by default so existing IGDB setups don't need any config change to keep working.
- **`appsettings.Development.json`** — placeholder added next to TMDB / MusicBrainz / IGDB stubs.

## Configuration

```bash
Collectify__Metadata__GiantBomb__ApiKey=your-free-key
Collectify__Metadata__GiantBomb__UserAgent="Collectify/1.0 (you@example.com)"
```

Get a free API key at https://www.giantbomb.com/api/. The User-Agent must include a real contact string per GiantBomb's API rules.

## Test plan

### CI

- [x] `dotnet test` — **server 234/234** (was 220 on `main`; +14 new across `GiantBombGameUpcClientTests` and `IgdbGameProviderTests`).
- [x] Server build clean.

### `GiantBombGameUpcClientTests` (10)

- `IsConfigured` matrix: both creds, missing key, whitespace UA.
- Blank input short-circuits without HTTP.
- URL shape: `releases/?filter=upc:…&api_key=…&format=json&field_list=id,name,game`.
- Mapping: prefers `game.name`; falls back to `release.name` when game is null.
- `status_code != 1` (e.g. invalid key returns 100) treated as a miss.
- Empty `results` → null.
- Cache reuse across separate client instances.
- 5xx → null + retry on next call (no negative cache).

### `IgdbGameProviderTests` (+4)

- GiantBomb fallback fires when UPCitemdb misses; resolved title drives the IGDB Apicalypse search.
- GiantBomb is **not** consulted when UPCitemdb already hits.
- Both-miss returns empty without calling IGDB title search.
- Unconfigured GiantBomb is fully skipped (no spurious calls).

### Manual

- [ ] Drop the GiantBomb env vars in `.env`, restart, scan a console disc UPC that UPCitemdb doesn't recognise (most non-current-gen games qualify) → IGDB candidates land.
- [ ] Re-scan the same code → second hit served from `LookupCache` (no GiantBomb / UPCitemdb traffic, no IGDB title search).
- [ ] Scan a UPC that UPCitemdb does recognise → GiantBomb is **not** called (verify via logs).

## Out of scope

- **Soft-fallback UX** when both UPC sources miss (pre-fill the barcode field on the Add page so the user can finish via title search) — separate UI-only follow-up.
- **Movies UPC fallback** — no equally-clean game-quality free source exists for movies. Current options for that path are paid (UPCitemdb keyed tier, BarcodeLookup.com).
- Dropping the soft fallback into `MoviesUpcClient` chain — same shape would compose, leaving the door open.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_