### PR TITLE
feat: toast notifications + opt-in user registration (closes #29)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,9 +1,11 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useAuth } from './services/auth';
 import Layout from './components/Layout';
+import { Toaster } from './components/toaster';
 import Dashboard from './pages/Dashboard';
 import Setup from './pages/Setup';
 import Login from './pages/Login';
+import Register from './pages/Register';
 import MoviesList from './pages/MoviesList';
 import MusicList from './pages/MusicList';
 import GamesList from './pages/GamesList';
@@ -18,21 +20,30 @@ export default function App() {
     return <div className="p-8 text-slate-400">Loading…</div>;
   }
 
+  // Toaster is mounted outside the auth-state branches so success
+  // toasts survive the navigate after login / logout / setup.
   if (auth?.needsSetup) {
     return (
-      <Routes>
-        <Route path="/setup" element={<Setup />} />
-        <Route path="*" element={<Navigate to="/setup" replace />} />
-      </Routes>
+      <>
+        <Routes>
+          <Route path="/setup" element={<Setup />} />
+          <Route path="*" element={<Navigate to="/setup" replace />} />
+        </Routes>
+        <Toaster />
+      </>
     );
   }
 
   if (!auth?.isAuthenticated) {
     return (
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </Routes>
+      <>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          {auth?.allowRegistration && <Route path="/register" element={<Register />} />}
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
+        <Toaster />
+      </>
     );
   }
 
@@ -52,6 +63,7 @@ export default function App() {
         <Route path="/tags" element={<TagsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      <Toaster />
     </Layout>
   );
 }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useAuth, useLogout } from '../services/auth';
