### PR TITLE
feat(ci,docker): release workflow for multi-arch image publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,10 @@ jobs:
           echo "name=${REF}" >> "$GITHUB_OUTPUT"
           # Assembly Version wants pure semver without the "v" prefix.
           echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+          # Resolve the actual commit SHA for the OCI revision label.
+          # During workflow_dispatch, github.sha is the dispatch ref (main),
+          # not necessarily the checked-out tag — so we resolve it explicitly.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -140,15 +144,15 @@ jobs:
           # semver tags via flavor=latest=auto (the default), so v1.2.3-rc1
           # won't clobber :latest but v1.2.3 will.
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.tag.outputs.name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.name }}
-            type=semver,pattern={{major}},value=${{ steps.tag.outputs.name }}
+            type=semver,pattern=v{{version}},value=${{ steps.tag.outputs.name }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ steps.tag.outputs.name }}
+            type=semver,pattern=v{{major}},value=${{ steps.tag.outputs.name }}
           labels: |
             org.opencontainers.image.title=Collectify
             org.opencontainers.image.description=Self-hosted media collection tracker
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.tag.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.tag.outputs.sha }}
 
       - name: Build and push (linux/amd64, linux/arm64)
         uses: docker/build-push-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,167 @@
+name: Release
+
+# Triggered by pushing a semver tag (e.g. `git tag v1.2.3 && git push --tags`).
+# Builds a multi-arch image and publishes it to a configurable OCI registry.
+#
+# REGISTRY CONFIGURATION
+# Set these in repository "Settings → Secrets and variables → Actions":
+#
+#   Variables (public, can be overridden per-fork):
+#     REGISTRY          host of the target registry. Default: ghcr.io.
+#                       Examples: "git.example.com", "registry.example.com:5000".
+#     IMAGE_NAME        path within the registry. Default: <owner>/<repo>
+#                       (e.g. "mforce/collectify"). Override if your registry
+#                       expects a different namespace (e.g. "library/collectify").
+#
+#   Secrets (private):
+#     REGISTRY_USER     username for `docker login`. Default: github.actor.
+#                       For Gitea / Harbor / a private registry, this is the
+#                       account whose token is in REGISTRY_TOKEN.
+#     REGISTRY_TOKEN    password or personal access token. Required.
+#
+# The defaults publish to GHCR using the bot identity that triggered the run,
+# which works out-of-the-box for public GitHub repos. To target Gitea instead,
+# set REGISTRY + IMAGE_NAME as vars and REGISTRY_USER + REGISTRY_TOKEN as
+# secrets. No workflow code change needed.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to (re-)publish, e.g. v1.2.3'
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || github.repository }}
+
+jobs:
+  test-server:
+    name: Server tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/server
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore Collectify.slnx
+
+      - name: Build
+        run: dotnet build Collectify.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --logger "console;verbosity=normal"
+
+  test-client:
+    name: Client tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/client
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: src/client/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  publish:
+    name: Build and push multi-arch image
+    needs: [test-server, test-client]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed when REGISTRY defaults to ghcr.io and the workflow logs in
+      # with the workflow's GITHUB_TOKEN. Harmless for other registries.
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          # Strip optional leading "refs/tags/" if present.
+          REF="${REF#refs/tags/}"
+          echo "name=${REF}" >> "$GITHUB_OUTPUT"
+          # Assembly Version wants pure semver without the "v" prefix.
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER || github.actor }}
+          # Falls back to the workflow's GITHUB_TOKEN so the out-of-the-box
+          # default (publishing to ghcr.io with the run's identity) works
+          # without any repo secrets configured.
+          password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags and OCI labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # metadata-action also adds :latest automatically for non-prerelease
+          # semver tags via flavor=latest=auto (the default), so v1.2.3-rc1
+          # won't clobber :latest but v1.2.3 will.
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.tag.outputs.name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.name }}
+            type=semver,pattern={{major}},value=${{ steps.tag.outputs.name }}
+          labels: |
+            org.opencontainers.image.title=Collectify
+            org.opencontainers.image.description=Self-hosted media collection tracker
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push (linux/amd64, linux/arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.tag.outputs.version }}
+          # GitHub Actions cache. First release is a cold build; subsequent
+          # ones reuse layers (apt-get curl install, npm install, dotnet
+          # restore) and finish in a fraction of the time.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,17 @@ RUN npm run build
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS server-build
 WORKDIR /server
