### PR TITLE
feat: covers ETag + immutable cache, cover GC, dashboard endpoint

### DIFF
--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -1,31 +1,99 @@
 import { Link } from 'react-router-dom';
-import { useList } from '../services/collection';
+import { useDashboard, type DashboardRecent } from '../services/collection';
 import { Card } from '../components/ui';
 
+const TYPE_LABEL: Record<DashboardRecent['type'], string> = {
+  movies: 'Movie',
+  music: 'Album',
+  games: 'Game',
+};
+
 export default function Dashboard() {
-  const movies = useList('movies', '');
-  const music = useList('music', '');
-  const games = useList('games', '');
+  const dashboard = useDashboard();
+  const summary = dashboard.data;
+  const counts = summary?.counts;
 
   const tiles = [
-    { to: '/movies', label: 'Movies', count: movies.data?.length ?? '…' },
-    { to: '/music', label: 'Music', count: music.data?.length ?? '…' },
-    { to: '/games', label: 'Games', count: games.data?.length ?? '…' },
+    { to: '/movies', label: 'Movies', count: counts?.movies },
+    { to: '/music', label: 'Music', count: counts?.music },
+    { to: '/games', label: 'Games', count: counts?.games },
   ];
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold text-white">Your collection</h1>
+
       <div className="grid sm:grid-cols-3 gap-4">
         {tiles.map((t) => (
           <Link key={t.to} to={t.to} className="block">
             <Card className="hover:border-indigo-500 transition-colors">
               <div className="text-slate-400 text-sm">{t.label}</div>
-              <div className="text-3xl font-semibold text-white mt-1">{t.count}</div>
+              <div className="text-3xl font-semibold text-white mt-1">
+                {t.count ?? '…'}
+              </div>
             </Card>
           </Link>
         ))}
       </div>
+
+      <RecentSection summary={summary} loading={dashboard.isLoading} error={dashboard.error} />
     </div>
+  );
+}
+
+function RecentSection({
+  summary,
+  loading,
+  error,
+}: {
+  summary: { recent: DashboardRecent[] } | undefined;
+  loading: boolean;
+  error: unknown;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Recent additions
+      </h2>
+      {loading && <p className="text-slate-400">Loading…</p>}
+      {error != null && <p className="text-rose-400">Failed to load.</p>}
+      {summary && summary.recent.length === 0 && !loading && (
+        <Card className="text-center text-slate-400">
+          Nothing here yet — pick a section above and click "+ Add" to start.
+        </Card>
+      )}
+      {summary && summary.recent.length > 0 && (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {summary.recent.map((r) => (
+            <Link key={`${r.type}-${r.id}`} to={`/${r.type}/${r.id}`} className="block">
+              <Card className="hover:border-indigo-500 transition-colors !p-3 flex gap-3 h-full">
+                {r.imagePath ? (
+                  <img
+                    src={r.imagePath}
+                    alt=""
+                    loading="lazy"
+                    className="w-12 h-16 object-cover rounded flex-none bg-slate-800"
+                  />
+                ) : (
+                  <div
+                    aria-hidden
+                    className="w-12 h-16 rounded flex-none bg-slate-800 border border-slate-700 flex items-center justify-center text-slate-600 text-[10px]"
+                  >
+                    no cover
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs uppercase tracking-wider text-slate-500">
+                    {TYPE_LABEL[r.type]}
+                  </div>
+                  <div className="text-sm font-medium text-white truncate">{r.title}</div>
+                  {r.year != null && <div className="text-xs text-slate-400">{r.year}</div>}
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -14,6 +14,39 @@ export function useList<T extends MediaType>(type: T, query: string) {
   });
 }
 
+export interface DashboardCounts {
+  movies: number;
+  music: number;
+  games: number;
+}
+
+export interface DashboardRecent {
+  type: MediaType;
+  id: number;
+  title: string;
+  year: number | null;
+  imagePath: string | null;
+  addedAt: string;
+}
+
+export interface DashboardSummary {
+  counts: DashboardCounts;
+  recent: DashboardRecent[];
+}
+
+/**
+ * Single-shot dashboard payload (per-type counts + the most recent
+ * additions across all three types). Replaces the old "fetch every
+ * list" approach so the home page renders without dragging the entire
+ * collection over the wire.
+ */
+export function useDashboard() {
+  return useQuery({
+    queryKey: ['dashboard'],
+    queryFn: () => api<DashboardSummary>('/api/dashboard'),
+  });
+}
+
 export function useItem<T extends MediaType>(type: T, id: number | undefined) {
   return useQuery({
     queryKey: [type, 'item', id],

--- a/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CoversEndpoints.cs
@@ -1,19 +1,31 @@
 using Collectify.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace Collectify.Api.Endpoints;
 
 public static class CoversEndpoints
 {
+    // Hashes are SHA-256-derived; resources at /covers/{hash} are
+    // immutable, so we can cache them aggressively. One year +
+    // "immutable" tells the browser it never needs to revalidate.
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+
     /// <summary>
     /// Streams cover-image bytes from the CoverImages table by content hash.
     /// Intentionally not auth-required so img tags work without a fetch
     /// dance; the hash is 16 hex chars derived from a URL the user already
     /// saw in their own collection, so they're effectively unguessable.
+    ///
+    /// Hash-keyed = immutable. Sets a strong ETag of the hash itself and
+    /// a one-year immutable Cache-Control. Conditional GETs that already
+    /// know the ETag short-circuit to a bare 304 -- no DB read for the
+    /// BLOB column, just headers.
     /// </summary>
     public static IEndpointRouteBuilder MapCoversEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/covers/{hash}", async (string hash, CollectifyDbContext db, CancellationToken ct) =>
+        app.MapGet("/covers/{hash}", async (string hash, CollectifyDbContext db, HttpContext http, CancellationToken ct) =>
         {
             // Public contract is a flat 16-char hex hash. Reject anything
             // else before touching the DB.
@@ -24,13 +36,47 @@ public static class CoversEndpoints
                 if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return Results.NotFound();
             }
 
+            // ETag is the hash itself, quoted (RFC 9110 §8.8.3). If the
+            // client already has it, skip the BLOB read entirely.
+            var etag = $"\"{hash}\"";
+            if (IfNoneMatchHit(http.Request.Headers.IfNoneMatch, etag))
+            {
+                http.Response.Headers[HeaderNames.ETag] = etag;
+                http.Response.Headers[HeaderNames.CacheControl] = ImmutableCacheControl;
+                return Results.StatusCode(StatusCodes.Status304NotModified);
+            }
+
             var entry = await db.CoverImages.AsNoTracking()
                 .FirstOrDefaultAsync(c => c.Hash == hash, ct);
             if (entry is null) return Results.NotFound();
 
+            http.Response.Headers[HeaderNames.ETag] = etag;
+            http.Response.Headers[HeaderNames.CacheControl] = ImmutableCacheControl;
             return Results.File(entry.Bytes, entry.ContentType);
         });
 
         return app;
+    }
+
+    private static bool IfNoneMatchHit(StringValues ifNoneMatch, string etag)
+    {
+        if (StringValues.IsNullOrEmpty(ifNoneMatch)) return false;
+        // Headers can be a comma-delimited list. RFC also allows '*'
+        // (which matches any current representation -- we honour it for
+        // completeness even though /covers/{hash} resources are
+        // immutable, so a hit is the right answer either way).
+        foreach (var raw in ifNoneMatch)
+        {
+            if (raw is null) continue;
+            foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (part == "*") return true;
+                // Be tolerant of weak validators ("W/\"hash\"") even
+                // though we only emit strong ones.
+                var trimmed = part.StartsWith("W/", StringComparison.Ordinal) ? part[2..] : part;
+                if (trimmed.Equals(etag, StringComparison.Ordinal)) return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/server/Collectify.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/DashboardEndpoints.cs
@@ -1,0 +1,83 @@
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Api.Endpoints;
+
+public static class DashboardEndpoints
+{
+    private const int RecentLimit = 6;
+
+    public record DashboardCounts(int Movies, int Music, int Games);
+
+    public record DashboardRecent(
+        string Type, // "movies" | "music" | "games"
+        int Id,
+        string Title,
+        int? Year,
+        string? ImagePath,
+        DateTime AddedAt);
+
+    public record DashboardSummary(DashboardCounts Counts, IReadOnlyList<DashboardRecent> Recent);
+
+    /// <summary>
+    /// One-shot dashboard payload: per-type counts + the N most recent
+    /// additions across all three types, owner-scoped. Replaces the
+    /// pull-all-three-lists dance the dashboard page used to do, so the
+    /// home page render is a single round-trip and doesn't drag entire
+    /// collections over the wire.
+    /// </summary>
+    public static IEndpointRouteBuilder MapDashboardEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/dashboard", async (
+            CollectifyDbContext db,
+            UserManager<AppUser> users,
+            HttpContext ctx,
+            CancellationToken ct) =>
+        {
+            var ownerId = users.GetUserId(ctx.User)!;
+
+            // Three lightweight COUNT(*) per-owner queries. Run them in
+            // parallel against the same DbContext is unsafe (EF doesn't
+            // allow concurrent operations on one context), so await
+            // each in sequence.
+            var movieCount = await db.Movies.CountAsync(m => m.OwnerId == ownerId, ct);
+            var musicCount = await db.MusicAlbums.CountAsync(a => a.OwnerId == ownerId, ct);
+            var gameCount = await db.Games.CountAsync(g => g.OwnerId == ownerId, ct);
+
+            // Each query asks for `RecentLimit` rows -- when we
+            // interleave them by AddedAt we keep at most `RecentLimit`
+            // of the combined stream, so larger pulls would be wasted.
+            var recentMovies = await db.Movies.AsNoTracking()
+                .Where(m => m.OwnerId == ownerId)
+                .OrderByDescending(m => m.AddedAt)
+                .Take(RecentLimit)
+                .Select(m => new DashboardRecent("movies", m.Id, m.Title, m.Year, m.ImagePath, m.AddedAt))
+                .ToListAsync(ct);
+            var recentMusic = await db.MusicAlbums.AsNoTracking()
+                .Where(a => a.OwnerId == ownerId)
+                .OrderByDescending(a => a.AddedAt)
+                .Take(RecentLimit)
+                .Select(a => new DashboardRecent("music", a.Id, a.Title, a.Year, a.ImagePath, a.AddedAt))
+                .ToListAsync(ct);
+            var recentGames = await db.Games.AsNoTracking()
+                .Where(g => g.OwnerId == ownerId)
+                .OrderByDescending(g => g.AddedAt)
+                .Take(RecentLimit)
+                .Select(g => new DashboardRecent("games", g.Id, g.Title, g.Year, g.ImagePath, g.AddedAt))
+                .ToListAsync(ct);
+
+            var recent = recentMovies.Concat(recentMusic).Concat(recentGames)
+                .OrderByDescending(r => r.AddedAt)
+                .Take(RecentLimit)
+                .ToList();
+
+            return Results.Ok(new DashboardSummary(
+                new DashboardCounts(movieCount, musicCount, gameCount),
+                recent));
+        }).RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddIgdbGameProvider(builder.Configuration);
 // rest of the data so a backup of collectify.db is a complete snapshot.
 builder.Services.AddHttpClient(CoverImageStore.HttpClientName);
 builder.Services.AddScoped<ICoverImageStore, CoverImageStore>();
+builder.Services.AddScoped<CoverImageGarbageCollector>();
 
 var app = builder.Build();
 
@@ -90,6 +91,10 @@ using (var scope = app.Services.CreateScope())
     // ConvertGamePlatformToEnum migration preserved in PlatformLegacy.
     // No-ops on a fresh DB or once everything's resolved.
     await GamePlatformBackfill.RunAsync(db);
+    // Drop CoverImages rows no longer referenced by any owning entity.
+    // Keeps the CoverImages table bounded as users re-scan / relookup
+    // metadata over time.
+    await scope.ServiceProvider.GetRequiredService<CoverImageGarbageCollector>().SweepAsync(db);
 }
 
 app.UseAuthentication();
@@ -102,6 +107,7 @@ app.MapGamesEndpoints();
 app.MapTagEndpoints();
 app.MapLookupEndpoints();
 app.MapCoversEndpoints();
+app.MapDashboardEndpoints();
 
 app.MapGet("/api/health", () => Results.Ok(new { status = "ok" }));
 

--- a/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageGarbageCollector.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/Images/CoverImageGarbageCollector.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Collectify.Infrastructure.Lookup.Images;
+
+/// <summary>
+/// One-shot sweep that removes <c>CoverImages</c> rows no longer
+/// referenced by any movie / album / game <c>ImagePath</c>. Run at app
+/// startup after migrations so a long-running install with lots of
+/// metadata churn (lookup-then-replace, scan-then-rescan, etc.) doesn't
+/// grow the CoverImages table without bound.
+///
+/// Safety nets:
+/// - A grace window (default 1h) keeps very recently-added covers even
+///   if they don't have a referrer yet -- protects against a race
+///   where the cover lands in the table before the owning entity is
+///   written.
+/// - Reference extraction is conservative: anything that looks like
+///   <c>/covers/&lt;hex&gt;</c> in an ImagePath counts as a reference.
+///   Other column values (legacy filesystem paths, raw provider URLs
+///   that didn't get re-hosted) don't pull any covers.
+/// </summary>
+public sealed class CoverImageGarbageCollector
+{
+    private readonly TimeProvider _clock;
+    private readonly ILogger<CoverImageGarbageCollector> _log;
+
+    public CoverImageGarbageCollector(TimeProvider clock, ILogger<CoverImageGarbageCollector> log)
+    {
+        _clock = clock;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Sweeps orphaned covers. Returns the number of rows deleted.
+    /// </summary>
+    /// <param name="grace">Minimum age a cover must have before it
+    /// becomes eligible for deletion. Defaults to 1 hour so newly-added
+    /// covers can't be GC'd mid-save.</param>
+    public async Task<int> SweepAsync(Data.CollectifyDbContext db, TimeSpan? grace = null, CancellationToken ct = default)
+    {
+        var graceWindow = grace ?? TimeSpan.FromHours(1);
+        var cutoff = _clock.GetUtcNow().UtcDateTime - graceWindow;
+
+        // Pull every cover path stored on any owning entity. We could
+        // do this in one big UNION query but the three tables are
+        // narrow and per-user, so the round-trip is cheap and the C#
+        // is easier to read.
+        var moviePaths = await db.Movies.AsNoTracking()
+            .Where(m => m.ImagePath != null).Select(m => m.ImagePath!).ToListAsync(ct);
+        var musicPaths = await db.MusicAlbums.AsNoTracking()
+            .Where(a => a.ImagePath != null).Select(a => a.ImagePath!).ToListAsync(ct);
+        var gamePaths = await db.Games.AsNoTracking()
+            .Where(g => g.ImagePath != null).Select(g => g.ImagePath!).ToListAsync(ct);
+
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var p in moviePaths.Concat(musicPaths).Concat(gamePaths))
+        {
+            if (TryExtractHash(p, out var hash)) referenced.Add(hash);
+        }
+
+        // ExecuteDeleteAsync emits a single DELETE with the predicate,
+        // no tracking, no per-row roundtrips. The .NET enumeration of
+        // `referenced.Contains(...)` is translated to a SQL `WHERE Hash
+        // NOT IN (…)` which is fine at our cardinality.
+        var deleted = await db.CoverImages
+            .Where(c => c.AddedAt < cutoff && !referenced.Contains(c.Hash))
+            .ExecuteDeleteAsync(ct);
+
+        if (deleted > 0)
+            _log.LogInformation("Cover GC: removed {Count} orphaned cover(s)", deleted);
+        return deleted;
+    }
+
+    /// <summary>
+    /// Pulls the 8-32 char hex hash out of an <c>ImagePath</c> like
+    /// <c>/covers/abcd1234ef</c>. Returns false for any other shape
+    /// (raw provider URLs, empty strings, etc.) so foreign references
+    /// don't accidentally pin a cover row.
+    /// </summary>
+    public static bool TryExtractHash(string? imagePath, out string hash)
+    {
+        hash = string.Empty;
+        if (string.IsNullOrEmpty(imagePath)) return false;
+        const string prefix = "/covers/";
+        if (!imagePath.StartsWith(prefix, StringComparison.Ordinal)) return false;
+
+        var candidate = imagePath.AsSpan(prefix.Length);
+        if (candidate.Length is < 8 or > 32) return false;
+        foreach (var c in candidate)
+        {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+        }
+        hash = candidate.ToString();
+        return true;
+    }
+}

--- a/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/CoversEndpointsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using Collectify.Domain.Entities;
 using Collectify.Tests.Infrastructure;
 
@@ -70,5 +71,96 @@ public class CoversEndpointsTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    // ---------- ETag / Cache-Control ----------
+
+    [Fact]
+    public async Task Get_HitSetsImmutableCacheControlAndEtag()
+    {
+        await using var factory = new CollectifyApiFactory();
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "abc1234567890def",
+            ContentType = "image/jpeg",
+            Bytes = [0xFF, 0xD8, 0xFF],
+        });
+
+        var response = await factory.CreateClient().GetAsync("/covers/abc1234567890def");
+
+        Assert.Equal("\"abc1234567890def\"", response.Headers.ETag?.ToString());
+        Assert.NotNull(response.Headers.CacheControl);
+        Assert.True(response.Headers.CacheControl!.Public);
+        Assert.Equal(TimeSpan.FromDays(365), response.Headers.CacheControl.MaxAge);
+        // The "immutable" extension isn't a strongly-typed property on
+        // CacheControlHeaderValue, so check the raw header.
+        var raw = string.Join(",", response.Headers.GetValues("Cache-Control"));
+        Assert.Contains("immutable", raw);
+    }
+
+    [Fact]
+    public async Task Get_WithMatchingIfNoneMatch_Returns304NoBody()
+    {
+        await using var factory = new CollectifyApiFactory();
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "abc1234567890def",
+            ContentType = "image/jpeg",
+            Bytes = [0xFF, 0xD8, 0xFF],
+        });
+
+        var client = factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/covers/abc1234567890def");
+        req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"abc1234567890def\""));
+        var response = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        // Browsers + caches expect ETag + Cache-Control to come back on
+        // 304s too, so they can re-prime their cache.
+        Assert.Equal("\"abc1234567890def\"", response.Headers.ETag?.ToString());
+        Assert.NotNull(response.Headers.CacheControl);
+        // 304 must not carry a body.
+        var body = await response.Content.ReadAsByteArrayAsync();
+        Assert.Empty(body);
+    }
+
+    [Fact]
+    public async Task Get_WithStarIfNoneMatch_Returns304()
+    {
+        // RFC 9110 §13.1.2: '*' matches any current representation.
+        await using var factory = new CollectifyApiFactory();
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "abc1234567890def",
+            ContentType = "image/jpeg",
+            Bytes = [0xFF, 0xD8, 0xFF],
+        });
+
+        var client = factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/covers/abc1234567890def");
+        req.Headers.TryAddWithoutValidation("If-None-Match", "*");
+        var response = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithStaleIfNoneMatch_Returns200AndFreshEtag()
+    {
+        await using var factory = new CollectifyApiFactory();
+        await factory.SeedAsync(new CoverImage
+        {
+            Hash = "abc1234567890def",
+            ContentType = "image/jpeg",
+            Bytes = [0xFF, 0xD8, 0xFF],
+        });
+
+        var client = factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/covers/abc1234567890def");
+        req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"stale1234567890\""));
+        var response = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("\"abc1234567890def\"", response.Headers.ETag?.ToString());
     }
 }