+import { useToast } from './toaster';
 
 const navItem = ({ isActive }: { isActive: boolean }) =>
   `px-3 py-2 rounded-md text-sm font-medium ${
@@ -10,6 +11,7 @@ const navItem = ({ isActive }: { isActive: boolean }) =>
 export default function Layout({ children }: { children: ReactNode }) {
   const { data: auth } = useAuth();
   const logout = useLogout();
+  const toast = useToast();
 
   return (
     <div className="min-h-full flex flex-col">
@@ -25,7 +27,9 @@ export default function Layout({ children }: { children: ReactNode }) {
           <div className="flex items-center gap-3 text-sm text-slate-400">
             <span className="hidden sm:inline">{auth?.userName}</span>
             <button
-              onClick={() => logout.mutate()}
+              onClick={() =>
+                logout.mutate(undefined, { onSuccess: () => toast.success('Signed out.') })
+              }
               className="text-slate-300 hover:text-white"
             >
               Sign out

--- a/src/client/components/toaster.test.tsx
+++ b/src/client/components/toaster.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Toaster, toast, _resetToasts } from './toaster';
+
+afterEach(() => {
+  // Real timers FIRST so the act-wrapped emit() that resetToasts fires
+  // doesn't get queued behind a fake timer flush.
+  vi.useRealTimers();
+  act(() => _resetToasts());
+});
+
+describe('Toaster', () => {
+  it('renders nothing when the queue is empty', () => {
+    const { container } = render(<Toaster />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a success toast as role=status', () => {
+    render(<Toaster />);
+    act(() => {
+      toast.success('Saved.');
+    });
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('Saved.');
+  });
+
+  it('renders an error toast as role=alert', () => {
+    render(<Toaster />);
+    act(() => {
+      toast.error('Boom.');
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Boom.');
+  });
+
+  it('auto-dismisses a success toast after its TTL', () => {
+    vi.useFakeTimers();
+    render(<Toaster />);
+    act(() => {
+      toast.success('Saved.');
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('keeps an error toast visible past the auto-dismiss window', () => {
+    vi.useFakeTimers();
+    render(<Toaster />);
+    act(() => {
+      toast.error('Boom.');
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('dismisses on the close button click', async () => {
+    render(<Toaster />);
+    act(() => {
+      toast.error('Boom.');
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('caps the visible stack to the four most-recent toasts', () => {
+    render(<Toaster />);
+    act(() => {
+      for (let i = 0; i < 6; i++) toast.error(`E ${i}`);
+    });
+
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(4);
+    // FIFO eviction: oldest two dropped, newest four remain in order.
+    expect(alerts[0]).toHaveTextContent('E 2');
+    expect(alerts[alerts.length - 1]).toHaveTextContent('E 5');
+  });
+});

--- a/src/client/components/toaster.tsx
+++ b/src/client/components/toaster.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+
+export type ToastKind = 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+// Module-level so any component can fire a toast without prop-drilling
+// a provider. The single <Toaster> mounted at the app root subscribes
+// to changes and re-renders the stack. Tests can drive the store
+// directly via useToast() inside a render.
+let toasts: Toast[] = [];
+const listeners = new Set<() => void>();
+let nextId = 1;
+
+const SUCCESS_TTL_MS = 2500;
+const INFO_TTL_MS = 4000;
+const MAX_STACK = 4;
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function push(kind: ToastKind, message: string): number {
+  const id = nextId++;
+  toasts = [...toasts, { id, kind, message }];
+  // Trim from the head when the stack overflows so the newest toast is
+  // always visible. We don't try to merge duplicates -- a busy save
+  // batch should show every result.
+  if (toasts.length > MAX_STACK) toasts = toasts.slice(toasts.length - MAX_STACK);
+  emit();
+
+  // Errors stay until the user dismisses them; success/info auto-fade.
+  if (kind === 'success') setTimeout(() => dismiss(id), SUCCESS_TTL_MS);
+  if (kind === 'info') setTimeout(() => dismiss(id), INFO_TTL_MS);
+
+  return id;
+}
+
+function dismissImpl(id: number) {
+  const before = toasts.length;
+  toasts = toasts.filter((t) => t.id !== id);
+  if (toasts.length !== before) emit();
+}
+
+/**
+ * Module-level imperative API. Usable from any module without a hook
+ * call -- handy outside React (e.g. interceptors, helpers) and inside
+ * tests. The <code>useToast()</code> hook just returns this same
+ * object so components and non-components share semantics.
+ */
+export const toast = {
+  success: (message: string) => push('success', message),
+  error: (message: string) => push('error', message),
+  info: (message: string) => push('info', message),
+  dismiss: dismissImpl,
+};
+
+/** Re-export for legacy call sites; identical to toast.dismiss. */
+export const dismiss = dismissImpl;
+
+/**
+ * Test-only: drop every queued toast. Production code should not call
+ * this -- toasts auto-dismiss on their own.
+ */
+export function _resetToasts() {
+  toasts = [];
+  nextId = 1;
+  emit();
+}
+
+/** Hook flavour for components that prefer dependency injection. */
+export function useToast() {
+  return toast;
+}
+
+/**
+ * Root-mounted toast renderer. Bottom-right on >= sm; bottom-center on
+ * mobile so it doesn't fight the on-screen keyboard. Success / info
+ * land as role=status (announced politely); errors as role=alert
+ * (announced assertively).
+ */
+export function Toaster() {
+  // useState/setTick triggers a re-render whenever the module store
+  // changes. Storing the toasts list directly would defeat the
+  // module-level singleton because each <Toaster> would get its own
+  // copy.
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const listener = () => setTick((t) => t + 1);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      // The container is purely structural; per-toast role/aria-live
+      // attributes do the announcing.
+      className="fixed z-50 bottom-4 right-4 flex flex-col gap-2 items-end max-w-[calc(100%-2rem)]"
+    >
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role={t.kind === 'error' ? 'alert' : 'status'}
+          aria-live={t.kind === 'error' ? 'assertive' : 'polite'}
+          className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm shadow-lg min-w-[16rem] max-w-md ${styleFor(t.kind)}`}
+        >
+          <span className="flex-1 break-words">{t.message}</span>
+          <button
+            type="button"
+            onClick={() => dismiss(t.id)}
+            aria-label="Dismiss notification"
+            className="opacity-70 hover:opacity-100"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function styleFor(kind: ToastKind): string {
+  switch (kind) {
+    case 'success':
+      return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100';
+    case 'error':
+      return 'border-rose-500/40 bg-rose-500/10 text-rose-100';
+    case 'info':
+      return 'border-slate-500/40 bg-slate-700/40 text-slate-100';
+  }
+}

--- a/src/client/pages/AddPage.tsx
+++ b/src/client/pages/AddPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useCreate } from '../services/collection';
+import { useToast } from '../components/toaster';
 import type { Album, Game, MediaType, Movie } from '../services/types';
 import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
 import MovieForm from '../components/MovieForm';
@@ -25,63 +25,36 @@ const titleByType: Record<MediaType, string> = {
   games: 'Add a game',
 };
 
