### PR TITLE
feat(ui): category-specific accent colors for movies/music/games

### DIFF
--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -24,9 +24,10 @@ interface Props<T extends MediaType> {
   title: string;
   newPath: string;
   renderItem: (item: any) => RenderedItem;
+  category?: 'movies' | 'music' | 'games';
 }
 
-export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem }: Props<T>) {
+export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem, category }: Props<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get('q') ?? '';
   const setQuery = (next: string) => {
@@ -48,10 +49,13 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
     navigate(newPath, { state: { barcodeOnly: code } });
   };
 
+  // Card hover border class — category accent or brand fallback
+  const cardHoverBorder = category ? `group-hover:border-${category}/30` : 'group-hover:border-brand/30';
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4">
-        <h1 className="text-xl font-medium text-text-primary tracking-tight">{title}</h1>
+        <h1 className={`text-xl font-medium tracking-tight ${category ? `text-${category}` : 'text-text-primary'}`}>{title}</h1>
         <div className="flex items-center gap-2">
           <BarcodeLookup
             type={type}
@@ -59,7 +63,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
             onBarcodeFallback={onBarcodeFallback}
           />
           <Link to={newPath}>
-            <Button>+ Add</Button>
+            <Button variant={category ? 'secondary' : 'primary'} className={category ? `border-${category}/30 text-${category}` : ''}>+ Add</Button>
           </Link>
         </div>
       </div>
@@ -90,7 +94,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
           const tags = base.tags ?? [];
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="group block">
-              <Card className="h-full !p-0 overflow-hidden transition-shadow hover:shadow-md group-hover:border-brand/30 dark:hover:bg-card/80">
+              <Card className={`h-full !p-0 overflow-hidden transition-shadow hover:shadow-md ${cardHoverBorder} dark:hover:bg-card/80`}>
                 <div className="flex flex-col md:flex-row">
                   {/* Cover art — scales with breakpoint, horizontal at md+ */}
                   <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
@@ -115,7 +119,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
                   <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
                     <div className="flex items-start justify-between gap-2">
                       <h3 className="font-medium text-text-primary leading-snug line-clamp-2">{r.primary}</h3>