--- a/src/server/tests/Collectify.Tests/Api/DashboardEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/DashboardEndpointsTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
+using Collectify.Tests.Infrastructure;
+
+namespace Collectify.Tests.Api;
+
+public class DashboardEndpointsTests
+{
+    private record DashboardCounts(int Movies, int Music, int Games);
+    private record DashboardRecent(
+        string Type, int Id, string Title, int? Year, string? ImagePath, DateTime AddedAt);
+    private record DashboardSummary(DashboardCounts Counts, DashboardRecent[] Recent);
+
+    [Fact]
+    public async Task Get_Unauthenticated_ReturnsUnauthorized()
+    {
+        await using var factory = new CollectifyApiFactory();
+
+        var response = await factory.CreateClient().GetAsync("/api/dashboard");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_EmptyCollection_ReturnsZeroCountsAndEmptyRecent()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var body = await alice.Client.GetJsonAsync<DashboardSummary>("/api/dashboard");
+
+        Assert.NotNull(body);
+        Assert.Equal(0, body!.Counts.Movies);
+        Assert.Equal(0, body.Counts.Music);
+        Assert.Equal(0, body.Counts.Games);
+        Assert.Empty(body.Recent);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsCountsScopedToTheCurrentOwner()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var bob = await factory.CreateAuthenticatedUserAsync("bob");
+
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception" });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet" });
+        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "OK Computer", ArtistName = "Radiohead", Format = MusicFormat.Cd });
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
+        // Bob's row -- must not appear in Alice's counts.
+        await factory.SeedAsync(new Movie { OwnerId = bob.Id, Title = "Bob's movie" });
+
+        var body = await alice.Client.GetJsonAsync<DashboardSummary>("/api/dashboard");
+
+        Assert.Equal(2, body!.Counts.Movies);
+        Assert.Equal(1, body.Counts.Music);
+        Assert.Equal(1, body.Counts.Games);
+    }
+
+    [Fact]
+    public async Task Get_RecentIsInterleavedByAddedAtDescAndCappedAt6()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        var t0 = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        // Seed across types out of chronological order so the endpoint
+        // really has to merge by AddedAt and not by source list.
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Old movie", AddedAt = t0 });
+        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Newer album", ArtistName = "x", Format = MusicFormat.Cd, AddedAt = t0.AddMinutes(3) });
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Newest game", Platform = GamePlatform.Pc, AddedAt = t0.AddMinutes(5) });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Mid movie", AddedAt = t0.AddMinutes(2) });
+
+        // Pad past the 6-item cap so we can confirm the limit.
+        for (int i = 0; i < 4; i++)
+        {
+            await factory.SeedAsync(new Movie
+            {
+                OwnerId = alice.Id, Title = $"Filler {i}", AddedAt = t0.AddSeconds(i),
+            });
+        }
+
+        var body = await alice.Client.GetJsonAsync<DashboardSummary>("/api/dashboard");
+
+        Assert.NotNull(body);
+        Assert.Equal(6, body!.Recent.Length);
+        // Sorted by AddedAt desc -- verify the top three are the
+        // explicitly-distinct entries we seeded.
+        Assert.Equal("Newest game", body.Recent[0].Title);
+        Assert.Equal("Newer album", body.Recent[1].Title);
+        Assert.Equal("Mid movie", body.Recent[2].Title);
+        // Type discriminator round-trips per row.
+        Assert.Equal("games", body.Recent[0].Type);
+        Assert.Equal("music", body.Recent[1].Type);
+        Assert.Equal("movies", body.Recent[2].Type);
+    }
+
+    [Fact]
+    public async Task Get_RecentEntriesIncludeIdYearAndImagePath()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var m = await factory.SeedAsync(new Movie
+        {
+            OwnerId = alice.Id,
+            Title = "Inception",
+            Year = 2010,
+            ImagePath = "/covers/abc1234567890def",
+        });
+
+        var body = await alice.Client.GetJsonAsync<DashboardSummary>("/api/dashboard");
+
+        var hit = Assert.Single(body!.Recent);
+        Assert.Equal(m.Id, hit.Id);
+        Assert.Equal(2010, hit.Year);
+        Assert.Equal("/covers/abc1234567890def", hit.ImagePath);
+    }
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/CoverImageGarbageCollectorTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CoverImageGarbageCollectorTests.cs
@@ -1,0 +1,163 @@
+using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
+using Collectify.Infrastructure.Data;
+using Collectify.Infrastructure.Lookup.Images;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public class CoverImageGarbageCollectorTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<CollectifyDbContext> _options;
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero));
+
+    public CoverImageGarbageCollectorTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
+        using var seed = new CollectifyDbContext(_options);
+        seed.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private CoverImageGarbageCollector NewGc() =>
+        new(_clock, NullLogger<CoverImageGarbageCollector>.Instance);
+
+    private static CoverImage Cover(string hash, DateTime addedAt) => new()
+    {
+        Hash = hash,
+        ContentType = "image/jpeg",
+        Bytes = [0xFF, 0xD8, 0xFF],
+        AddedAt = addedAt,
+    };
+
+    [Fact]
+    public async Task SweepAsync_DeletesUnreferencedCoversPastTheGraceWindow()
+    {
+        var now = _clock.GetUtcNow().UtcDateTime;
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            db.CoverImages.AddRange(
+                Cover("aaaa1111aaaa1111", now.AddDays(-10)), // referenced by movie
+                Cover("bbbb2222bbbb2222", now.AddDays(-10)), // referenced by album
+                Cover("cccc3333cccc3333", now.AddDays(-10)), // referenced by game
+                Cover("dddd4444dddd4444", now.AddDays(-10)) // orphan
+            );
+            db.Movies.Add(new Movie { OwnerId = "alice", Title = "Movie", ImagePath = "/covers/aaaa1111aaaa1111" });
+            db.MusicAlbums.Add(new MusicAlbum { OwnerId = "alice", Title = "Album", ArtistName = "x", Format = MusicFormat.Cd, ImagePath = "/covers/bbbb2222bbbb2222" });
+            db.Games.Add(new Game { OwnerId = "alice", Title = "Game", Platform = GamePlatform.Pc, ImagePath = "/covers/cccc3333cccc3333" });
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            var deleted = await NewGc().SweepAsync(db);
+            Assert.Equal(1, deleted);
+        }
+
+        await using (var assert = new CollectifyDbContext(_options))
+        {
+            var hashes = assert.CoverImages.Select(c => c.Hash).OrderBy(h => h).ToList();
+            Assert.Equal(new[] { "aaaa1111aaaa1111", "bbbb2222bbbb2222", "cccc3333cccc3333" }, hashes);
+        }
+    }
+
+    [Fact]
+    public async Task SweepAsync_KeepsRecentlyAddedOrphansUntilTheyAgeOut()
+    {
+        // A cover that's an orphan *right now* but was added 5 minutes
+        // ago might belong to an entity that's still mid-save. Default
+        // grace is 1 hour, so it survives the sweep.
+        var now = _clock.GetUtcNow().UtcDateTime;
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            db.CoverImages.Add(Cover("ffff9999ffff9999", now.AddMinutes(-5)));
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            var deleted = await NewGc().SweepAsync(db);
+            Assert.Equal(0, deleted);
+        }
+
+        await using (var assert = new CollectifyDbContext(_options))
+        {
+            Assert.Single(assert.CoverImages);
+        }
+    }
+
+    [Fact]
+    public async Task SweepAsync_IgnoresImagePathsThatArentCoverHashes()
+    {
+        // Legacy filesystem paths and raw provider URLs aren't pointers
+        // into the CoverImages table; they must not pin anything.
+        var now = _clock.GetUtcNow().UtcDateTime;
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            db.CoverImages.Add(Cover("eeee5555eeee5555", now.AddDays(-2)));
+            db.Movies.Add(new Movie
+            {
+                OwnerId = "alice",
+                Title = "Old",
+                ImagePath = "https://example.com/some-poster.jpg", // raw URL
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            var deleted = await NewGc().SweepAsync(db);
+            Assert.Equal(1, deleted);
+        }
+
+        await using (var assert = new CollectifyDbContext(_options))
+        {
+            Assert.Empty(assert.CoverImages);
+        }
+    }
+
+    [Fact]
+    public async Task SweepAsync_OnEmptyOrAllReferenced_IsANoOp()
+    {
+        var now = _clock.GetUtcNow().UtcDateTime;
+        await using (var db = new CollectifyDbContext(_options))
+        {
+            db.CoverImages.Add(Cover("aaaa1111aaaa1111", now.AddDays(-2)));
+            db.Movies.Add(new Movie { OwnerId = "alice", Title = "M", ImagePath = "/covers/aaaa1111aaaa1111" });
+            await db.SaveChangesAsync();
+        }
+
+        await using var db2 = new CollectifyDbContext(_options);
+        Assert.Equal(0, await NewGc().SweepAsync(db2));
+    }
+
+    [Theory]
+    [InlineData("/covers/abc12345", "abc12345")]
+    [InlineData("/covers/deadbeefcafe1234", "deadbeefcafe1234")]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("https://image.tmdb.org/t/p/w342/poster.jpg", null)]
+    [InlineData("/covers/", null)]
+    [InlineData("/covers/HASWITHNONHEX", null)]
+    [InlineData("/covers/way-too-long-to-possibly-be-a-cover-hash", null)]
+    public void TryExtractHash_OnlyAcceptsTheCoverPathShape(string? input, string? expected)
+    {
+        var got = CoverImageGarbageCollector.TryExtractHash(input, out var hash);
+        if (expected is null)
+        {
+            Assert.False(got);
+        }
+        else
+        {
+            Assert.True(got);
+            Assert.Equal(expected, hash);
+        }
+    }
+}