+const successByType: Record<MediaType, string> = {
+  movies: 'Movie added.',
+  music: 'Album added.',
+  games: 'Game added.',
+};
+
 export default function AddPage<T extends MediaType>({ type }: { type: T }) {
   const create = useCreate(type);
   const nav = useNavigate();
   const location = useLocation();
+  const toast = useToast();
   const navState = location.state as PrefillState | null;
   const prefill = navState?.prefill;
   const prefillBarcode = navState?.barcodeOnly;
 
-  // Persisted-feedback so the success banner can stay on screen briefly
-  // before we redirect to the detail page.
-  const [feedback, setFeedback] = useState<
-    | { kind: 'idle' }
-    | { kind: 'success'; message: string }
-    | { kind: 'error'; message: string }
-  >({ kind: 'idle' });
-
-  // Surface server / network errors as a banner instead of just a small
-  // line under the form. The mutation reports the latest error via
-  // create.error, but it's clearer to mirror it into our feedback state
-  // so the success / error visuals share one slot.
-  useEffect(() => {
-    if (create.error) {
-      setFeedback({ kind: 'error', message: (create.error as Error).message });
-    }
-  }, [create.error]);
-
   const onSuccess = (id?: number) => {
-    setFeedback({ kind: 'success', message: 'Saved! Redirecting…' });
-    // Brief hold so the user sees the banner; the page navigates after.
-    setTimeout(() => {
-      if (id) nav(`/${type}/${id}`);
-      else nav(`/${type}`);
-    }, 600);
+    // Toast survives the navigate so the user gets a confirmation on
+    // the detail page they land on.
+    toast.success(successByType[type]);
+    if (id) nav(`/${type}/${id}`);
+    else nav(`/${type}`);
+  };
+
+  const onFailure = (err: unknown) => {
+    toast.error(`Failed to save: ${(err as Error).message ?? 'unknown error'}`);
   };
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold text-white">{titleByType[type]}</h1>
-
-      {feedback.kind === 'success' && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200"
-        >
-          {feedback.message}
-        </div>
-      )}
-      {feedback.kind === 'error' && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
-        >
-          Failed to save: {feedback.message}
-        </div>
-      )}
 
       <Card>
         {type === 'movies' && (
@@ -93,6 +66,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
             onSubmit={(m) =>
               create.mutate(m as Movie & Album & Game, {
                 onSuccess: (created: any) => onSuccess(created?.id),
+                onError: onFailure,
               })
             }
           />
@@ -106,6 +80,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
             onSubmit={(a) =>
               create.mutate(a as Movie & Album & Game, {
                 onSuccess: (created: any) => onSuccess(created?.id),
+                onError: onFailure,
               })
             }
           />
@@ -119,6 +94,7 @@ export default function AddPage<T extends MediaType>({ type }: { type: T }) {
             onSubmit={(g) =>
               create.mutate(g as Movie & Album & Game, {
                 onSuccess: (created: any) => onSuccess(created?.id),
+                onError: onFailure,
               })
             }
           />

--- a/src/client/pages/EditPage.tsx
+++ b/src/client/pages/EditPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDelete, useItem, useUpdate } from '../services/collection';
+import { useToast } from '../components/toaster';
 import type { Album, Game, MediaType, Movie } from '../services/types';
 import MovieForm from '../components/MovieForm';
 import AlbumForm from '../components/AlbumForm';
@@ -13,6 +13,12 @@ const titleByType: Record<MediaType, string> = {
   games: 'Edit game',
 };
 
+const deletedByType: Record<MediaType, string> = {
+  movies: 'Movie deleted.',
+  music: 'Album deleted.',
+  games: 'Game deleted.',
+};
+
 export default function EditPage<T extends MediaType>({ type }: { type: T }) {
   const { id } = useParams<{ id: string }>();
   const idNum = id ? Number(id) : undefined;
@@ -20,28 +26,7 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
   const update = useUpdate(type);
   const del = useDelete(type);
   const nav = useNavigate();
-
-  // Save feedback shared between success and error so the visuals
-  // mirror AddPage. Success auto-clears; error sticks until the next
-  // attempt.
-  const [feedback, setFeedback] = useState<
-    | { kind: 'idle' }
-    | { kind: 'success'; message: string }
-    | { kind: 'error'; message: string }
-  >({ kind: 'idle' });
-
-  useEffect(() => {
-    if (update.error) {
-      setFeedback({ kind: 'error', message: (update.error as Error).message });
-    }
-  }, [update.error]);
-
-  // Auto-clear the success banner so it doesn't linger forever.
-  useEffect(() => {
-    if (feedback.kind !== 'success') return;
-    const t = setTimeout(() => setFeedback({ kind: 'idle' }), 2000);
-    return () => clearTimeout(t);
-  }, [feedback.kind]);
+  const toast = useToast();
 
   if (item.isLoading) return <p className="text-slate-400">Loading…</p>;
   if (item.error || !item.data) return <p className="text-rose-400">Not found.</p>;
@@ -49,40 +34,29 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
   const onDelete = () => {
     if (!idNum) return;
     if (!confirm('Delete this entry?')) return;
-    del.mutate(idNum, { onSuccess: () => nav(`/${type}`) });
+    del.mutate(idNum, {
+      onSuccess: () => {
+        toast.success(deletedByType[type]);
+        nav(`/${type}`);
+      },
+      onError: (err) => toast.error(`Failed to delete: ${(err as Error).message ?? 'unknown error'}`),
+    });
   };
 
-  const onSaved = () => setFeedback({ kind: 'success', message: 'Saved.' });
+  const onSaved = () => toast.success('Saved.');
+  const onSaveFailure = (err: unknown) =>
+    toast.error(`Failed to save: ${(err as Error).message ?? 'unknown error'}`);
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold text-white">{titleByType[type]}</h1>
-
-      {feedback.kind === 'success' && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200"
-        >
-          {feedback.message}
-        </div>
-      )}
-      {feedback.kind === 'error' && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
-        >
-          Failed to save: {feedback.message}
-        </div>
-      )}
 
       <Card>
         {type === 'movies' && (
           <MovieForm
             initial={item.data as Movie}
             submitting={update.isPending}
-            onSubmit={(m) => update.mutate({ ...m, id: idNum! } as any, { onSuccess: onSaved })}
+            onSubmit={(m) => update.mutate({ ...m, id: idNum! } as any, { onSuccess: onSaved, onError: onSaveFailure })}
             onDelete={onDelete}
           />
         )}
@@ -90,7 +64,7 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
           <AlbumForm
             initial={item.data as Album}
             submitting={update.isPending}
-            onSubmit={(a) => update.mutate({ ...a, id: idNum! } as any, { onSuccess: onSaved })}
+            onSubmit={(a) => update.mutate({ ...a, id: idNum! } as any, { onSuccess: onSaved, onError: onSaveFailure })}
             onDelete={onDelete}
           />
         )}