-                      <StatusPill status={base.status} />
+                      <StatusPill status={base.status} category={category} />
                     </div>
 
                     {r.secondary && (
@@ -126,13 +130,13 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
                     )}
 
                     {base.personalRating != null && (
-                      <div className="text-sm text-brand font-medium">★ {base.personalRating}/10</div>
+                      <div className={`text-sm font-medium ${category ? `text-${category}` : 'text-brand'}`}>★ {base.personalRating}/10</div>
                     )}
 
                     {tags.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-auto pt-1">
                         {tags.slice(0, 4).map((t) => (
-                          <TagChip key={t} name={t} />
+                          <TagChip key={t} name={t} category={category} />
                         ))}
                         {tags.length > 4 && (
                           <span className="text-xs text-text-tertiary">+{tags.length - 4}</span>

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -27,6 +27,24 @@ interface Props<T extends MediaType> {
   category?: 'movies' | 'music' | 'games';
 }
 
+const TITLE_CLASS: Record<string, string> = {
+  movies: 'text-movies',
+  music: 'text-music',
+  games: 'text-games',
+};
+
+const BTN_CLASS: Record<string, string> = {
+  movies: 'border-movies-light text-movies',
+  music: 'border-music-light text-music',
+  games: 'border-games-light text-games',
+};
+
+const CARD_BORDER: Record<string, string> = {
+  movies: 'group-hover:border-movies',
+  music: 'group-hover:border-music',
+  games: 'group-hover:border-games',
+};
+
 export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem, category }: Props<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get('q') ?? '';
@@ -49,13 +67,15 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
     navigate(newPath, { state: { barcodeOnly: code } });
   };
 
-  // Card hover border class — category accent or brand fallback
-  const cardHoverBorder = category ? `group-hover:border-${category}/30` : 'group-hover:border-brand/30';
+  // Hardcoded class lookups — Tailwind can't detect dynamic template literals
+  const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
+  const btnClass = category ? BTN_CLASS[category] : '';
+  const cardBorder = category ? CARD_BORDER[category] : 'group-hover:border-brand/30';
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4">
-        <h1 className={`text-xl font-medium tracking-tight ${category ? `text-${category}` : 'text-text-primary'}`}>{title}</h1>
+        <h1 className={`text-xl font-medium tracking-tight ${titleClass}`}>{title}</h1>
         <div className="flex items-center gap-2">
           <BarcodeLookup
             type={type}
@@ -63,7 +83,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
             onBarcodeFallback={onBarcodeFallback}
           />
           <Link to={newPath}>
-            <Button variant={category ? 'secondary' : 'primary'} className={category ? `border-${category}/30 text-${category}` : ''}>+ Add</Button>
+            <Button variant={category ? 'secondary' : 'primary'} className={btnClass}>+ Add</Button>
           </Link>
         </div>
       </div>
@@ -94,7 +114,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
           const tags = base.tags ?? [];
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="group block">
-              <Card className={`h-full !p-0 overflow-hidden transition-shadow hover:shadow-md ${cardHoverBorder} dark:hover:bg-card/80`}>
+              <Card className={`h-full !p-0 overflow-hidden transition-shadow hover:shadow-md ${cardBorder} dark:hover:bg-card/80`}>
                 <div className="flex flex-col md:flex-row">
                   {/* Cover art — scales with breakpoint, horizontal at md+ */}
                   <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
@@ -130,7 +150,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
                     )}
 
                     {base.personalRating != null && (
-                      <div className={`text-sm font-medium ${category ? `text-${category}` : 'text-brand'}`}>★ {base.personalRating}/10</div>
+                      <div className={`text-sm font-medium ${category ? TITLE_CLASS[category] : 'text-brand'}`}>★ {base.personalRating}/10</div>
                     )}
 
                     {tags.length > 0 && (

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -13,10 +13,17 @@ const navItems: { to: string; label: string; category: NavCategory | null }[] = 
   { to: '/tags', label: 'Tags', category: null },
 ];
 
-const catColor = (cat: string | null) =>
-  cat === 'movies' ? 'text-movies' : cat === 'music' ? 'text-music' : cat === 'games' ? 'text-games' : 'text-brand';
-const catBorder = (cat: string | null) =>
-  cat === 'movies' ? 'border-movies/30' : cat === 'music' ? 'border-music/30' : cat === 'games' ? 'border-games/30' : 'border-brand/20';
+const NAV_ACTIVE_DESKTOP: Record<string, string> = {
+  movies: 'text-movies font-medium border-b-2 border-movies',
+  music: 'text-music font-medium border-b-2 border-music',
+  games: 'text-games font-medium border-b-2 border-games',
+};
+
+const NAV_ACTIVE_MOBILE: Record<string, string> = {
+  movies: 'text-movies font-medium',
+  music: 'text-music font-medium',
+  games: 'text-games font-medium',
+};
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { data: auth } = useAuth();
@@ -63,7 +70,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `inline-flex items-center px-3 py-1.5 rounded text-sm transition-colors ${
                     isActive
-                      ? `${catColor(item.category)} font-medium border-b-2 ${catBorder(item.category)}`
+                      ? NAV_ACTIVE_DESKTOP[item.category ?? ''] ?? ''
                       : 'text-text-secondary hover:text-text-primary'
                   }`
                 }
@@ -120,7 +127,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `block px-3 py-2 rounded text-sm transition-colors ${
                     isActive
-                      ? `${catColor(item.category)} font-medium`
+                      ? NAV_ACTIVE_MOBILE[item.category ?? ''] ?? ''
                       : 'text-text-secondary hover:text-text-primary hover:bg-gray-50 dark:hover:bg-[#353840]'
                   }`
                 }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -17,12 +17,14 @@ const NAV_ACTIVE_DESKTOP: Record<string, string> = {
   movies: 'text-movies font-medium border-b-2 border-movies',
   music: 'text-music font-medium border-b-2 border-music',
   games: 'text-games font-medium border-b-2 border-games',
+  default: 'text-brand font-medium border-b-2 border-brand/30',
 };
 
 const NAV_ACTIVE_MOBILE: Record<string, string> = {
   movies: 'text-movies font-medium',
   music: 'text-music font-medium',
   games: 'text-games font-medium',
+  default: 'text-brand font-medium',
 };
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -70,7 +72,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `inline-flex items-center px-3 py-1.5 rounded text-sm transition-colors ${
                     isActive
-                      ? NAV_ACTIVE_DESKTOP[item.category ?? ''] ?? ''
+                      ? NAV_ACTIVE_DESKTOP[item.category ?? 'default'] ?? ''
                       : 'text-text-secondary hover:text-text-primary'
                   }`
                 }
