### PR TITLE
docs(env): list full env-var inventory for all metadata providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,68 @@
-# Copy to .env to override defaults.
-# Phase 2 metadata provider keys (all optional). Each provider degrades
-# gracefully when its config block is unset -- the lookup endpoint replies
-# with `configured: false` and an empty result set.
+# Copy to .env to override defaults. Every variable in this file is
+# OPTIONAL — the app boots with sensible defaults. A provider is only
+# "configured" (and its UI affordances visible) once its required keys
+# are set; until then the matching lookup endpoint replies with
+# { configured: false } and an empty result set.
+#
+# ASP.NET binds these via the "__" double-underscore separator
+# (Collectify__Metadata__Tmdb__ApiKey === Collectify:Metadata:Tmdb:ApiKey
+# in appsettings.json).
 
-# TMDB (movies). Get a v3 API key at https://www.themoviedb.org/settings/api
+# ----------------------------------------------------------------------
+# Cross-provider knobs
+# ----------------------------------------------------------------------
+# How long a cached LookupCache row stays fresh before the provider is
+# re-queried. Format is .NET TimeSpan (d.hh:mm:ss). Default: 30 days.
+# Collectify__Metadata__CacheTtl=30.00:00:00
+
+# ----------------------------------------------------------------------
+# TMDB — movies (https://www.themoviedb.org/settings/api)
+# ----------------------------------------------------------------------
+# Required to enable movie lookup. Use a v3 API key (not the Read Access Token).
 # Collectify__Metadata__Tmdb__ApiKey=
+# Override only if you're proxying TMDB or running tests. Defaults are fine.
+# Collectify__Metadata__Tmdb__BaseUrl=https://api.themoviedb.org/3/
+# Collectify__Metadata__Tmdb__ImageBaseUrl=https://image.tmdb.org/t/p/w342
 
-# MusicBrainz (music). No key, but you must set a contact-bearing User-Agent
-# per their etiquette. Format: "AppName/Version (contact@example.com)"
+# ----------------------------------------------------------------------
+# MusicBrainz — music (https://musicbrainz.org/doc/MusicBrainz_API)
+# ----------------------------------------------------------------------
+# No API key, but MusicBrainz requires a contact-bearing User-Agent string
+# per their etiquette policy. Format: "AppName/Version (contact@example.com)"
+# Unset = music lookup is skipped.
 # Collectify__Metadata__MusicBrainz__UserAgent=
+# Collectify__Metadata__MusicBrainz__BaseUrl=https://musicbrainz.org/ws/2/
 
-# IGDB (games). Twitch app credentials -- IGDB uses Twitch OAuth.
-# https://dev.twitch.tv/console/apps
+# ----------------------------------------------------------------------
+# IGDB — games (https://api-docs.igdb.com/#getting-started)
+# ----------------------------------------------------------------------
+# IGDB uses Twitch OAuth. Create an app at https://dev.twitch.tv/console/apps
+# and copy both the client id and secret. Both are required to enable game lookup.
 # Collectify__Metadata__Igdb__TwitchClientId=
 # Collectify__Metadata__Igdb__TwitchClientSecret=
+# Collectify__Metadata__Igdb__BaseUrl=https://api.igdb.com/v4/
+
+# ----------------------------------------------------------------------
+# UPCitemdb — barcode fallback for movies/games when the per-type provider
+# doesn't recognise a UPC. (MusicBrainz handles barcodes natively and
+# skips this step.) The free trial endpoint is IP rate-limited and has
+# no key, so there's nothing to set unless you're swapping to a paid tier.
+# ----------------------------------------------------------------------
+# Collectify__Metadata__Upc__BaseUrl=https://api.upcitemdb.com/
+
+# ----------------------------------------------------------------------
+# Auth — open registration is OFF by default so single-user installs
+# stay single-user. Flip to "true" if you want the /register page and
+# POST /api/auth/register endpoint exposed.
+# ----------------------------------------------------------------------
+# Collectify__Auth__AllowRegistration=false
+
+# ----------------------------------------------------------------------
+# Runtime / paths — docker-compose.yml sets sane defaults; override only
+# if you're running outside the supplied compose file.
+# ----------------------------------------------------------------------
+# Directory for collectify.db (and EF migrations). In the container this
+# is /data, which is bound to a named volume.
+# Collectify__DataDir=/data
+# ASPNETCORE_URLS=http://+:8080
+# ASPNETCORE_ENVIRONMENT=Production


### PR DESCRIPTION
## Summary

- Rewrites `.env.example` to spell out every `Collectify__*` knob the app reads, grouped by provider with required-vs-default keys called out so users know exactly which one to set to enable a given lookup.
- Adds entries that were missing entirely (`Collectify__Metadata__CacheTtl`, `Collectify__Metadata__Upc__BaseUrl`, `Collectify__Auth__AllowRegistration`, `Collectify__DataDir`, `ASPNETCORE_*`) plus per-provider `BaseUrl` overrides for completeness.
- All entries stay commented-out (file's job is "uncomment to override defaults").

Part of #39 (consumer-facing docs slice — independent of the registry-publish work).

## Test plan

- [x] No code changes; file is read at boot by `IConfiguration` and every line maps to an existing `Options` property (verified against `MetadataLookupOptions.cs` + `AuthOptions.cs`).
- [ ] After merge: `docker compose up` with a copied `.env` and a TMDB key → confirm `/api/lookup/movies?query=...` returns results.