@@ -98,7 +72,7 @@ export default function EditPage<T extends MediaType>({ type }: { type: T }) {
           <GameForm
             initial={item.data as Game}
             submitting={update.isPending}
-            onSubmit={(g) => update.mutate({ ...g, id: idNum! } as any, { onSuccess: onSaved })}
+            onSubmit={(g) => update.mutate({ ...g, id: idNum! } as any, { onSuccess: onSaved, onError: onSaveFailure })}
             onDelete={onDelete}
           />
         )}

--- a/src/client/pages/Login.tsx
+++ b/src/client/pages/Login.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { useLogin } from '../services/auth';
+import { Link } from 'react-router-dom';
+import { useAuth, useLogin } from '../services/auth';
+import { useToast } from '../components/toaster';
 import { Button, Card, Field, Input } from '../components/ui';
 
 export default function Login() {
   const [userName, setUserName] = useState('');
   const [password, setPassword] = useState('');
   const login = useLogin();
+  const { data: auth } = useAuth();
+  const toast = useToast();
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
@@ -15,7 +19,12 @@ export default function Login() {
           className="space-y-4"
           onSubmit={(e) => {
             e.preventDefault();
-            login.mutate({ userName, password });
+            login.mutate(
+              { userName, password },
+              {
+                onSuccess: () => toast.success(`Welcome back, ${userName}.`),
+              },
+            );
           }}
         >
           <Field label="Username">
@@ -29,6 +38,14 @@ export default function Login() {
             {login.isPending ? 'Signing in…' : 'Sign in'}
           </Button>
         </form>
+        {auth?.allowRegistration && (
+          <p className="mt-4 text-sm text-slate-400 text-center">
+            Don't have an account?{' '}
+            <Link to="/register" className="text-indigo-300 hover:text-indigo-200 underline">
+              Create one
+            </Link>
+          </p>
+        )}
       </Card>
     </div>
   );

--- a/src/client/pages/Register.tsx
+++ b/src/client/pages/Register.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useRegister } from '../services/auth';
+import { useToast } from '../components/toaster';
+import { Button, Card, Field, Input } from '../components/ui';
+
+export default function Register() {
+  const [userName, setUserName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const register = useRegister();
+  const toast = useToast();
+
+  // The mismatch check is purely client-side guard rails; the server
+  // doesn't see `confirm`. The button stays disabled while the two
+  // fields disagree so the network round-trip never fires.
+  const mismatched = confirm.length > 0 && password !== confirm;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <h1 className="text-2xl font-semibold text-white mb-6">Create an account</h1>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (mismatched) return;
+            register.mutate(
+              { userName, password },
+              {
+                onSuccess: () => toast.success(`Welcome, ${userName}.`),
+              },
+            );
+          }}
+        >
+          <Field label="Username">
+            <Input value={userName} onChange={(e) => setUserName(e.target.value)} autoFocus required />
+          </Field>
+          <Field label="Password">
+            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={8} />
+          </Field>
+          <Field label="Confirm password">
+            <Input
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+              minLength={8}
+              aria-invalid={mismatched || undefined}
+            />
+          </Field>
+          {mismatched && <p className="text-sm text-rose-400">Passwords don't match.</p>}
+          {register.error && (
+            <p className="text-sm text-rose-400">{(register.error as Error).message ?? 'Registration failed.'}</p>
+          )}
+          <Button type="submit" disabled={register.isPending || mismatched} className="w-full">
+            {register.isPending ? 'Creating account…' : 'Create account'}
+          </Button>
+        </form>
+        <p className="mt-4 text-sm text-slate-400 text-center">
+          Already have an account?{' '}
+          <Link to="/login" className="text-indigo-300 hover:text-indigo-200 underline">
+            Sign in
+          </Link>
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/src/client/pages/Setup.tsx
+++ b/src/client/pages/Setup.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSetup } from '../services/auth';
+import { useToast } from '../components/toaster';
 import { Button, Card, Field, Input } from '../components/ui';
 
 export default function Setup() {
@@ -7,6 +8,7 @@ export default function Setup() {
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const setup = useSetup();
+  const toast = useToast();
   const mismatch = password.length > 0 && confirm.length > 0 && password !== confirm;
 
   return (
@@ -18,7 +20,11 @@ export default function Setup() {
           className="space-y-4"
           onSubmit={(e) => {
             e.preventDefault();
-            if (!mismatch) setup.mutate({ userName, password });
+            if (!mismatch)
+              setup.mutate(
+                { userName, password },
+                { onSuccess: () => toast.success('Account created.') },
+              );
           }}
         >
           <Field label="Username">

--- a/src/client/pages/Tags.test.tsx
+++ b/src/client/pages/Tags.test.tsx
@@ -67,7 +67,10 @@ describe('TagsPage', () => {
     await userEvent.click(screen.getByLabelText('Delete tag sci-fi'));
 
     expect(window.confirm).toHaveBeenCalledOnce();
-    expect(mockMutate).toHaveBeenCalledWith(7);
+    // The page now passes onSuccess / onError options for toast wiring;
+    // assert on the id positional arg and ignore the options object.
+    expect(mockMutate).toHaveBeenCalledOnce();
+    expect(mockMutate.mock.calls[0][0]).toBe(7);
   });
 
   it('skips deletion when the user cancels the confirm dialog', async () => {

--- a/src/client/pages/Tags.tsx
+++ b/src/client/pages/Tags.tsx
@@ -1,14 +1,19 @@
 import { useDeleteTag, useTags } from '../services/tags';
+import { useToast } from '../components/toaster';
 import { Button, Card } from '../components/ui';
 import type { Tag } from '../services/types';
 
 export default function TagsPage() {
   const tags = useTags();
   const del = useDeleteTag();
+  const toast = useToast();
 
   const onDelete = (t: Tag) => {
     if (!confirm(`Delete tag "${t.name}"? It will be removed from every item it's attached to.`)) return;
-    del.mutate(t.id);
+    del.mutate(t.id, {
+      onSuccess: () => toast.success(`Tag "${t.name}" deleted.`),
+      onError: (err) => toast.error(`Failed to delete tag: ${(err as Error).message ?? 'unknown error'}`),
+    });
   };
 
   return (

--- a/src/client/services/auth.ts
+++ b/src/client/services/auth.ts
@@ -5,6 +5,8 @@ export interface AuthState {
   needsSetup: boolean;
   isAuthenticated: boolean;
   userName: string | null;
+  /** True when the server's Collectify:Auth:AllowRegistration flag is on. */
+  allowRegistration: boolean;
 }
 
 export function useAuth() {
@@ -37,5 +39,19 @@ export function useLogout() {
   return useMutation({
     mutationFn: () => api('/api/auth/logout', { method: 'POST' }),
     onSuccess: () => qc.invalidateQueries(),
+  });
+}
+
+/**
+ * Self-registration mutation. Only meaningful when the server's
+ * AllowRegistration flag is on; with the flag off the underlying
+ * endpoint returns 404 and this surfaces as a fetch error.
+ */
+export function useRegister() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { userName: string; password: string }) =>
+      api('/api/auth/register', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['auth'] }),
   });
 }

--- a/src/server/Collectify.Api/Endpoints/AuthEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/AuthEndpoints.cs
@@ -2,6 +2,7 @@ using Collectify.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Collectify.Api.Endpoints;
 
@@ -9,22 +10,30 @@ public static class AuthEndpoints
 {
     public record SetupRequest(string UserName, string Password);
     public record LoginRequest(string UserName, string Password);
-    public record AuthState(bool NeedsSetup, bool IsAuthenticated, string? UserName);
+    public record RegisterRequest(string UserName, string Password);
+    public record AuthState(
+        bool NeedsSetup,
+        bool IsAuthenticated,
+        string? UserName,
+        bool AllowRegistration);
 
     public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/auth");
 
-        group.MapGet("/me", async (HttpContext ctx, UserManager<AppUser> users) =>
+        group.MapGet("/me", async (
+            HttpContext ctx,
+            UserManager<AppUser> users,
+            IOptions<AuthOptions> auth) =>
         {
             var anyUser = await users.Users.AnyAsync();
             if (!anyUser)
-                return Results.Ok(new AuthState(true, false, null));
+                return Results.Ok(new AuthState(true, false, null, auth.Value.AllowRegistration));
 
             if (ctx.User?.Identity?.IsAuthenticated == true)
-                return Results.Ok(new AuthState(false, true, ctx.User.Identity.Name));
+                return Results.Ok(new AuthState(false, true, ctx.User.Identity.Name, auth.Value.AllowRegistration));
 
-            return Results.Ok(new AuthState(false, false, null));
+            return Results.Ok(new AuthState(false, false, null, auth.Value.AllowRegistration));
         });
 
         group.MapPost("/setup", async (
@@ -60,6 +69,40 @@ public static class AuthEndpoints
         group.MapPost("/logout", async (SignInManager<AppUser> signIn) =>
         {
             await signIn.SignOutAsync();
+            return Results.Ok(new { ok = true });
+        });
+
+        // Public self-registration. Gated by Collectify:Auth:AllowRegistration
+        // so single-user installs aren't accidentally open. Returns 404
+        // when disabled, matching the "this URL doesn't exist" feel the
+        // client uses to decide whether to render the link.
+        group.MapPost("/register", async (
+            [FromBody] RegisterRequest req,
+            UserManager<AppUser> users,
+            SignInManager<AppUser> signIn,
+            IOptions<AuthOptions> auth) =>
+        {
+            if (!auth.Value.AllowRegistration)
+                return Results.NotFound();
+
+            // First-run still goes through /setup; refuse here so the
+            // admin bootstrap isn't bypassed by a stranger hitting the
+            // raw URL before the owner has set up their account.
+            if (!await users.Users.AnyAsync())
+                return Results.BadRequest(new { error = "First-run setup hasn't completed. Use /setup." });
+
+            if (string.IsNullOrWhiteSpace(req.UserName) || string.IsNullOrWhiteSpace(req.Password))
+                return Results.BadRequest(new { error = "Username and password required." });
+
+            // UserManager.CreateAsync enforces UserName uniqueness via
+            // the Identity schema, so duplicates fall through to the
+            // IdentityResult.Errors path.
+            var user = new AppUser { UserName = req.UserName };
+            var result = await users.CreateAsync(user, req.Password);
+            if (!result.Succeeded)
+                return Results.BadRequest(new { error = string.Join("; ", result.Errors.Select(e => e.Description)) });
+
+            await signIn.SignInAsync(user, isPersistent: true);
             return Results.Ok(new { ok = true });
         });
 

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -28,6 +28,9 @@ builder.Services.AddDbContext<CollectifyDbContext>(opt =>
     opt.UseSqlite($"Data Source={dbPath}");
 });
 
+builder.Services.AddOptions<AuthOptions>()
+    .Bind(builder.Configuration.GetSection(AuthOptions.SectionName));
+
 builder.Services
     .AddIdentityCore<AppUser>(opt =>
     {

--- a/src/server/Collectify.Api/appsettings.Development.json
+++ b/src/server/Collectify.Api/appsettings.Development.json
@@ -7,6 +7,9 @@
   },
   "Collectify": {
     "DataDir": "./data",
+    "Auth": {
+      "AllowRegistration": false
+    },
     "Metadata": {
       "Tmdb": {
         "ApiKey": ""

--- a/src/server/Collectify.Infrastructure/Identity/AuthOptions.cs
+++ b/src/server/Collectify.Infrastructure/Identity/AuthOptions.cs
@@ -1,0 +1,20 @@
+namespace Collectify.Infrastructure.Identity;
+
+/// <summary>
+/// Bound from the <c>Collectify:Auth</c> config section. Single knob
+/// today: whether the public registration endpoint and matching UI
+/// affordance are exposed. Default is <c>false</c> so single-user
+/// installs aren't accidentally opened up.
+/// </summary>
+public sealed class AuthOptions
+{
+    public const string SectionName = "Collectify:Auth";
+
+    /// <summary>
+    /// When false: <c>POST /api/auth/register</c> returns 404 and the
+    /// client hides the "Create an account" link. The first-run
+    /// <c>/setup</c> flow is unaffected -- it stays the admin
+    /// bootstrap.
+    /// </summary>
+    public bool AllowRegistration { get; set; }
+}

--- a/src/server/tests/Collectify.Tests/Api/AuthEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/AuthEndpointsTests.cs
@@ -6,7 +6,7 @@ namespace Collectify.Tests.Api;
 
 public class AuthEndpointsTests
 {
-    private record AuthState(bool NeedsSetup, bool IsAuthenticated, string? UserName);
+    private record AuthState(bool NeedsSetup, bool IsAuthenticated, string? UserName, bool AllowRegistration);
 
     [Fact]
     public async Task GetMe_BeforeAnyUserExists_ReturnsNeedsSetup()
@@ -131,5 +131,113 @@ public class AuthEndpointsTests
 
         var me = await alice.Client.GetFromJsonAsync<AuthState>("/api/auth/me");
         Assert.False(me!.IsAuthenticated);
+    }
+
+    // ---------- /api/auth/me allowRegistration ----------
+
+    [Fact]
+    public async Task GetMe_ExposesAllowRegistrationFromConfig()
+    {
+        await using var off = new CollectifyApiFactory();
+        var meOff = await off.CreateClient().GetFromJsonAsync<AuthState>("/api/auth/me");
+        Assert.False(meOff!.AllowRegistration);
+
+        await using var on = new CollectifyApiFactory { AllowRegistration = true };
+        var meOn = await on.CreateClient().GetFromJsonAsync<AuthState>("/api/auth/me");
+        Assert.True(meOn!.AllowRegistration);
+    }
+
+    // ---------- /api/auth/register ----------
+
+    [Fact]
+    public async Task Register_WhenDisabled_Returns404()
+    {
+        // Default factory: AllowRegistration=false. The endpoint should
+        // act like it doesn't exist so the client can use a single
+        // signal (404) to decide whether to surface the link.
+        await using var factory = new CollectifyApiFactory();
+        await factory.CreateAuthenticatedUserAsync("alice");
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "bob", Password = "Test-Password-2" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WhenEnabledAndNoUsersExist_ReturnsBadRequest()
+    {
+        // First-run still belongs to /setup. /register refuses before
+        // the admin bootstrap has run so a stranger hitting the raw URL
+        // doesn't preempt the install owner.
+        await using var factory = new CollectifyApiFactory { AllowRegistration = true };
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "first", Password = "Test-Password-2" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WhenEnabledAndSetupDone_CreatesUserAndSignsIn()
+    {
+        await using var factory = new CollectifyApiFactory { AllowRegistration = true };
+        await factory.CreateAuthenticatedUserAsync("alice"); // admin already exists
+
+        var client = factory.CreateClient();
+        var register = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "bob", Password = "Test-Password-2" });
+
+        Assert.Equal(HttpStatusCode.OK, register.StatusCode);
+
+        // The endpoint signs the new user in -- the same HttpClient
+        // should now see itself as bob.
+        var me = await client.GetFromJsonAsync<AuthState>("/api/auth/me");
+        Assert.True(me!.IsAuthenticated);
+        Assert.Equal("bob", me.UserName);
+    }
+
+    [Fact]
+    public async Task Register_WithDuplicateUserName_ReturnsBadRequest()
+    {
+        await using var factory = new CollectifyApiFactory { AllowRegistration = true };
+        await factory.CreateAuthenticatedUserAsync("alice");
+
+        var client = factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "alice", Password = "Test-Password-2" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WithBlankFields_ReturnsBadRequest()
+    {
+        await using var factory = new CollectifyApiFactory { AllowRegistration = true };
+        await factory.CreateAuthenticatedUserAsync("alice");
+
+        var client = factory.CreateClient();
+        var noName = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "", Password = "Test-Password-2" });
+        var noPass = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "bob", Password = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, noName.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, noPass.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WithShortPassword_ReturnsBadRequest()
+    {
+        await using var factory = new CollectifyApiFactory { AllowRegistration = true };
+        await factory.CreateAuthenticatedUserAsync("alice");
+
+        var client = factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/auth/register",
+            new { UserName = "bob", Password = "short" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -28,6 +29,13 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     /// <summary>Optional override for tests that want a scripted game provider.</summary>
     public IGameMetadataProvider? GameProvider { get; init; }
 
+    /// <summary>
+    /// Toggles the <c>Collectify:Auth:AllowRegistration</c> flag. Defaults
+    /// to <c>false</c> so the registration endpoint stays 404 unless a
+    /// test deliberately opts in.
+    /// </summary>
+    public bool AllowRegistration { get; init; }
+
     public CollectifyApiFactory()
     {
         _connection = new SqliteConnection("DataSource=:memory:");
@@ -37,6 +45,14 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Collectify:Auth:AllowRegistration"] = AllowRegistration ? "true" : "false",
+            });
+        });
 
         builder.ConfigureServices(services =>
         {


### PR DESCRIPTION
Closes #29. Two coupled threads in one PR — both touch the auth screens and rely on the same toast layer.

## Summary

### Toasts

- **`components/toaster.tsx`** — module-level store + `<Toaster />` renderer + `useToast()` hook + an imperative `toast` export so non-component code can fire one too.
  - Success / info auto-dismiss (2.5s / 4s); **errors stick** until manually closed.
  - Max 4 visible at a time; oldest evicted on overflow.
  - `role="status"` for success/info (announced politely), `role="alert"` for errors (announced assertively).
- **`<Toaster />` mounted at the app root** — outside the auth-state `Routes` branches — so success toasts **survive the navigate** after login / logout / setup / save.
- **Wired into**:
  - `AddPage` save success/failure (drops the old inline success banner; error toast replaces the per-page error banner so the visual language is consistent).
  - `EditPage` save + delete success/failure.
  - `Login` success ("Welcome back, X."). Login *errors* stay inline — they're form-local validation feedback.
  - `Logout` success ("Signed out.").
  - `Setup` success ("Account created.").
  - `Tags` delete success/failure.

### Registration

- **`AuthOptions`** binds the `Collectify:Auth` section. Single knob today: `AllowRegistration` (bool, **default `false`**).
- **`POST /api/auth/register`** behind the flag:
  - **404 when disabled** so the client can use one signal to decide whether to render the link.
  - Refuses when no users exist (first-run still belongs to `/setup` — no preempting the admin bootstrap from a stranger who hits the raw URL).
  - Otherwise creates the user via `UserManager.CreateAsync` (which enforces uniqueness) and signs them in.
- **`GET /api/auth/me`** exposes `allowRegistration` so the client can show / hide the affordance without a separate fetch.
- **`/register` page** — username + password + confirm, client-side mismatch guard, welcome toast on success.
- **Login page** — surfaces a "Don't have an account? Create one" link when `allowRegistration` is true.
- **`CollectifyApiFactory`** — new `AllowRegistration` init-only property + `ConfigureAppConfiguration` injection so tests can toggle the flag per factory instance.

## Configuration

```bash
Collectify__Auth__AllowRegistration=true
```

With the flag off (default), the register endpoint 404s and the Login page hides the link — single-user installs aren't accidentally opened up.

## Test plan

### CI
- [x] `dotnet test` — **server 278/278** (was 271; +7 across `AuthEndpointsTests`).
- [x] `npm test -- --run` — **client 66/66** (was 59; +7 across `toaster.test.tsx`).
- [x] Server + Vite builds clean.

### New backend tests (`AuthEndpointsTests`)
- `/me` exposes `AllowRegistration` from config (false by default, true when toggled).
- `/register` returns **404** when disabled.
- `/register` returns 400 when enabled but no users exist (preempts /setup edge case).
- `/register` success path creates the user and signs them in (`/me` on the same client reports the new user).
- Duplicate username → 400 via `IdentityResult.Errors`.
- Blank username / password → 400.
- Short password (below the Identity options floor) → 400.

### New client tests (`toaster.test.tsx`)
- Empty queue renders nothing.
- `role=status` for success, `role=alert` for errors.
- Success toast auto-dismisses after its TTL.
- Error toast survives past the auto-dismiss window.
- Close button dismisses on click.
- 4-deep FIFO stack cap with newest-on-top.

### Manual
- [x] Default config: log in / out / save / delete each fire a toast that survives navigation; login errors stay inline. The login screen has **no** "Create one" link.
- [x] Set `Collectify__Auth__AllowRegistration=true`, restart. `/api/auth/me` returns `allowRegistration: true`. Login page now shows the link → `/register` renders → submit creates an account, toasts "Welcome, X.", and lands logged-in.
- [x] Try `/register` while signed out without first running `/setup` (zero users in the DB) → 400 error from the form.

## Out of scope

- **Persistent action toasts** ("Item deleted — Undo") — needs the underlying mutations to support reversal. Separate ticket if we want it.
- **Email verification / password reset** for self-registered users — file separately if multi-user usage actually picks up.
- **Per-user API key overrides + admin user management UI** — Phase 4 deferred items the issue calls out.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_