@@ -127,7 +129,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `block px-3 py-2 rounded text-sm transition-colors ${
                     isActive
-                      ? NAV_ACTIVE_MOBILE[item.category ?? ''] ?? ''
+                      ? NAV_ACTIVE_MOBILE[item.category ?? 'default'] ?? ''
                       : 'text-text-secondary hover:text-text-primary hover:bg-gray-50 dark:hover:bg-[#353840]'
                   }`
                 }

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -4,12 +4,19 @@ import { useAuth, useLogout } from '../services/auth';
 import { useToast } from './toaster';
 import DarkModeToggle from './DarkModeToggle';
 
-const navItems = [
-  { to: '/movies', label: 'Movies' },
-  { to: '/music', label: 'Music' },
-  { to: '/games', label: 'Games' },
-  { to: '/tags', label: 'Tags' },
+type NavCategory = 'movies' | 'music' | 'games';
+
+const navItems: { to: string; label: string; category: NavCategory | null }[] = [
+  { to: '/movies', label: 'Movies', category: 'movies' },
+  { to: '/music', label: 'Music', category: 'music' },
+  { to: '/games', label: 'Games', category: 'games' },
+  { to: '/tags', label: 'Tags', category: null },
 ];
+
+const catColor = (cat: string | null) =>
+  cat === 'movies' ? 'text-movies' : cat === 'music' ? 'text-music' : cat === 'games' ? 'text-games' : 'text-brand';
+const catBorder = (cat: string | null) =>
+  cat === 'movies' ? 'border-movies/30' : cat === 'music' ? 'border-music/30' : cat === 'games' ? 'border-games/30' : 'border-brand/20';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { data: auth } = useAuth();
@@ -56,7 +63,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `inline-flex items-center px-3 py-1.5 rounded text-sm transition-colors ${
                     isActive
-                      ? 'text-brand font-medium'
+                      ? `${catColor(item.category)} font-medium border-b-2 ${catBorder(item.category)}`
                       : 'text-text-secondary hover:text-text-primary'
                   }`
                 }
@@ -113,7 +120,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 className={({ isActive }) =>
                   `block px-3 py-2 rounded text-sm transition-colors ${
                     isActive
-                      ? 'text-brand font-medium'
+                      ? `${catColor(item.category)} font-medium`
                       : 'text-text-secondary hover:text-text-primary hover:bg-gray-50 dark:hover:bg-[#353840]'
                   }`
                 }

--- a/src/client/components/ui.tsx
+++ b/src/client/components/ui.tsx
@@ -264,6 +264,12 @@ const CAT_RATING_FILLED: Record<string, string> = {
   games: 'bg-games/20 border-games/30 text-games',
 };
 
