### PR TITLE
feat: per-type search filters on list pages (closes #25)

### DIFF
--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useList } from '../services/collection';
 import { useFiltersState } from '../services/filters';
 import { Button, Card, Input, StatusPill, TagChip } from './ui';
@@ -28,7 +27,18 @@ interface Props<T extends MediaType> {
 }
 
 export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem }: Props<T>) {
-  const [query, setQuery] = useState('');
+  // Search-input state lives in the URL as `?q=` so it deep-links and
+  // survives back/forward, same contract as the filters. useFiltersState
+  // already preserves every param it doesn't own, so Clear-all leaves
+  // `q` alone -- the two states are independent.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get('q') ?? '';
+  const setQuery = (next: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set('q', next);
+    else params.delete('q');
+    setSearchParams(params, { replace: true });
+  };
   const { filters, setFilters, clear } = useFiltersState(type);
   const list = useList(type, query, filters);
   const items = list.data ?? [];
@@ -84,7 +94,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
       {list.isLoading && <p className="text-slate-400">Loading…</p>}
       {list.error && <p className="text-rose-400">Failed to load.</p>}
       {!list.isLoading && items.length === 0 && (
-        <Card className="text-center text-slate-400">No items yet — click "+ Add" to start.</Card>
+        <Card className="text-center text-slate-400">No items yet — click \"+ Add\" to start.</Card>
       )}
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useList } from '../services/collection';
+import { useFiltersState } from '../services/filters';
 import { Button, Card, Input, StatusPill, TagChip } from './ui';
 import BarcodeLookup from './BarcodeLookup';
+import FiltersPanel from './FiltersPanel';
 import type { CollectionItemBase, MediaType } from '../services/types';
 import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
 