+# Stamped into the published assembly so /api/health reports the
+# release version. Defaults to 0.0.0 for local builds; the release
+# workflow passes --build-arg VERSION=<git tag without leading v>.
+ARG VERSION=0.0.0
 COPY src/server/ ./
 RUN dotnet restore Collectify.slnx
 COPY --from=client-build /client/dist ./Collectify.Api/wwwroot
-RUN dotnet publish Collectify.Api/Collectify.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish Collectify.Api/Collectify.Api.csproj -c Release -o /app/publish \
+    /p:UseAppHost=false \
+    /p:Version=${VERSION} \
+    /p:InformationalVersion=${VERSION}
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml`: tag-triggered (`v*.*.*`) workflow that gates on `dotnet test` + `npm test`, then builds **linux/amd64 + linux/arm64** with buildx/QEMU and publishes to a configurable OCI registry.
- `Dockerfile` gains a `VERSION` build-arg, stamped into the published assembly via `/p:Version` and `/p:InformationalVersion` — so `/api/health` reports the actual release tag instead of `0.0.0`.
- Registry config is fully parameterised by repo vars + secrets, so swapping between Gitea, GHCR, Docker Hub, or self-hosted Harbor is a config change with no workflow edit:

  | Setting | Default | Purpose |
  |---|---|---|
  | `vars.REGISTRY` | `ghcr.io` | Registry host (e.g. `git.example.com`). |
  | `vars.IMAGE_NAME` | `<owner>/<repo>` | Image path inside the registry. |
  | `secrets.REGISTRY_USER` | `github.actor` | Username for `docker login`. |
  | `secrets.REGISTRY_TOKEN` | `secrets.GITHUB_TOKEN` | Password / PAT. |

  Defaults publish to GHCR using the run's identity, so the workflow is functional out-of-the-box on a fresh fork. For your Gitea, set `vars.REGISTRY = <gitea host>`, `secrets.REGISTRY_USER = <user>`, `secrets.REGISTRY_TOKEN = <PAT>` — done.

- `docker/metadata-action` derives `:vX.Y.Z`, `:vX.Y`, `:vX`, and `:latest` (auto-skipped for prereleases like `v1.2.3-rc1`).
- OCI labels: `title`, `description`, `source`, `version`, `revision` — populated from the run context so registry UIs show useful metadata.
- Workflow_dispatch fallback so a published tag can be re-published manually (e.g. after fixing a workflow bug) without recreating the git tag.

Part of #39, phase 2 of 6.

## Phasing

1. [x] **Phase 1: Health endpoint + Dockerfile `HEALTHCHECK`** — completed in #40.
2. [x] **Phase 2: Release workflow + multi-arch publish** — this PR.
3. [ ] **Phase 3: Consumer compose example + README rewrite** — switch self-hosters from clone-and-build to pull-and-run.
4. [ ] **Phase 4: DB auto-backup before EF migrations** — protect self-hosted upgrades.
5. [ ] **Phase 5: CHANGELOG + OCI labels + image scan** — improve release visibility and registry metadata.
6. [ ] **Phase 6: Optional runtime polish** — alpine runtime and/or digest pinning after measurement.

## Test plan

- [x] Workflow YAML parses (`yaml.safe_load`).
- [x] Local `dotnet build … -p:Version=0.0.99 -p:InformationalVersion=0.0.99` stamps the assembly correctly (verified via `strings` on the DLL).
- [ ] **After merge**: set `secrets.REGISTRY_USER` + `secrets.REGISTRY_TOKEN` (and optionally `vars.REGISTRY` + `vars.IMAGE_NAME` for Gitea) in repo settings, then `git tag v0.1.0 && git push --tags`. Confirm:
  - Both test jobs pass.
  - Publish job builds amd64 + arm64.
  - Image appears in the registry with tags `:v0.1.0`, `:v0.1`, `:v0`, `:latest`.
  - `curl https://<host>/api/health` on a running container returns `{"status":"ok","version":"0.1.0"}`.

## Follow-ups (out of scope)

- Phase 3: README rewrite + consumer compose example that pulls from the registry instead of building.
- Phase 4: DB auto-backup before EF migrations.
- Phase 5: CHANGELOG, trivy scan in CI, image digest pinning.