+const CAT_RATING_CLEAR: Record<string, string> = {
+  movies: 'border-movies/40 text-movies hover:border-movies',
+  music: 'border-music/40 text-music hover:border-music',
+  games: 'border-games/40 text-games hover:border-games',
+};
+
 export function RatingInput({ value, onChange, ariaLabel = 'Personal rating', category }: RatingInputProps & { category?: string }) {
   return (
     <div role="radiogroup" aria-label={ariaLabel} className="flex flex-wrap gap-1.5">
@@ -271,6 +277,7 @@ export function RatingInput({ value, onChange, ariaLabel = 'Personal rating', ca
         const selected = value === n;
         const activeClass = category && CAT_RATING_ACTIVE[category] ? CAT_RATING_ACTIVE[category] : 'bg-brand border-brand text-white';
         const filledClass = category && CAT_RATING_FILLED[category] ? CAT_RATING_FILLED[category] : 'bg-brand/20 border-brand/30 text-brand';
+        const clearClass = category && CAT_RATING_CLEAR[category] ? CAT_RATING_CLEAR[category] : 'border-border text-text-secondary hover:border-gray-400';
         return (
           <button
             key={n}
@@ -284,7 +291,7 @@ export function RatingInput({ value, onChange, ariaLabel = 'Personal rating', ca
                 ? activeClass
                 : value != null && n <= value
                   ? filledClass
-                  : 'bg-input-bg border-border text-text-secondary hover:border-gray-400'
+                  : clearClass
             }`}
           >
             {n}
@@ -316,21 +323,21 @@ const STATUS_STYLE: Record<CollectionStatus, string> = {
 
 const CAT_STATUS_STYLE: Record<string, Record<CollectionStatus, string>> = {
   movies: {
-    Owned: 'bg-movies/light text-movies border-movies/border',
-    Wishlist: 'bg-movies/light/60 text-movies/70 border-movies/border',
-    OnOrder: 'bg-movies/light text-movies border-movies/border',
+    Owned: 'bg-movies-light text-movies border-movies-border',
+    Wishlist: 'bg-movies-light/60 text-movies/70 border-movies-border',
+    OnOrder: 'bg-movies-light text-movies border-movies-border',
     Sold: 'bg-pill-bg text-text-tertiary border-border',
   },
   music: {
-    Owned: 'bg-music/light text-music border-music/border',
-    Wishlist: 'bg-music/light/60 text-music/70 border-music/border',
-    OnOrder: 'bg-music/light text-music border-music/border',
+    Owned: 'bg-music-light text-music border-music-border',
+    Wishlist: 'bg-music-light/60 text-music/70 border-music-border',
+    OnOrder: 'bg-music-light text-music border-music-border',
     Sold: 'bg-pill-bg text-text-tertiary border-border',
   },
   games: {
-    Owned: 'bg-games/light text-games border-games/border',
-    Wishlist: 'bg-games/light/60 text-games/70 border-games/border',
-    OnOrder: 'bg-games/light text-games border-games/border',
+    Owned: 'bg-games-light text-games border-games-border',
+    Wishlist: 'bg-games-light/60 text-games/70 border-games-border',
+    OnOrder: 'bg-games-light text-games border-games-border',
     Sold: 'bg-pill-bg text-text-tertiary border-border',
   },
 };
@@ -357,9 +364,9 @@ export function ConditionPill({ condition }: { condition: Condition }) {
 // ─── Tag chips & input ──────────────────────────────────────────
 
 const CAT_TAG_STYLE: Record<string, string> = {
-  movies: 'bg-movies/light text-movies border-movies/border hover:bg-movies/20',
-  music: 'bg-music/light text-music border-music/border hover:bg-music/20',
-  games: 'bg-games/light text-games border-games/border hover:bg-games/20',
+  movies: 'bg-movies-light text-movies border-movies-border hover:bg-movies/20',
+  music: 'bg-music-light text-music border-music-border hover:bg-music/20',
+  games: 'bg-games-light text-games border-games-border hover:bg-games/20',
 };
 
 export function TagChip({ name, category, onRemove }: { name: string; category?: string; onRemove?: () => void }) {

--- a/src/client/components/ui.tsx
+++ b/src/client/components/ui.tsx
@@ -252,11 +252,25 @@ interface RatingInputProps {
   ariaLabel?: string;
 }
 
-export function RatingInput({ value, onChange, ariaLabel = 'Personal rating' }: RatingInputProps) {
+const CAT_RATING_ACTIVE: Record<string, string> = {
+  movies: 'bg-movies border-movies text-white',
+  music: 'bg-music border-music text-white',
+  games: 'bg-games border-games text-white',
+};
+
+const CAT_RATING_FILLED: Record<string, string> = {
+  movies: 'bg-movies/20 border-movies/30 text-movies',
+  music: 'bg-music/20 border-music/30 text-music',
+  games: 'bg-games/20 border-games/30 text-games',
+};
+
+export function RatingInput({ value, onChange, ariaLabel = 'Personal rating', category }: RatingInputProps & { category?: string }) {
   return (
     <div role="radiogroup" aria-label={ariaLabel} className="flex flex-wrap gap-1.5">
       {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => {
         const selected = value === n;
+        const activeClass = category && CAT_RATING_ACTIVE[category] ? CAT_RATING_ACTIVE[category] : 'bg-brand border-brand text-white';
+        const filledClass = category && CAT_RATING_FILLED[category] ? CAT_RATING_FILLED[category] : 'bg-brand/20 border-brand/30 text-brand';
         return (
           <button
             key={n}
@@ -267,9 +281,9 @@ export function RatingInput({ value, onChange, ariaLabel = 'Personal rating' }: 
             onClick={() => onChange(selected ? null : n)}
             className={`w-9 h-9 rounded text-sm font-medium border transition-colors ${
               selected
-                ? 'bg-brand border-brand text-white'
+                ? activeClass
                 : value != null && n <= value
-                  ? 'bg-brand/20 border-brand/30 text-brand'
+                  ? filledClass
                   : 'bg-input-bg border-border text-text-secondary hover:border-gray-400'
             }`}
           >
@@ -294,16 +308,38 @@ export function RatingInput({ value, onChange, ariaLabel = 'Personal rating' }: 
 // ─── Pills ───────────────────────────────────────────────────────
 
 const STATUS_STYLE: Record<CollectionStatus, string> = {
-  Owned: 'bg-brand/10 text-brand border-brand/20',
+  Owned: 'bg-pill-bg text-text-secondary border-border',
   Wishlist: 'bg-pill-bg text-text-secondary border-border',
-  OnOrder: 'bg-brand/15 text-brand border-brand/30',
+  OnOrder: 'bg-pill-bg text-text-secondary border-border',
   Sold: 'bg-pill-bg text-text-tertiary border-border',
 };
 
-export function StatusPill({ status }: { status: CollectionStatus }) {
+const CAT_STATUS_STYLE: Record<string, Record<CollectionStatus, string>> = {
+  movies: {
+    Owned: 'bg-movies/light text-movies border-movies/border',
+    Wishlist: 'bg-movies/light/60 text-movies/70 border-movies/border',
+    OnOrder: 'bg-movies/light text-movies border-movies/border',
+    Sold: 'bg-pill-bg text-text-tertiary border-border',
+  },
+  music: {
+    Owned: 'bg-music/light text-music border-music/border',
+    Wishlist: 'bg-music/light/60 text-music/70 border-music/border',
+    OnOrder: 'bg-music/light text-music border-music/border',
+    Sold: 'bg-pill-bg text-text-tertiary border-border',
+  },
+  games: {
+    Owned: 'bg-games/light text-games border-games/border',
+    Wishlist: 'bg-games/light/60 text-games/70 border-games/border',
+    OnOrder: 'bg-games/light text-games border-games/border',
+    Sold: 'bg-pill-bg text-text-tertiary border-border',
+  },
+};
+
+export function StatusPill({ status, category }: { status: CollectionStatus; category?: string }) {
   const label = COLLECTION_STATUSES.find((s) => s.value === status)?.label ?? status;
+  const style = category && CAT_STATUS_STYLE[category] ? CAT_STATUS_STYLE[category][status] : STATUS_STYLE[status];
   return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border ${STATUS_STYLE[status]}`}>
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border ${style}`}>
       {label}
     </span>
   );
@@ -320,16 +356,23 @@ export function ConditionPill({ condition }: { condition: Condition }) {
 
 // ─── Tag chips & input ──────────────────────────────────────────
 
-export function TagChip({ name, onRemove }: { name: string; onRemove?: () => void }) {
+const CAT_TAG_STYLE: Record<string, string> = {
+  movies: 'bg-movies/light text-movies border-movies/border hover:bg-movies/20',
+  music: 'bg-music/light text-music border-music/border hover:bg-music/20',
+  games: 'bg-games/light text-games border-games/border hover:bg-games/20',
+};
+
+export function TagChip({ name, category, onRemove }: { name: string; category?: string; onRemove?: () => void }) {
+  const style = category && CAT_TAG_STYLE[category] ? CAT_TAG_STYLE[category] : 'bg-brand/10 text-brand border-brand/20 hover:bg-brand/20';
   return (
-    <span className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-xs bg-brand/10 text-brand border border-brand/20">
+    <span className={`inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-xs ${style}`}>
       {name}
       {onRemove && (
         <button
           type="button"
           onClick={onRemove}
           aria-label={`Remove tag ${name}`}
-          className="inline-flex items-center justify-center min-w-[24px] min-h-[24px] rounded-full hover:bg-brand/20 transition-colors"
+          className="inline-flex items-center justify-center min-w-[24px] min-h-[24px] rounded-full hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
         >
           ×
         </button>
@@ -343,9 +386,10 @@ interface TagInputProps {
   onChange: (next: string[]) => void;
   suggestions?: string[];
   placeholder?: string;
+  category?: string;
 }
 
-export function TagInput({ value, onChange, suggestions = [], placeholder = 'Add tag…' }: TagInputProps) {
+export function TagInput({ value, onChange, suggestions = [], placeholder = 'Add tag…', category }: TagInputProps) {
   const [draft, setDraft] = useState('');
 
   const commit = (raw: string) => {
@@ -376,7 +420,7 @@ export function TagInput({ value, onChange, suggestions = [], placeholder = 'Add
     <div>
       <div className="flex flex-wrap gap-1.5 items-center rounded border border-border bg-card p-1.5 focus-within:border-brand transition-colors">
         {value.map((t) => (
-          <TagChip key={t} name={t} onRemove={() => remove(t)} />
+          <TagChip key={t} name={t} category={category} onRemove={() => remove(t)} />
         ))}
         <input
           value={draft}

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -8,13 +8,16 @@ const TYPE_LABEL: Record<DashboardRecent['type'], string> = {
   games: 'Game',
 };
 
+const TILE_BORDER: Record<string, string> = {
+  movies: 'border-t-movies',
+  music: 'border-t-music',
+  games: 'border-t-games',
+};
+
 export default function Dashboard() {
   const dashboard = useDashboard();
   const summary = dashboard.data;
   const counts = summary?.counts;
-
-  const catBorder = (type: string) =>
-    type === 'movies' ? 'border-t-movies' : type === 'music' ? 'border-t-music' : type === 'games' ? 'border-t-games' : '';
 
   const tiles = [
     { to: '/movies', label: 'Movies', count: counts?.movies, type: 'movies' as const },
@@ -29,7 +32,7 @@ export default function Dashboard() {
       <div className="grid sm:grid-cols-3 gap-3">
         {tiles.map((t) => (
           <Link key={t.to} to={t.to} className="block">
-            <Card className={`hover:border-brand/40 transition-colors border-t-2 ${catBorder(t.type)}`}>
+            <Card className={`hover:border-brand/40 transition-colors border-t-2 ${TILE_BORDER[t.type]}`}>
               <div className="text-text-secondary text-sm">{t.label}</div>
               <div className="text-2xl font-medium text-text-primary mt-1">
                 {t.count ?? '…'}

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -13,10 +13,13 @@ export default function Dashboard() {
   const summary = dashboard.data;
   const counts = summary?.counts;
 
+  const catBorder = (type: string) =>
+    type === 'movies' ? 'border-t-movies' : type === 'music' ? 'border-t-music' : type === 'games' ? 'border-t-games' : '';
+
   const tiles = [
-    { to: '/movies', label: 'Movies', count: counts?.movies },
-    { to: '/music', label: 'Music', count: counts?.music },
-    { to: '/games', label: 'Games', count: counts?.games },
+    { to: '/movies', label: 'Movies', count: counts?.movies, type: 'movies' as const },
+    { to: '/music', label: 'Music', count: counts?.music, type: 'music' as const },
+    { to: '/games', label: 'Games', count: counts?.games, type: 'games' as const },
   ];
 
   return (
@@ -26,7 +29,7 @@ export default function Dashboard() {
       <div className="grid sm:grid-cols-3 gap-3">
         {tiles.map((t) => (
           <Link key={t.to} to={t.to} className="block">
-            <Card className="hover:border-brand/40 transition-colors">
+            <Card className={`hover:border-brand/40 transition-colors border-t-2 ${catBorder(t.type)}`}>
               <div className="text-text-secondary text-sm">{t.label}</div>
               <div className="text-2xl font-medium text-text-primary mt-1">
                 {t.count ?? '…'}

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -7,6 +7,7 @@ export default function GamesList() {
       type="games"
       title="Games"
       newPath="/games/new"
+      category="games"
       renderItem={(g: Game) => {
         // Prefer the canonical label; fall back to the legacy free-text
         // when the row is still pending re-classification so the card

--- a/src/client/pages/MoviesList.tsx
+++ b/src/client/pages/MoviesList.tsx
@@ -7,6 +7,7 @@ export default function MoviesList() {
       type="movies"
       title="Movies"
       newPath="/movies/new"
+      category="movies"
       renderItem={(m: Movie) => {
         const fmts = MOVIE_FORMAT_FLAGS.filter((f) => ((m.formats ?? 0) & f.value) !== 0).map((f) => f.label).join(', ');
         return {

--- a/src/client/pages/MusicList.tsx
+++ b/src/client/pages/MusicList.tsx
@@ -7,6 +7,7 @@ export default function MusicList() {
       type="music"
       title="Music"
       newPath="/music/new"
+      category="music"
       renderItem={(a: Album) => ({
         primary: a.title,
         secondary: [a.artistName, a.year].filter(Boolean).join(' · '),

--- a/src/client/tailwind.config.js
+++ b/src/client/tailwind.config.js
@@ -14,22 +14,16 @@ export default {
           DEFAULT: '#0052ff',   // Coinbase Blue — primary CTA / links (neutral fallback)
           hover: '#578bfa',     // lighter blue on hover
         },
-        // Per-category accent colors
-        movies: {
-          DEFAULT: '#f59e0b',   // amber-500 — cinema feel
-          light: 'rgba(245,158,11,0.1)',
-          border: 'rgba(245,158,11,0.2)',
-        },
-        music: {
-          DEFAULT: '#8b5cf6',   // violet-500 — vinyl/creative feel
-          light: 'rgba(139,92,246,0.1)',
-          border: 'rgba(139,92,246,0.2)',
-        },
-        games: {
-          DEFAULT: '#14b8a6',   // teal-500 — gaming feel
-          light: 'rgba(20,184,166,0.1)',
-          border: 'rgba(20,184,166,0.2)',
-        },
+        // Per-category accent colors (flat keys for Tailwind detection)
+        movies: '#f59e0b',
+        'movies-light': 'rgba(245,158,11,0.1)',
+        'movies-border': 'rgba(245,158,11,0.2)',
+        music: '#8b5cf6',
+        'music-light': 'rgba(139,92,246,0.1)',
+        'music-border': 'rgba(139,92,246,0.2)',
+        games: '#14b8a6',
+        'games-light': 'rgba(20,184,166,0.1)',
+        'games-border': 'rgba(20,184,166,0.2)',
         surface: 'var(--color-surface)',       // page background (adapts)
         card: 'var(--color-card)',             // cards/panels (adapts)
         text: {

--- a/src/client/tailwind.config.js
+++ b/src/client/tailwind.config.js
@@ -11,8 +11,24 @@ export default {
       colors: {
         // Coinbase-inspired palette
         brand: {
-          DEFAULT: '#0052ff',   // Coinbase Blue — primary CTA / links
+          DEFAULT: '#0052ff',   // Coinbase Blue — primary CTA / links (neutral fallback)
           hover: '#578bfa',     // lighter blue on hover
+        },
+        // Per-category accent colors
+        movies: {
+          DEFAULT: '#f59e0b',   // amber-500 — cinema feel
+          light: 'rgba(245,158,11,0.1)',
+          border: 'rgba(245,158,11,0.2)',
+        },
+        music: {
+          DEFAULT: '#8b5cf6',   // violet-500 — vinyl/creative feel
+          light: 'rgba(139,92,246,0.1)',
+          border: 'rgba(139,92,246,0.2)',
+        },
+        games: {
+          DEFAULT: '#14b8a6',   // teal-500 — gaming feel
+          light: 'rgba(20,184,166,0.1)',
+          border: 'rgba(20,184,166,0.2)',
         },
         surface: 'var(--color-surface)',       // page background (adapts)
         card: 'var(--color-card)',             // cards/panels (adapts)


### PR DESCRIPTION
## Summary

Fixes #46

Gives each collection type its own accent color so users can instantly tell which section they are in:

- **Movies** → amber/gold (#f59e0b) — cinema feel
- **Music** → violet/purple (#8b5cf6) — vinyl/creative feel  
- **Games** → teal/green (#14b8a6) — gaming feel

### Changes

- **Tailwind config**: added `movies`, `music`, `games` color tokens with light/border variants
- **Nav**: active items use category color + bottom border underline
- **CollectionList cards**: hover borders, status pills, tag chips, and rating stars all adopt the category accent
- **Dashboard stat tiles**: colored top border per type (amber/violet/teal)
- Brand blue (#0052ff) stays as neutral fallback for non-category elements

### Files changed

- `src/client/tailwind.config.js` — new color tokens
- `src/client/components/Layout.tsx` — nav active state per category
- `src/client/components/ui.tsx` — StatusPill, TagChip, RatingInput accept optional `category` prop
- `src/client/components/CollectionList.tsx` — consume category for card styling
- `src/client/pages/Dashboard.tsx` — colored stat tile borders
- `src/client/pages/MoviesList.tsx`, `MusicList.tsx`, `GamesList.tsx` — pass category to CollectionList

### Verification

- [x] `npm run build` clean (tsc + vite)
- [x] All 91 client tests pass
- [x] Light and dark mode compatible (colors are Tailwind palette, no hardcoded overrides needed)