@@ -27,7 +29,8 @@ interface Props<T extends MediaType> {
 
 export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem }: Props<T>) {
   const [query, setQuery] = useState('');
-  const list = useList(type, query);
+  const { filters, setFilters, clear } = useFiltersState(type);
+  const list = useList(type, query, filters);
   const items = list.data ?? [];
   const navigate = useNavigate();
 
@@ -69,6 +72,13 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
         placeholder={`Search ${title.toLowerCase()}…`}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+      />
+
+      <FiltersPanel
+        type={type}
+        value={filters}
+        onChange={setFilters}
+        onClear={clear}
       />
 
       {list.isLoading && <p className="text-slate-400">Loading…</p>}

--- a/src/client/components/FiltersPanel.tsx
+++ b/src/client/components/FiltersPanel.tsx
@@ -1,0 +1,326 @@
+import { useState } from 'react';
+import {
+  Button,
+  Card,
+  Field,
+  Input,
+  SearchableSelect,
+  Select,
+  TagChip,
+} from './ui';
+import { activeFilterCount, type Filters } from '../services/filters';
+import {
+  COLLECTION_STATUSES,
+  COMPLETION_STATUSES,
+  DIGITAL_STORES,
+  GAME_PLATFORMS,
+  MOVIE_FORMAT_FLAGS,
+  MUSIC_FORMATS,
+  WATCH_STATUSES,
+  type MediaType,
+} from '../services/types';
+
+interface Props<T extends MediaType> {
+  type: T;
+  value: Filters<T>;
+  onChange: (next: Filters<T>) => void;
+  onClear: () => void;
+}
+
+/**
+ * Per-type collapsible filter panel. Opens to a grid of fields
+ * appropriate for the media type; renders a chip strip of currently
+ * active filters whether or not the body is open. The empty-state
+ * (no active filters) hides the chip strip but leaves the disclosure
+ * trigger so the user can still expand the panel.
+ */
+export default function FiltersPanel<T extends MediaType>({ type, value, onChange, onClear }: Props<T>) {
+  const [open, setOpen] = useState(false);
+  const active = activeFilterCount(value as unknown as Record<string, unknown>);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          className="text-sm text-slate-300 hover:text-white inline-flex items-center gap-2"
+        >
+          <span>{open ? '▾' : '▸'} Filters{active > 0 && ` (${active})`}</span>
+        </button>
+        {active > 0 && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-slate-400 hover:text-rose-300"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {active > 0 && (
+        <ActiveChips type={type} value={value} onChange={onChange} />
+      )}
+
+      {open && (
+        <Card>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {type === 'movies' && <MovieFields value={value as Filters<'movies'>} onChange={onChange as (v: Filters<'movies'>) => void} />}
+            {type === 'music' && <AlbumFields value={value as Filters<'music'>} onChange={onChange as (v: Filters<'music'>) => void} />}
+            {type === 'games' && <GameFields value={value as Filters<'games'>} onChange={onChange as (v: Filters<'games'>) => void} />}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ---------- Per-type field renderers ----------
+
+function MovieFields({ value, onChange }: { value: Filters<'movies'>; onChange: (next: Filters<'movies'>) => void }) {
+  const set = <K extends keyof Filters<'movies'>>(k: K, v: Filters<'movies'>[K]) =>
+    onChange({ ...value, [k]: v });
+  return (
+    <>
+      <YearRange from={value.yearFrom} to={value.yearTo} onChange={(yf, yt) => onChange({ ...value, yearFrom: yf, yearTo: yt })} />
+      <Field label="Director">
+        <Input value={value.director ?? ''} onChange={(e) => set('director', e.target.value || undefined)} />
+      </Field>
+      <Field label="Studio">
+        <Input value={value.studio ?? ''} onChange={(e) => set('studio', e.target.value || undefined)} />
+      </Field>
+      <Field label="Genre">
+        <Input value={value.genre ?? ''} onChange={(e) => set('genre', e.target.value || undefined)} placeholder="substring match" />
+      </Field>
+      <Field label="Format">
+        <Select value={value.format ?? ''} onChange={(e) => set('format', (e.target.value || undefined) as Filters<'movies'>['format'])}>
+          <option value="">Any</option>
+          {MOVIE_FORMAT_FLAGS.map((f) => (
+            <option key={f.key} value={f.key}>{f.label}</option>
+          ))}
+        </Select>
+      </Field>
+      <Field label="Status">
+        <Select value={value.status ?? ''} onChange={(e) => set('status', (e.target.value || undefined) as Filters<'movies'>['status'])}>
+          <option value="">Any</option>
+          {COLLECTION_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </Select>
+      </Field>
+      <Field label="Watch status">
+        <Select value={value.watchStatus ?? ''} onChange={(e) => set('watchStatus', (e.target.value || undefined) as Filters<'movies'>['watchStatus'])}>
+          <option value="">Any</option>
+          {WATCH_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </Select>
+      </Field>
+      <RatingMin value={value.ratingMin} onChange={(v) => set('ratingMin', v)} />
+    </>
+  );
+}
+
+function AlbumFields({ value, onChange }: { value: Filters<'music'>; onChange: (next: Filters<'music'>) => void }) {
+  const set = <K extends keyof Filters<'music'>>(k: K, v: Filters<'music'>[K]) =>
+    onChange({ ...value, [k]: v });
+  return (
+    <>
+      <YearRange from={value.yearFrom} to={value.yearTo} onChange={(yf, yt) => onChange({ ...value, yearFrom: yf, yearTo: yt })} />
+      <Field label="Artist">
+        <Input value={value.artist ?? ''} onChange={(e) => set('artist', e.target.value || undefined)} />
+      </Field>
+      <Field label="Label">
+        <Input value={value.label ?? ''} onChange={(e) => set('label', e.target.value || undefined)} />
+      </Field>
+      <Field label="Genre">
+        <Input value={value.genre ?? ''} onChange={(e) => set('genre', e.target.value || undefined)} placeholder="substring match" />
+      </Field>
+      <Field label="Format">
+        <Select value={value.format ?? ''} onChange={(e) => set('format', (e.target.value || undefined) as Filters<'music'>['format'])}>
+          <option value="">Any</option>
+          {MUSIC_FORMATS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+        </Select>
+      </Field>
+      <Field label="Status">
+        <Select value={value.status ?? ''} onChange={(e) => set('status', (e.target.value || undefined) as Filters<'music'>['status'])}>
+          <option value="">Any</option>
+          {COLLECTION_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </Select>
+      </Field>
+      <RatingMin value={value.ratingMin} onChange={(v) => set('ratingMin', v)} />
+    </>
+  );
+}
+
+function GameFields({ value, onChange }: { value: Filters<'games'>; onChange: (next: Filters<'games'>) => void }) {
+  const set = <K extends keyof Filters<'games'>>(k: K, v: Filters<'games'>[K]) =>
+    onChange({ ...value, [k]: v });
+  return (
+    <>
+      <YearRange from={value.yearFrom} to={value.yearTo} onChange={(yf, yt) => onChange({ ...value, yearFrom: yf, yearTo: yt })} />
+      <Field label="Platform">
+        <SearchableSelect
+          value={value.platform ?? ''}
+          onChange={(v) => set('platform', (v || undefined) as Filters<'games'>['platform'])}
+          options={[{ value: '', label: 'Any' }, ...GAME_PLATFORMS]}
+          placeholder="Any"
+        />
+      </Field>
+      <Field label="Publisher">
+        <Input value={value.publisher ?? ''} onChange={(e) => set('publisher', e.target.value || undefined)} />
+      </Field>
+      <Field label="Developer">
+        <Input value={value.developer ?? ''} onChange={(e) => set('developer', e.target.value || undefined)} />
+      </Field>
+      <Field label="Status">
+        <Select value={value.status ?? ''} onChange={(e) => set('status', (e.target.value || undefined) as Filters<'games'>['status'])}>
+          <option value="">Any</option>
+          {COLLECTION_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </Select>
+      </Field>
+      <Field label="Completion">
+        <Select value={value.completionStatus ?? ''} onChange={(e) => set('completionStatus', (e.target.value || undefined) as Filters<'games'>['completionStatus'])}>
+          <option value="">Any</option>
+          {COMPLETION_STATUSES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+        </Select>
+      </Field>
+      <Field label="Physical / Digital">
+        <Select
+          value={value.digital === undefined ? '' : value.digital ? 'true' : 'false'}
+          onChange={(e) =>
+            set('digital', e.target.value === '' ? undefined : e.target.value === 'true')
+          }
+        >
+          <option value="">Any</option>
+          <option value="true">Digital</option>
+          <option value="false">Physical</option>
+        </Select>
+      </Field>
+      <Field label="Digital store">
+        <Select value={value.digitalStore ?? ''} onChange={(e) => set('digitalStore', (e.target.value || undefined) as Filters<'games'>['digitalStore'])}>
+          <option value="">Any</option>
+          {DIGITAL_STORES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </Select>
+      </Field>
+      <RatingMin value={value.ratingMin} onChange={(v) => set('ratingMin', v)} />
+    </>
+  );
+}
+
+// ---------- Shared little controls ----------
+
+function YearRange({
+  from,
+  to,
+  onChange,
+}: {
+  from: number | undefined;
+  to: number | undefined;
+  onChange: (f: number | undefined, t: number | undefined) => void;
+}) {
+  return (
+    <Field label="Year range">
+      <div className="flex gap-2 items-center">
+        <Input
+          type="number"
+          inputMode="numeric"
+          placeholder="from"
+          value={from ?? ''}
+          onChange={(e) => onChange(e.target.value ? Number(e.target.value) : undefined, to)}
+        />
+        <span className="text-slate-500 text-xs">–</span>
+        <Input
+          type="number"
+          inputMode="numeric"
+          placeholder="to"
+          value={to ?? ''}
+          onChange={(e) => onChange(from, e.target.value ? Number(e.target.value) : undefined)}
+        />
+      </div>
+    </Field>
+  );
+}
+
+function RatingMin({ value, onChange }: { value: number | undefined; onChange: (v: number | undefined) => void }) {
+  return (
+    <Field label="Min rating">
+      <Select value={value ?? ''} onChange={(e) => onChange(e.target.value ? Number(e.target.value) : undefined)}>
+        <option value="">Any</option>
+        {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+          <option key={n} value={n}>{n}+</option>
+        ))}
+      </Select>
+    </Field>
+  );
+}
+
+// ---------- Active filter chips ----------
+
+interface ChipProps<T extends MediaType> {
+  type: T;
+  value: Filters<T>;
+  onChange: (next: Filters<T>) => void;
+}
+
+function ActiveChips<T extends MediaType>({ type, value, onChange }: ChipProps<T>) {
+  const entries = describeActive(type, value);
+  if (entries.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {entries.map((e) => (
+        <span
+          key={e.key}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-slate-800 text-slate-200 border border-slate-700"
+        >
+          <span className="text-slate-400 mr-1">{e.label}:</span> {e.display}
+          <button
+            type="button"
+            onClick={() => onChange({ ...value, [e.key]: undefined } as Filters<T>)}
+            aria-label={`Remove ${e.label} filter`}
+            className="ml-0.5 text-slate-400 hover:text-rose-300"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Turn the filters object into a list of `{ key, label, display }`
+ * entries for the chip strip. Year range is rendered as a single chip
+ * when either bound is set (so removing it clears both).
+ */
+function describeActive<T extends MediaType>(_type: T, filters: Filters<T>): { key: string; label: string; display: string }[] {
+  const out: { key: string; label: string; display: string }[] = [];
+  const f = filters as Record<string, unknown>;
+  if (f.yearFrom != null || f.yearTo != null) {
+    out.push({
+      key: 'yearFrom',
+      label: 'Year',
+      display: `${f.yearFrom ?? '…'}–${f.yearTo ?? '…'}`,
+    });
+  }
+  const labels: Record<string, string> = {
+    director: 'Director', studio: 'Studio', genre: 'Genre',
+    artist: 'Artist', label: 'Label',
+    publisher: 'Publisher', developer: 'Developer',
+    format: 'Format', platform: 'Platform',
+    status: 'Status', watchStatus: 'Watch',
+    completionStatus: 'Completion', digital: 'Digital',
+    digitalStore: 'Store', ratingMin: 'Min rating',
+  };
+  for (const [key, value] of Object.entries(f)) {
+    if (key === 'yearFrom' || key === 'yearTo' || key === 'tag') continue;
+    if (value === undefined || value === null || value === '') continue;
+    const display = typeof value === 'boolean' ? (value ? 'Digital' : 'Physical') : String(value);
+    out.push({ key, label: labels[key] ?? key, display });
+  }
+  if (Array.isArray(f.tag) && f.tag.length > 0) {
+    out.push({ key: 'tag', label: 'Tags', display: f.tag.join(', ') });
+  }
+  return out;
+}
+
+/** Tiny reuse so chip removal can share styling without indirection. */
+export { TagChip };

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -1,15 +1,25 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './client';
+import { filtersToParams, type Filters } from './filters';
 import type { Album, Game, MediaType, Movie } from './types';
 
 type ItemMap = { movies: Movie; music: Album; games: Game };
 
-export function useList<T extends MediaType>(type: T, query: string) {
+/**
+ * List with an optional filter object. `query` stays the free-text
+ * search; the filter object gets serialised to the per-endpoint query
+ * params via {@link filtersToParams}. The query key includes both so
+ * TanStack Query caches by the full (query + filters) pair and a
+ * filter change refetches deterministically.
+ */
+export function useList<T extends MediaType>(type: T, query: string, filters?: Filters<T>) {
   return useQuery({
-    queryKey: [type, 'list', query],
+    queryKey: [type, 'list', query, filters ?? {}],
     queryFn: () => {
-      const qs = query ? `?query=${encodeURIComponent(query)}` : '';
-      return api<ItemMap[T][]>(`/api/${type}${qs}`);
+      const params = filters ? filtersToParams(filters as Record<string, unknown>) : new URLSearchParams();
+      if (query) params.set('query', query);
+      const qs = params.toString();
+      return api<ItemMap[T][]>(`/api/${type}${qs ? `?${qs}` : ''}`);
     },
   });
 }

--- a/src/client/services/filters.test.ts
+++ b/src/client/services/filters.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { activeFilterCount, filtersToParams } from './filters';
+
+describe('filtersToParams', () => {
+  it('omits undefined / null / empty / NaN values', () => {
+    const params = filtersToParams({
+      yearFrom: undefined,
+      yearTo: null,
+      director: '',
+      ratingMin: Number.NaN,
+      studio: 'Warner',
+    });
+
+    expect(params.toString()).toBe('studio=Warner');
+  });
+
+  it('emits one entry per array element so the server sees a repeated query param', () => {
+    const params = filtersToParams({ tag: ['scifi', 'noir'] });
+    // URLSearchParams stringifies arrays as repeated keys, which is
+    // exactly what the [FromQuery(Name="tag")] string[] binder expects.
+    expect(params.getAll('tag')).toEqual(['scifi', 'noir']);
+  });
+
+  it('round-trips booleans and numbers as strings', () => {
+    const params = filtersToParams({ digital: true, ratingMin: 7 });
+    expect(params.get('digital')).toBe('true');
+    expect(params.get('ratingMin')).toBe('7');
+  });
+
+  it('drops empty strings inside arrays', () => {
+    const params = filtersToParams({ tag: ['scifi', '', 'noir'] });
+    expect(params.getAll('tag')).toEqual(['scifi', 'noir']);
+  });
+});
+
+describe('activeFilterCount', () => {
+  it('counts only set scalar fields', () => {
+    expect(activeFilterCount({ a: 'x', b: undefined, c: 0 })).toBe(2);
+  });
+
+  it('treats empty arrays as inactive but non-empty as a single bucket', () => {
+    expect(activeFilterCount({ tag: [] })).toBe(0);
+    expect(activeFilterCount({ tag: ['scifi'] })).toBe(1);
+    expect(activeFilterCount({ tag: ['scifi', 'noir'] })).toBe(1);
+  });
+
+  it('ignores empty strings', () => {
+    expect(activeFilterCount({ director: '', studio: 'Warner' })).toBe(1);
+  });
+});

--- a/src/client/services/filters.ts
+++ b/src/client/services/filters.ts
@@ -1,0 +1,198 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type {
+  CollectionStatus,
+  CompletionStatus,
+  DigitalStore,
+  GamePlatform,
+  MediaType,
+  MovieFormat,
+  MusicFormat,
+  WatchStatus,
+} from './types';
+
+// Per-type filter shapes mirror the query params the server endpoints
+// accept. Keep them flat and JSON-serialisable so the URL <->
+// state round-trip stays trivial.
+
+export interface MovieFilters {
+  yearFrom?: number;
+  yearTo?: number;
+  director?: string;
+  studio?: string;
+  genre?: string;
+  format?: MovieFormat;
+  status?: CollectionStatus;
+  watchStatus?: WatchStatus;
+  ratingMin?: number;
+  tag?: string[];
+}
+
+export interface AlbumFilters {
+  yearFrom?: number;
+  yearTo?: number;
+  artist?: string;
+  label?: string;
+  genre?: string;
+  format?: MusicFormat;
+  status?: CollectionStatus;
+  ratingMin?: number;
+  tag?: string[];
+}
+
+export interface GameFilters {
+  yearFrom?: number;
+  yearTo?: number;
+  publisher?: string;
+  developer?: string;
+  platform?: GamePlatform;
+  digital?: boolean;
+  digitalStore?: DigitalStore;
+  status?: CollectionStatus;
+  completionStatus?: CompletionStatus;
+  ratingMin?: number;
+  tag?: string[];
+}
+
+export type FiltersMap = {
+  movies: MovieFilters;
+  music: AlbumFilters;
+  games: GameFilters;
+};
+
+export type Filters<T extends MediaType> = FiltersMap[T];
+
+/**
+ * Serialize a filters object into URLSearchParams. Arrays get one
+ * entry per value (so `tag=a&tag=b`) which matches the binding shape
+ * on the server. Booleans become "true"/"false"; undefined / null /
+ * empty-string / NaN / empty-array values are dropped.
+ */
+export function filtersToParams(filters: Record<string, unknown>): URLSearchParams {
+  const out = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v === undefined || v === null || v === '') continue;
+        out.append(key, String(v));
+      }
+      continue;
+    }
+    if (typeof value === 'number' && Number.isNaN(value)) continue;
+    out.append(key, String(value));
+  }
+  return out;
+}
+
+/**
+ * Inverse of {@link filtersToParams}. Pulls a filters object out of
+ * a URLSearchParams. The per-key shape table is the source of truth
+ * for how each query param is typed; values for keys not listed are
+ * preserved as strings.
+ */
+function paramsToFilters<T extends MediaType>(type: T, params: URLSearchParams): Filters<T> {
+  const result: Record<string, unknown> = {};
+  const schema = SCHEMA[type];
+  for (const [key, def] of Object.entries(schema)) {
+    if (def === 'string[]') {
+      const values = params.getAll(key).filter((v) => v.length > 0);
+      if (values.length > 0) result[key] = values;
+    } else if (def === 'number') {
+      const raw = params.get(key);
+      if (raw !== null && raw.length > 0) {
+        const n = Number(raw);
+        if (Number.isFinite(n)) result[key] = n;
+      }
+    } else if (def === 'boolean') {
+      const raw = params.get(key);
+      if (raw === 'true') result[key] = true;
+      else if (raw === 'false') result[key] = false;
+    } else {
+      const raw = params.get(key);
+      if (raw !== null && raw.length > 0) result[key] = raw;
+    }
+  }
+  return result as Filters<T>;
+}
+
+type ParamShape = 'string' | 'number' | 'boolean' | 'string[]';
+
+// Keys not listed default to `string`, but every filter key here is
+// explicitly typed so the per-type round-trip stays predictable.
+const SCHEMA: Record<MediaType, Record<string, ParamShape>> = {
+  movies: {
+    yearFrom: 'number', yearTo: 'number',
+    director: 'string', studio: 'string', genre: 'string',
+    format: 'string', status: 'string', watchStatus: 'string',
+    ratingMin: 'number',
+    tag: 'string[]',
+  },
+  music: {
+    yearFrom: 'number', yearTo: 'number',
+    artist: 'string', label: 'string', genre: 'string',
+    format: 'string', status: 'string',
+    ratingMin: 'number',
+    tag: 'string[]',
+  },
+  games: {
+    yearFrom: 'number', yearTo: 'number',
+    publisher: 'string', developer: 'string',
+    platform: 'string', digital: 'boolean', digitalStore: 'string',
+    status: 'string', completionStatus: 'string',
+    ratingMin: 'number',
+    tag: 'string[]',
+  },
+};
+
+/**
+ * URL-synced filter state. Reading filters reflects the current
+ * search-string; the returned setter writes them back via
+ * react-router's navigation, so deep-linking and browser back/forward
+ * work for free. Free-text search is intentionally **not** part of the
+ * filter set -- the list page's search input owns its own state and
+ * stays in the URL via a separate `q` param.
+ */
+export function useFiltersState<T extends MediaType>(type: T) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = paramsToFilters(type, searchParams);
+
+  const setFilters = useCallback(
+    (next: Filters<T>) => {
+      // Preserve any non-filter params we don't manage (e.g. `q`) so
+      // the search input doesn't get clobbered on every filter change.
+      const merged = new URLSearchParams();
+      const ownKeys = new Set(Object.keys(SCHEMA[type]));
+      for (const [k, v] of searchParams.entries()) {
+        if (!ownKeys.has(k)) merged.append(k, v);
+      }
+      for (const [k, v] of filtersToParams(next as unknown as Record<string, unknown>).entries()) {
+        merged.append(k, v);
+      }
+      setSearchParams(merged, { replace: true });
+    },
+    [type, searchParams, setSearchParams],
+  );
+
+  const clear = useCallback(() => {
+    const merged = new URLSearchParams();
+    const ownKeys = new Set(Object.keys(SCHEMA[type]));
+    for (const [k, v] of searchParams.entries()) {
+      if (!ownKeys.has(k)) merged.append(k, v);
+    }
+    setSearchParams(merged, { replace: true });
+  }, [type, searchParams, setSearchParams]);
+
+  return { filters, setFilters, clear };
+}
+
+/** Number of active (non-default) filter fields on the given object. */
+export function activeFilterCount(filters: Record<string, unknown>): number {
+  let n = 0;
+  for (const v of Object.values(filters)) {
+    if (v === undefined || v === null || v === '') continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    n++;
+  }
+  return n;
+}

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -48,6 +48,16 @@ public static class GamesEndpoints
             [FromQuery] string? query,
             [FromQuery] GamePlatform? platform,
             [FromQuery] bool? digital,
+            [FromQuery] int? year,
+            [FromQuery] int? yearFrom,
+            [FromQuery] int? yearTo,
+            [FromQuery] string? publisher,
+            [FromQuery] string? developer,
+            [FromQuery] CollectionStatus? status,
+            [FromQuery] CompletionStatus? completionStatus,
+            [FromQuery] DigitalStore? digitalStore,
+            [FromQuery] int? ratingMin,
+            [FromQuery(Name = "tag")] string[]? tag,
             CollectifyDbContext db,
             UserManager<AppUser> users,
             HttpContext ctx) =>
@@ -63,6 +73,29 @@ public static class GamesEndpoints
             }
             if (platform.HasValue) q = q.Where(g => g.Platform == platform.Value);
             if (digital.HasValue) q = q.Where(g => g.IsDigital == digital.Value);
+            if (year.HasValue) q = q.Where(g => g.Year == year);
+            if (yearFrom.HasValue) q = q.Where(g => g.Year != null && g.Year >= yearFrom);
+            if (yearTo.HasValue) q = q.Where(g => g.Year != null && g.Year <= yearTo);
+            if (!string.IsNullOrWhiteSpace(publisher))
+            {
+                var like = $"%{publisher}%";
+                q = q.Where(g => g.Publisher != null && EF.Functions.Like(g.Publisher, like));
+            }
+            if (!string.IsNullOrWhiteSpace(developer))
+            {
+                var like = $"%{developer}%";
+                q = q.Where(g => g.Developer != null && EF.Functions.Like(g.Developer, like));
+            }
+            if (status.HasValue) q = q.Where(g => g.Status == status.Value);
+            if (completionStatus.HasValue) q = q.Where(g => g.CompletionStatus == completionStatus.Value);
+            if (digitalStore.HasValue) q = q.Where(g => g.DigitalStore == digitalStore.Value);
+            if (ratingMin is { } rm) q = q.Where(g => g.PersonalRating != null && g.PersonalRating >= rm);
+            if (tag is { Length: > 0 })
+            {
+                var normalised = tag.Select(t => t.Trim().ToLowerInvariant()).Where(t => t.Length > 0).ToArray();
+                if (normalised.Length > 0)
+                    q = q.Where(g => g.Tags.Any(t => normalised.Contains(t.Name)));
+            }
 
             var items = await q.OrderByDescending(g => g.AddedAt).Take(500).ToListAsync();
             return Results.Ok(items.Select(ToDto));

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -49,6 +49,15 @@ public static class MoviesEndpoints
             [FromQuery] string? query,
             [FromQuery] MovieFormat? format,
             [FromQuery] int? year,
+            [FromQuery] int? yearFrom,
+            [FromQuery] int? yearTo,
+            [FromQuery] string? director,
+            [FromQuery] string? studio,
+            [FromQuery] string? genre,
+            [FromQuery] CollectionStatus? status,
+            [FromQuery] WatchStatus? watchStatus,
+            [FromQuery] int? ratingMin,
+            [FromQuery(Name = "tag")] string[]? tag,
             CollectifyDbContext db,
             UserManager<AppUser> users,
             HttpContext ctx) =>
@@ -64,7 +73,40 @@ public static class MoviesEndpoints
             }
             if (format.HasValue && format.Value != MovieFormat.None)
                 q = q.Where(m => (m.Formats & format.Value) != 0);
+            // Legacy single-year stays for back-compat; yearFrom/yearTo
+            // is the new range-style filter.
             if (year.HasValue) q = q.Where(m => m.Year == year);
+            if (yearFrom.HasValue) q = q.Where(m => m.Year != null && m.Year >= yearFrom);
+            if (yearTo.HasValue) q = q.Where(m => m.Year != null && m.Year <= yearTo);
+            if (!string.IsNullOrWhiteSpace(director))
+            {
+                var like = $"%{director}%";
+                q = q.Where(m => m.Director != null && EF.Functions.Like(m.Director, like));
+            }
+            if (!string.IsNullOrWhiteSpace(studio))
+            {
+                var like = $"%{studio}%";
+                q = q.Where(m => m.Studio != null && EF.Functions.Like(m.Studio, like));
+            }
+            if (!string.IsNullOrWhiteSpace(genre))
+            {
+                // Genres is stored as a comma-separated string; substring
+                // match is good enough for the volume here.
+                var like = $"%{genre}%";
+                q = q.Where(m => m.Genres != null && EF.Functions.Like(m.Genres, like));
+            }
+            if (status.HasValue) q = q.Where(m => m.Status == status.Value);
+            if (watchStatus.HasValue) q = q.Where(m => m.WatchStatus == watchStatus.Value);
+            if (ratingMin is { } rm) q = q.Where(m => m.PersonalRating != null && m.PersonalRating >= rm);
+            if (tag is { Length: > 0 })
+            {
+                // OR semantics within the multi-value filter: an item
+                // matches if any of its tags is in the requested set.
+                // Normalised to lower-case to match TagResolver.
+                var normalised = tag.Select(t => t.Trim().ToLowerInvariant()).Where(t => t.Length > 0).ToArray();
+                if (normalised.Length > 0)
+                    q = q.Where(m => m.Tags.Any(t => normalised.Contains(t.Name)));
+            }
 
             var items = await q.OrderByDescending(m => m.AddedAt).Take(500).ToListAsync();
             return Results.Ok(items.Select(ToDto));

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -46,6 +46,14 @@ public static class MusicEndpoints
             [FromQuery] string? query,
             [FromQuery] MusicFormat? format,
             [FromQuery] int? year,
+            [FromQuery] int? yearFrom,
+            [FromQuery] int? yearTo,
+            [FromQuery] string? artist,
+            [FromQuery] string? label,
+            [FromQuery] string? genre,
+            [FromQuery] CollectionStatus? status,
+            [FromQuery] int? ratingMin,
+            [FromQuery(Name = "tag")] string[]? tag,
             CollectifyDbContext db,
             UserManager<AppUser> users,
             HttpContext ctx) =>
@@ -61,6 +69,31 @@ public static class MusicEndpoints
             }
             if (format.HasValue) q = q.Where(a => a.Format == format.Value);
             if (year.HasValue) q = q.Where(a => a.Year == year);
+            if (yearFrom.HasValue) q = q.Where(a => a.Year != null && a.Year >= yearFrom);
+            if (yearTo.HasValue) q = q.Where(a => a.Year != null && a.Year <= yearTo);
+            if (!string.IsNullOrWhiteSpace(artist))
+            {
+                var like = $"%{artist}%";
+                q = q.Where(a => EF.Functions.Like(a.ArtistName, like));
+            }
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                var like = $"%{label}%";
+                q = q.Where(a => a.Label != null && EF.Functions.Like(a.Label, like));
+            }
+            if (!string.IsNullOrWhiteSpace(genre))
+            {
+                var like = $"%{genre}%";
+                q = q.Where(a => a.Genres != null && EF.Functions.Like(a.Genres, like));
+            }
+            if (status.HasValue) q = q.Where(a => a.Status == status.Value);
+            if (ratingMin is { } rm) q = q.Where(a => a.PersonalRating != null && a.PersonalRating >= rm);
+            if (tag is { Length: > 0 })
+            {
+                var normalised = tag.Select(t => t.Trim().ToLowerInvariant()).Where(t => t.Length > 0).ToArray();
+                if (normalised.Length > 0)
+                    q = q.Where(a => a.Tags.Any(t => normalised.Contains(t.Name)));
+            }
 
             var items = await q.OrderByDescending(a => a.AddedAt).Take(500).ToListAsync();
             return Results.Ok(items.Select(ToDto));

--- a/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
@@ -288,6 +288,47 @@ public class GamesEndpointsTests
         Assert.Equal("Digital", hits![0].Title);
     }
 
+    [Fact]
+    public async Task List_FiltersByYearRangePublisherDeveloperCompletionAndRating()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades",       Platform = GamePlatform.Pc,     Year = 2020, Publisher = "Supergiant", Developer = "Supergiant", CompletionStatus = CompletionStatus.Beaten, PersonalRating = 9 });
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Witcher 3",   Platform = GamePlatform.Pc,     Year = 2015, Publisher = "CD Projekt", Developer = "CD Projekt", CompletionStatus = CompletionStatus.Playing, PersonalRating = 8 });
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Tetris",      Platform = GamePlatform.GameBoy, Year = 1989, Publisher = "Nintendo",   Developer = "Bullet-Proof Software", CompletionStatus = CompletionStatus.NotStarted });
+
+        var byYear = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?yearFrom=2010");
+        Assert.Equal(2, byYear!.Length);
+
+        var byPublisher = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?publisher=Supergiant");
+        Assert.Single(byPublisher!);
+
+        var byDeveloper = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?developer=Projekt");
+        Assert.Single(byDeveloper!);
+
+        var byCompletion = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?completionStatus=Beaten");
+        Assert.Single(byCompletion!);
+        Assert.Equal("Hades", byCompletion![0].Title);
+
+        var byRating = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?ratingMin=9");
+        Assert.Single(byRating!);
+    }
+
+    [Fact]
+    public async Task List_FiltersByPlatform_OrSemanticsAreAvailableViaCombiningWithOtherFilters()
+    {
+        // Single-value enum filter today (one platform per request).
+        // Documented as a future enhancement if multi-platform OR
+        // becomes a real need.
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Ps5 game",  Platform = GamePlatform.Ps5 });
+        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Switch game", Platform = GamePlatform.Switch });
+
+        var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=Ps5");
+        Assert.Single(hits!);
+    }
+
     // -------- Personal / acquisition / completion fields round-trip --------
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -400,6 +400,109 @@ public class MoviesEndpointsTests
         Assert.All(hits, m => Assert.Equal(2010, m.Year));
     }
 