### PR DESCRIPTION
Three polish items in one sweep, all server-or-frontend-local with clear test boundaries:

1. **`/covers/{hash}` immutable caching** — strong ETag + 1y immutable `Cache-Control` + `If-None-Match` short-circuit. Conditional GETs skip the BLOB read entirely.
2. **Cover GC** — one-shot startup sweep that drops `CoverImages` rows no referenced by any movie / album / game `ImagePath`. Bounded growth without manual janitorial work.
3. **`GET /api/dashboard`** — single payload (counts + recent additions across all three types). Home page no longer fetches three whole lists just to render numbers.

## Summary

### 1. Covers — ETag + immutable cache

- Strong ETag of the hash itself (quoted, per RFC 9110 §8.8.3).
- `Cache-Control: public, max-age=31536000, immutable` — hash is SHA-256-derived, resource is genuinely immutable.
- `If-None-Match` handling: matching ETag (or `*`) returns 304 + ETag + Cache-Control **before** the BLOB column is read. Tolerates weak validators (`W/"…"`) even though only strong ones are emitted.

### 2. Cover GC

- `CoverImageGarbageCollector.SweepAsync(db, grace?)` — single query that finds every cover referenced by `Movies.ImagePath` / `MusicAlbums.ImagePath` / `Games.ImagePath`, then `ExecuteDeleteAsync` everything else past a 1-hour grace window.
- Reference extraction is conservative: only `/covers/<hex>` paths pin a row (legacy filesystem paths and raw provider URLs don't keep stale rows alive).
- Wired into `Program.cs` after the existing migration + `GamePlatformBackfill` step. Idempotent — no-op once everything resolved.

### 3. `GET /api/dashboard`

- Returns `{ counts: { movies, music, games }, recent: DashboardRecent[6] }`, owner-scoped via cookie auth.
- `recent` is interleaved across all three types and sorted by `AddedAt` desc (each per-type query asks for at most 6 rows, so the merge can't pull more than 6 of the combined stream).
- Replaces the dashboard page's "fetch every list to count rows" dance — a single `useDashboard()` query handles both counts + recent.

### Client

- `services/collection.ts` — `useDashboard()` hook + types (`DashboardSummary` / `DashboardCounts` / `DashboardRecent`).
- `pages/Dashboard.tsx` — refactored to a single query; new "Recent additions" section under the count tiles with type label, thumbnail (or "no cover" placeholder), title, year, and a deep-link to the detail page.

## Test plan

### CI
- [x] `dotnet test` — **server 271 / 271** (was 250; +21 new).
- [x] `npm test -- --run` — **client 59 / 59** unchanged.
- [x] Server + Vite builds clean.

### `CoversEndpointsTests` (+4)
- `ETag` header lands on hit with quoted hash; `Cache-Control` has `public`, `max-age=31536000`, and the `immutable` extension.
- `If-None-Match` with the matching ETag → 304 with ETag + Cache-Control echoed and no body.
- `If-None-Match: *` → 304.
- Stale `If-None-Match` → 200 with the fresh ETag.

### `CoverImageGarbageCollectorTests` (4 cases + 1 theory)
- Unreferenced past the grace window gets deleted; referenced rows stay.
- Recently-added orphans (younger than grace) survive.
- Foreign URLs (raw provider URLs in `ImagePath`) don't pin anything — true orphans still get reaped.
- No-op when empty / all-referenced.
- `TryExtractHash` theory: only `/covers/<hex>` of valid length returns a hash; everything else returns false.

### `DashboardEndpointsTests` (5)
- Unauthenticated → 401.
- Empty collection → all-zero counts + empty recent.
- Counts are owner-scoped (bob's rows don't leak into alice's response).
- Recent is interleaved by `AddedAt` desc and capped at 6 across the three types; type discriminator round-trips per row.
- `year` / `imagePath` round-trip on a single entry.

### Manual
- [x] Boot the app, open `/`. Counts populate; recent additions show the last few items with thumbnails.
- [x] Reload `/movies` or any list page after a cover has been served — DevTools network tab shows the cover request as a 304 (or "(disk cache)") after the first paint.
- [x] Add an entry with a cover, edit it to use a different cover. Restart the server; the previous cover row is gone after the startup sweep.
- [x] Manually insert a fresh orphan via SQL with `AddedAt = now()`; restart; it survives the sweep (grace window).

## Out of scope (future)

- **Conditional GET on the list endpoints** — `ETag` is most useful for cacheable static content; per-user list endpoints change on every save, so the win is smaller.
- **HTTP `Vary` headers** — we don't vary by Accept-Encoding or Accept; the BLOBs are pre-compressed JPEG/PNG.
- **Manual `/api/admin/gc-covers` trigger** — startup sweep is enough for a single-user install.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_