### PR TITLE
feat: soft-fallback when barcode scan finds no match

### DIFF
--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -14,6 +14,11 @@ interface Props {
    * enrichment chain as picking from in-form search.
    */
   prefillLookup?: MusicLookupResult;
+  /**
+   * Soft-fallback prefill: just the barcode, no metadata. Set when the
+   * list-page scanner couldn't resolve the UPC.
+   */
+  prefillBarcode?: string;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (a: Album) => void;
@@ -29,7 +34,7 @@ const empty: Album = {
   tags: [],
 };
 
-export default function AlbumForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function AlbumForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [a, setA] = useState<Album>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setA(initial); }, [initial]);
@@ -89,6 +94,14 @@ export default function AlbumForm({ initial, prefillLookup, submitting, submitLa
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
 
+  // Soft-fallback prefill (list-page scan with no provider candidates):
+  // drop the barcode into the field so the user can finish via title
+  // search. Skipped when a full prefillLookup landed; that owns it.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (prefillBarcode && !prefillLookup) set('barcode', prefillBarcode);
+  }, []);
+
   const runLookup = async (
     id: string,
     label: string,
@@ -140,6 +153,8 @@ export default function AlbumForm({ initial, prefillLookup, submitting, submitLa
       <BarcodeLookup
         type="music"
         onPick={importLookup}
+        onBarcodeFallback={(code) => set('barcode', code)}
+        fallbackLabel="Save this barcode anyway"
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),
           secondary: r.artistName + (r.label ? ` · ${r.label}` : ''),

--- a/src/client/components/BarcodeLookup.test.tsx
+++ b/src/client/components/BarcodeLookup.test.tsx
@@ -153,6 +153,51 @@ describe('BarcodeLookup', () => {
     expect(await screen.findByText(/No match for 0000000000000/i)).toBeInTheDocument();
   });
 
+  it('exposes a soft-fallback button on miss when onBarcodeFallback is wired', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: true,
+      results: [],
+    });
+    const onBarcodeFallback = vi.fn();
+
+    render(
+      <BarcodeLookup
+        type="movies"
+        onPick={vi.fn()}
+        onBarcodeFallback={onBarcodeFallback}
+        fallbackLabel="Add with this barcode"
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0000000000000');
+
+    const fallback = await screen.findByRole('button', { name: /Add with this barcode/i });
+    await userEvent.click(fallback);
+
+    expect(onBarcodeFallback).toHaveBeenCalledTimes(1);
+    expect(onBarcodeFallback).toHaveBeenCalledWith('0000000000000');
+    // The miss UI is dismissed once the fallback fires.
+    expect(screen.queryByText(/No match for/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render the fallback button when onBarcodeFallback is omitted', async () => {
+    mockLookupByBarcode.mockResolvedValue({
+      provider: 'tmdb',
+      configured: true,
+      results: [],
+    });
+
+    render(<BarcodeLookup type="movies" onPick={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Scan barcode/i }));
+    await waitFor(() => expect(fireDetection).not.toBeNull());
+    fireDetection!('0000000000000');
+
+    expect(await screen.findByText(/No match for/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add with this barcode/i })).not.toBeInTheDocument();
+  });
+
   it('renders an HTTPS hint when getUserMedia is unavailable', async () => {
     // Strip mediaDevices to simulate plain HTTP / non-secure context.
     Object.defineProperty(globalThis.navigator, 'mediaDevices', {

--- a/src/client/components/BarcodeLookup.tsx
+++ b/src/client/components/BarcodeLookup.tsx
@@ -21,6 +21,17 @@ interface Props<T extends MediaType> {
   onPick: (item: ResultMap[T]) => void;
   /** Optional row renderer; mirrors OnlineSearch so callers can share the same fn. */
   renderItem?: (item: ResultMap[T]) => { primary: string; secondary?: ReactNode; image?: string | null };
+  /**
+   * Soft-fallback hook fired when the lookup returns 0 candidates for a
+   * scanned code (UPCitemdb's free coverage is patchy for movies / games
+   * in particular). Lets the parent salvage the scan -- e.g. the list
+   * page navigates to /add with the barcode pre-filled so the user can
+   * finish via the reliable title search without retyping the UPC.
+   * If omitted, a "no match" message is shown and that's it.
+   */
+  onBarcodeFallback?: (code: string) => void;
+  /** Label for the fallback button when onBarcodeFallback is wired. */
+  fallbackLabel?: string;
 }
 
 type Phase =
@@ -40,7 +51,13 @@ type Phase =
  * (Blu-ray + UHD + box-set), so we always render a list rather than
  * auto-importing the first hit.
  */
-export default function BarcodeLookup<T extends MediaType>({ type, onPick, renderItem }: Props<T>) {
+export default function BarcodeLookup<T extends MediaType>({
+  type,
+  onPick,
+  renderItem,
+  onBarcodeFallback,
+  fallbackLabel = 'Add with this barcode anyway',
+}: Props<T>) {
   const [scannerOpen, setScannerOpen] = useState(false);
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
 
@@ -86,7 +103,21 @@ export default function BarcodeLookup<T extends MediaType>({ type, onPick, rende
         </p>
       )}
       {phase.kind === 'results' && phase.configured && phase.results.length === 0 && (
-        <p className="text-xs text-slate-400">No match for {phase.code}.</p>
+        <div className="space-y-1">
+          <p className="text-xs text-slate-400">No match for {phase.code}.</p>
+          {onBarcodeFallback && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                onBarcodeFallback(phase.code);
+                setPhase({ kind: 'idle' });
+              }}
+            >
+              {fallbackLabel}
+            </Button>
+          )}
+        </div>
       )}
       {phase.kind === 'results' && phase.results.length > 0 && (
         <div className="rounded-md bg-slate-900 border border-slate-700 max-h-80 overflow-auto">

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -40,12 +40,25 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
     navigate(newPath, { state: { prefill: item } });
   };
 
+  // Soft fallback: when the scan resolves but no provider candidates
+  // come back (common for movies / games -- UPCitemdb coverage gaps),
+  // still salvage the scan by sending the user to /add with just the
+  // barcode pre-filled. They can finish via the reliable title search
+  // without having to retype the UPC.
+  const onBarcodeFallback = (code: string) => {
+    navigate(newPath, { state: { barcodeOnly: code } });
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold text-white">{title}</h1>
         <div className="flex items-center gap-2">
-          <BarcodeLookup type={type} onPick={onBarcodePick} />
+          <BarcodeLookup
+            type={type}
+            onPick={onBarcodePick}
+            onBarcodeFallback={onBarcodeFallback}
+          />
           <Link to={newPath}>
             <Button>+ Add</Button>
           </Link>

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -20,6 +20,11 @@ interface Props {
    * picking from in-form search.
    */
   prefillLookup?: GameLookupResult;
+  /**
+   * Soft-fallback prefill: just the barcode, no metadata. Set when the
+   * list-page scanner couldn't resolve the UPC.
+   */
+  prefillBarcode?: string;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (g: Game) => void;
@@ -34,7 +39,7 @@ const empty: Game = {
   tags: [],
 };
 
-export default function GameForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function GameForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [g, setG] = useState<Game>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setG(initial); }, [initial]);
@@ -57,6 +62,14 @@ export default function GameForm({ initial, prefillLookup, submitting, submitLab
   // Seed once on mount when a prefill arrives via navigation state.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
+
+  // Soft-fallback prefill (list-page scan with no provider candidates):
+  // drop the barcode into the field so the user can finish via title
+  // search. Skipped when a full prefillLookup landed; that owns it.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (prefillBarcode && !prefillLookup) set('barcode', prefillBarcode);
+  }, []);
 
   const runLookup = async (
     id: string,
@@ -109,6 +122,8 @@ export default function GameForm({ initial, prefillLookup, submitting, submitLab
       <BarcodeLookup
         type="games"
         onPick={importLookup}
+        onBarcodeFallback={(code) => set('barcode', code)}
+        fallbackLabel="Save this barcode anyway"
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),
           secondary: [r.developer, r.platform].filter(Boolean).join(' · ') || r.description?.slice(0, 120),

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -16,6 +16,12 @@ interface Props {
    * follow-up call lands.
    */
   prefillLookup?: MovieLookupResult;
+  /**
+   * Soft-fallback prefill: just the barcode, no metadata. Set when the
+   * list-page scanner couldn't resolve the UPC -- the user can finish
+   * via title search without retyping it.
+   */
+  prefillBarcode?: string;
   submitting?: boolean;
   submitLabel?: string;
   onSubmit: (m: Movie) => void;
@@ -31,7 +37,7 @@ const empty: Movie = {
   tags: [],
 };
 
-export default function MovieForm({ initial, prefillLookup, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
+export default function MovieForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [m, setM] = useState<Movie>(initial ?? empty);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setM(initial); }, [initial]);
@@ -93,6 +99,16 @@ export default function MovieForm({ initial, prefillLookup, submitting, submitLa
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { if (prefillLookup) importLookup(prefillLookup); }, []);
 
+  // Soft-fallback prefill: when a list-page scan resolved but no
+  // candidates came back, the parent passes just the barcode. Drop it
+  // straight into the field so the user can finish via title search
+  // without retyping. Skipped when prefillLookup also fired -- the
+  // lookup result owns the barcode field in that case.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (prefillBarcode && !prefillLookup) set('barcode', prefillBarcode);
+  }, []);
+
   const runLookup = async (
     id: string,
     label: string,
@@ -145,6 +161,8 @@ export default function MovieForm({ initial, prefillLookup, submitting, submitLa
       <BarcodeLookup
         type="movies"
         onPick={importLookup}
+        onBarcodeFallback={(code) => set('barcode', code)}
+        fallbackLabel="Save this barcode anyway"
         renderItem={(r) => ({
           primary: r.title + (r.year ? ` (${r.year})` : ''),
           secondary: r.description?.slice(0, 120),

--- a/src/client/pages/AddPage.tsx
+++ b/src/client/pages/AddPage.tsx
@@ -10,6 +10,13 @@ import { Card } from '../components/ui';
 
 interface PrefillState {
   prefill?: MovieLookupResult | MusicLookupResult | GameLookupResult;
+  /**
+   * Soft-fallback hint from the list-page scanner: a barcode the user
+   * scanned that didn't match any provider. We seed only the barcode
+   * field so the user can finish via the reliable title search without
+   * retyping the UPC.
+   */
+  barcodeOnly?: string;
 }
 
 const titleByType: Record<MediaType, string> = {
@@ -22,7 +29,9 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
   const create = useCreate(type);
   const nav = useNavigate();
   const location = useLocation();
-  const prefill = (location.state as PrefillState | null)?.prefill;
+  const navState = location.state as PrefillState | null;
+  const prefill = navState?.prefill;
+  const prefillBarcode = navState?.barcodeOnly;
 
   // Persisted-feedback so the success banner can stay on screen briefly
   // before we redirect to the detail page.
@@ -78,6 +87,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
         {type === 'movies' && (
           <MovieForm
             prefillLookup={prefill as MovieLookupResult | undefined}
+            prefillBarcode={prefillBarcode}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(m) =>
@@ -90,6 +100,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
         {type === 'music' && (
           <AlbumForm
             prefillLookup={prefill as MusicLookupResult | undefined}
+            prefillBarcode={prefillBarcode}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(a) =>
@@ -102,6 +113,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
         {type === 'games' && (
           <GameForm
             prefillLookup={prefill as GameLookupResult | undefined}
+            prefillBarcode={prefillBarcode}
             submitting={create.isPending}
             submitLabel="Create"
             onSubmit={(g) =>


### PR DESCRIPTION
UPC coverage in UPCitemdb's free trial is patchy for movies / games, so a lot of barcode scans return "no match" and leave the user with nothing actionable. This PR turns those misses into a one-click handoff to the (reliable) title-search flow with the scanned barcode pre-filled — no retyping, no dead-end.

Replaces the closed #27 (GiantBomb) which couldn't ship because GiantBomb's API is gated by a Cloudflare managed JS challenge that returns a `Just a moment…` page to anything that doesn't run their browser-side JS.

## Summary

- **`BarcodeLookup`** — new optional `onBarcodeFallback(code)` + `fallbackLabel` props. When the lookup returns `configured: true` with `results: []`, a button next to the "No match for X" line fires the callback. Without the prop the button isn't rendered and existing UX is unchanged.
- **`CollectionList`** — wires the list-page fallback to `navigate(newPath, { state: { barcodeOnly: code } })`. Lands the user on `/{type}/new` with the UPC already in the form.
- **`AddPage`** — reads `location.state.barcodeOnly` and passes it as `prefillBarcode` to the appropriate form.
- **`MovieForm` / `AlbumForm` / `GameForm`** — new `prefillBarcode` prop. On first mount sets the barcode field if it's provided **and** a full `prefillLookup` didn't already arrive (the lookup result owns the field in that case). The in-form `<BarcodeLookup>` instance also wires `onBarcodeFallback` to `set('barcode', code)` directly so scanning inside the form on a miss still patches the field instead of dead-ending.

## UX flow

| Where | Trigger | Result |
|---|---|---|
| List page | Scan → 1+ candidates | Pick → `/{type}/new` with full lookup prefill (existing behaviour, unchanged) |
| List page | Scan → no match | Click *"Add with this barcode anyway"* → `/{type}/new` with the barcode field pre-filled |
| In-form | Scan → 1+ candidates | Pick → all metadata fields filled (existing behaviour, unchanged) |
| In-form | Scan → no match | Click *"Save this barcode anyway"* → barcode field patched, modal closes |

## Test plan

### CI

- [x] `npm test -- --run` — **client 51/51** (was 49; +2 fallback tests).
- [x] Vite build clean. Bundle size unchanged (`index ~250 KB / BarcodeScanner ~445 KB lazy`).

### `BarcodeLookup.test.tsx` (+2)

- Fallback button fires the callback with the scanned code and dismisses the miss UI.
- Fallback button isn't rendered when `onBarcodeFallback` is omitted (back-compat).

### Manual

- [x] On the games list page, scan a UPC that UPCitemdb doesn't recognise → "No match for X" + button → tap → `/games/new` opens with the Barcode field already populated and the rest of the form empty. Run an IGDB title search to fill in everything else and Save → entry has both the barcode and the title-search metadata.
- [x] Inside the movie form, scan a UPC that doesn't match → tap *"Save this barcode anyway"* → modal closes, the barcode field is filled, the rest of the form keeps whatever the user already typed.
- [x] List page, scan a UPC that **does** match → unchanged: candidates render, picking navigates to `/movies/new` with the full prefill.

## Out of scope

- A second free game-UPC source (PriceCharting was on the table; needs a curl-first probe before committing — see #27 for context).
- Auto-pick when there's exactly one candidate. Multi-edition UPCs are common enough that always showing the list is worth one extra click.