+    [Fact]
+    public async Task List_FiltersByYearRange_InclusiveBothEnds()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Old", Year = 1999 });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Mid", Year = 2010 });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Top", Year = 2020 });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Future", Year = 2025 });
+
+        var hits = await alice.Client.GetJsonAsync<MovieResponse[]>(
+            "/api/movies/?yearFrom=2000&yearTo=2020");
+
+        Assert.Equal(2, hits!.Length);
+        Assert.All(hits, m => Assert.InRange(m.Year ?? 0, 2000, 2020));
+    }
+
+    [Fact]
+    public async Task List_FiltersByDirector_StudioGenre_MatchSubstring()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi, action" });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",    Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi" });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas", Director = "Martin Scorsese", Studio = "Warner Bros", Genres = "crime" });
+
+        var byDirector = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?director=Nolan");
+        Assert.Equal(2, byDirector!.Length);
+
+        var byStudio = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?studio=Warner");
+        Assert.Equal(3, byStudio!.Length);
+
+        // Substring against the comma-joined Genres column.
+        var byGenre = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?genre=sci-fi");
+        Assert.Equal(2, byGenre!.Length);
+    }
+
+    [Fact]
+    public async Task List_FiltersByStatusAndWatchStatusAndRatingMin()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Watched-9", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, PersonalRating = 9 });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Unwatched", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Unwatched, PersonalRating = 5 });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Wishlist",        Status = CollectionStatus.Wishlist });
+
+        var byStatus = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?status=Wishlist");
+        var hit = Assert.Single(byStatus!);
+        Assert.Equal("Wishlist", hit.Title);
+
+        var byWatch = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?watchStatus=Watched");
+        Assert.Single(byWatch!);
+
+        var byRating = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?ratingMin=7");
+        Assert.Single(byRating!);
+        Assert.Equal("Owned-Watched-9", byRating![0].Title);
+    }
+
+    [Fact]
+    public async Task List_FiltersByTag_OrSemanticsAcrossMultipleValues()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+
+        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "scifi" });
+        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "noir" });
+        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "comedy" });
+
+        await alice.Client.PostAsJsonAsync("/api/movies/",
+            new { Title = "Blade Runner", Year = 1982, Formats = MovieFormat.BluRay, Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, WatchCount = 0, Tags = new[] { "scifi", "noir" } });
+        await alice.Client.PostAsJsonAsync("/api/movies/",
+            new { Title = "Airplane",     Year = 1980, Formats = MovieFormat.Dvd,    Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, WatchCount = 0, Tags = new[] { "comedy" } });
+        await alice.Client.PostAsJsonAsync("/api/movies/",
+            new { Title = "Casablanca",   Year = 1942, Formats = MovieFormat.Dvd,    Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, WatchCount = 0, Tags = new[] { "noir" } });
+
+        // Single tag.
+        var byScifi = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?tag=scifi");
+        Assert.Single(byScifi!);
+        Assert.Equal("Blade Runner", byScifi![0].Title);
+
+        // Multi-value OR: scifi or noir matches Blade Runner *and* Casablanca.
+        var byEither = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?tag=scifi&tag=noir");
+        Assert.Equal(2, byEither!.Length);
+        Assert.Contains(byEither, m => m.Title == "Blade Runner");
+        Assert.Contains(byEither, m => m.Title == "Casablanca");
+    }
+
+    [Fact]
+    public async Task List_CombinesFiltersWithAndSemantics()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Year = 2010, Director = "Nolan",     Status = CollectionStatus.Owned });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",     Year = 2020, Director = "Nolan",     Status = CollectionStatus.Owned });
+        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas",Year = 1990, Director = "Scorsese",  Status = CollectionStatus.Owned });
+
+        var hits = await alice.Client.GetJsonAsync<MovieResponse[]>(
+            "/api/movies/?director=Nolan&yearFrom=2015");
+
+        Assert.Single(hits!);
+        Assert.Equal("Tenet", hits![0].Title);
+    }
+
     // -------- Personal / acquisition / watch fields round-trip --------
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
@@ -319,6 +319,35 @@ public class MusicEndpointsTests
         Assert.Equal(new DateOnly(2024, 8, 1), body.LastPlayedOn);
     }
 
+    [Fact]
+    public async Task List_FiltersByYearRange_ArtistLabelGenreStatusRating()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "OK Computer", ArtistName = "Radiohead",   Year = 1997, Label = "Parlophone", Genres = "rock", PersonalRating = 9, Status = CollectionStatus.Owned });
+        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Funeral",     ArtistName = "Arcade Fire", Year = 2004, Label = "Merge",      Genres = "indie", PersonalRating = 7, Status = CollectionStatus.Owned });
+        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Pet Sounds",  ArtistName = "Beach Boys",  Year = 1966, Label = "Capitol",    Genres = "pop", PersonalRating = 10, Status = CollectionStatus.Wishlist });
+
+        var byYear = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?yearFrom=1990&yearTo=2000");
+        var only = Assert.Single(byYear!);
+        Assert.Equal("OK Computer", only.Title);
+
+        var byArtist = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?artist=Radiohead");
+        Assert.Single(byArtist!);
+
+        var byLabel = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?label=Merge");
+        Assert.Single(byLabel!);
+
+        var byGenre = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?genre=indie");
+        Assert.Single(byGenre!);
+
+        var byStatus = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?status=Wishlist");
+        Assert.Single(byStatus!);
+
+        var byRating = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?ratingMin=9");
+        Assert.Equal(2, byRating!.Length);
+    }
+
     // -------- Tags --------
 
     [Fact]


### PR DESCRIPTION
Closes #25. Adds a faceted-filter layer on every list page, end to end. URL-synced so deep-linking + browser back/forward work, AND across distinct filters and OR within multi-value filters per the issue spec.

## Summary

### Backend

Each list endpoint gains the missing filter params (existing ones — `format`, `year`, `platform`, `digital` — stay for back-compat):

| | New params |
|---|---|
| `GET /api/movies` | `yearFrom`, `yearTo`, `director`, `studio`, `genre`, `status`, `watchStatus`, `ratingMin`, `tag` (repeatable) |
| `GET /api/music` | `yearFrom`, `yearTo`, `artist`, `label`, `genre`, `status`, `ratingMin`, `tag` |
| `GET /api/games` | `yearFrom`, `yearTo`, `publisher`, `developer`, `status`, `completionStatus`, `digitalStore`, `ratingMin`, `tag` |

- **Semantics**: `AND` across distinct filters, `OR` within the multi-value `tag` filter (item matches if any of its tags are in the requested set). Per the issue: "OR semantics within multi-value filters."
- Tag values are lower-cased before the predicate runs (matches `TagResolver`), so the URL doesn't have to care about case.
- Predicates are explicit per type — three endpoints don't justify a generic builder.

### Frontend

- **`services/filters.ts`** — per-type `Filters` interfaces, `filtersToParams()` / `paramsToFilters()` round-trip via `URLSearchParams`, and a `useFiltersState(type)` hook that bidirectionally syncs filters with the URL `?search`. Unrelated params (e.g. the search input's `q` if you wire one up) are preserved on every update.
- **`services/collection.ts`** — `useList(type, query, filters?)` serializes filters into the request URL and folds them into the TanStack query key so a filter change refetches deterministically.
- **`components/FiltersPanel.tsx`** — collapsible disclosure with an active-count + **Clear all**; opens to a grid of fields appropriate to the type (year range, free-text substring inputs, enum selects, digital/physical toggle, min-rating select). Active filters render as **removable chips** above the panel body so users can drop one at a time.
- **`CollectionList`** wires the panel above the search input and threads the filters into `useList`.

## Test plan

### CI
- [x] `dotnet test` — **server 286/286** (was 278; +8).
- [x] `npm test -- --run` — **client 73/73** (was 66; +7).
- [x] Server + Vite builds clean.

### Backend (per-type filter tests)
- **Movies**: year range inclusive, director/studio/genre substring, status+watch+rating, tag OR semantics, AND combination (`director=Nolan&yearFrom=2015`).
- **Music**: year range + artist/label/genre/status/rating.
- **Games**: year range + publisher / developer / completionStatus / rating. Existing platform + digital tests stay green.

### Frontend (`filters.test.ts`)
- `filtersToParams`: omits `undefined` / `null` / empty / `NaN`; repeats array values; stringifies booleans + numbers; drops empty strings inside arrays.
- `activeFilterCount`: counts set scalars, treats empty arrays as inactive, ignores empty strings.

### Manual
- [x] Open `/movies`, click **Filters**, set `Director: Nolan` + `Year range: 2015–`. List narrows to a single row. URL shows `?director=Nolan&yearFrom=2015`. Browser back undoes filters one step.
- [x] Refresh the page after deep-linking that URL: filters re-hydrate, list stays narrowed.
- [x] Click the chip for `Director: Nolan` ✕ → removed from URL + list reflows.
- [x] **Clear all** wipes every filter but leaves the search input's `q` alone.
- [x] Repeat the smoke on `/music` and `/games`.

## Out of scope

- **Saved filter presets / "smart playlists"** — listed in the issue, deferred.
- **Sort options** — separate enhancement; default `OrderByDescending(AddedAt)` stays.
- **Server-side fuzzy / typo tolerance** — `LIKE %x%` is enough at our cardinality.
- **Multi-value enum filters** (e.g. `?platform=Ps5&platform=Switch`) — single-value selects today; documented as a future enhancement if the URL parameter starts feeling cramped. The server already accepts repeated `tag` so the same shape will plug in.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1dDSYJadWoKd8porzootw)_