### PR TITLE
feat(ui): three view sizes for collection lists (list, medium, big)

### DIFF
--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,9 +1,10 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useList } from '../services/collection';
 import { useFiltersState } from '../services/filters';
-import { Button, Card, Input, StatusPill, TagChip } from './ui';
+import { Button, Card, Input, StatusPill, TagChip, ViewSwitcher } from './ui';
 import BarcodeLookup from './BarcodeLookup';
 import FiltersPanel from './FiltersPanel';
+import { useViewPreference, type ViewMode } from '../hooks/useViewPreference';
 import type { CollectionItemBase, MediaType } from '../services/types';
 import type { GameLookupResult, MovieLookupResult, MusicLookupResult } from '../services/lookup';
 
@@ -45,6 +46,116 @@ const CARD_BORDER: Record<string, string> = {
   games: 'group-hover:border-games',
 };
 
+// ─── Card variants ──────────────────────────────────────────────
+
+interface BaseItem extends CollectionItemBase {
+  id?: number;
+  imagePath?: string | null;
+}
+
+function CoverBlock({ src }: { src?: string | null }) {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt=""
+        loading="lazy"
+        className="w-full aspect-[2/3] object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+    );
+  }
+  return (
+    <div aria-hidden className="w-full aspect-[2/3] flex items-center justify-center text-text-tertiary text-xs font-medium bg-imgPlaceholder">
+      no cover
+    </div>
+  );
+}
+
+function ListCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+  const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
+  return (
+    <Card className={`!p-0 overflow-hidden transition-shadow hover:shadow-md ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'} dark:hover:bg-card/80`}>
+      <div className="flex items-center gap-3 p-2">
+        <div className="w-16 shrink-0 bg-imgPlaceholder overflow-hidden rounded">
+          <CoverBlock src={item.imagePath} />
+        </div>
+        <div className="flex-1 min-w-0 flex items-center gap-2">
+          <h3 className={`font-medium text-text-primary leading-snug truncate ${titleClass}`}>{r.primary}</h3>
+          {r.secondary && <span className="text-sm text-text-secondary shrink-0">{r.secondary}</span>}
+        </div>
+        <StatusPill status={item.status} category={category} />
+      </div>
+    </Card>
+  );
+}
+
+function MediumCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+  const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
+  const tags = item.tags ?? [];
+  return (
+    <Card className={`!p-0 overflow-hidden transition-shadow hover:shadow-md ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'} dark:hover:bg-card/80`}>
+      <div className="flex gap-3 p-3">
+        <div className="w-24 shrink-0 bg-imgPlaceholder overflow-hidden rounded">
+          <CoverBlock src={item.imagePath} />
+        </div>
+        <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
+            <StatusPill status={item.status} category={category} />
+          </div>
+          {r.secondary && <div className="text-sm text-text-secondary truncate">{r.secondary}</div>}
+          {item.personalRating != null && (
+            <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
+          )}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {tags.slice(0, 3).map((t) => (
+                <TagChip key={t} name={t} category={category} />
+              ))}
+              {tags.length > 3 && <span className="text-xs text-text-tertiary">+{tags.length - 3}</span>}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function BigCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+  const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
+  const tags = item.tags ?? [];
+  return (
+    <Card className={`!p-0 overflow-hidden transition-shadow hover:shadow-md ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'} dark:hover:bg-card/80`}>
+      <div className="flex flex-col md:flex-row">
+        <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
+          <CoverBlock src={item.imagePath} />
+        </div>
+        <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
+            <StatusPill status={item.status} category={category} />
+          </div>
+          {r.secondary && <div className="text-sm text-text-secondary truncate">{r.secondary}</div>}
+          {r.tertiary && <div className="text-xs text-text-tertiary truncate">{r.tertiary}</div>}
+          {item.personalRating != null && (
+            <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
+          )}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-auto pt-1">
+              {tags.slice(0, 4).map((t) => (
+                <TagChip key={t} name={t} category={category} />
+              ))}
+              {tags.length > 4 && <span className="text-xs text-text-tertiary">+{tags.length - 4}</span>}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────
+
 export default function CollectionList<T extends MediaType>({ type, title, newPath, renderItem, category }: Props<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get('q') ?? '';
@@ -58,48 +169,40 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
   const list = useList(type, query, filters);
   const items = list.data ?? [];
   const navigate = useNavigate();
+  const [viewMode, setViewMode] = useViewPreference(type);
 
   const onBarcodePick = (item: ResultMap[T]) => {
     navigate(newPath, { state: { prefill: item } });
   };
-
   const onBarcodeFallback = (code: string) => {
     navigate(newPath, { state: { barcodeOnly: code } });
   };
 
-  // Hardcoded class lookups — Tailwind can't detect dynamic template literals
-  const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   const btnClass = category ? BTN_CLASS[category] : '';
-  const cardBorder = category ? CARD_BORDER[category] : 'group-hover:border-brand/30';
+
+  // Grid classes per view mode
+  const gridClass = viewMode === 'list'
+    ? 'grid-cols-1 gap-2'
+    : viewMode === 'medium'
+      ? 'grid-cols-1 sm:grid-cols-2 gap-3'
+      : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4';
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between gap-4">
-        <h1 className={`text-xl font-medium tracking-tight ${titleClass}`}>{title}</h1>
-        <div className="flex items-center gap-2">
-          <BarcodeLookup
-            type={type}
-            onPick={onBarcodePick}
-            onBarcodeFallback={onBarcodeFallback}
-          />
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <h1 className={`text-xl font-medium tracking-tight ${category ? TITLE_CLASS[category] : 'text-text-primary'}`}>{title}</h1>
+        <div className="flex items-center gap-2 flex-wrap">
+          <ViewSwitcher value={viewMode} onChange={setViewMode} />
+          <BarcodeLookup type={type} onPick={onBarcodePick} onBarcodeFallback={onBarcodeFallback} />
           <Link to={newPath}>
             <Button variant={category ? 'secondary' : 'primary'} className={btnClass}>+ Add</Button>
           </Link>
         </div>
       </div>
 
-      <Input
-        placeholder={`Search ${title.toLowerCase()}…`}
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
+      <Input placeholder={`Search ${title.toLowerCase()}…`} value={query} onChange={(e) => setQuery(e.target.value)} />
 
-      <FiltersPanel
-        type={type}
-        value={filters}
-        onChange={setFilters}
-        onClear={clear}
-      />
+      <FiltersPanel type={type} value={filters} onChange={setFilters} onClear={clear} />
 
       {list.isLoading && <p className="text-text-secondary">Loading…</p>}
       {list.error && <p className="text-error">Failed to load.</p>}
@@ -107,65 +210,15 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
         <Card className="text-center text-text-secondary py-8">No items yet — click "+ Add" to start.</Card>
       )}
 
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className={`grid ${gridClass}`}>
         {items.map((item) => {
-          const base = item as CollectionItemBase & { id?: number; imagePath?: string | null };
+          const base = item as BaseItem;
           const r = renderItem(item);
-          const tags = base.tags ?? [];
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="group block">
-              <Card className={`h-full !p-0 overflow-hidden transition-shadow hover:shadow-md ${cardBorder} dark:hover:bg-card/80`}>
-                <div className="flex flex-col md:flex-row">
-                  {/* Cover art — scales with breakpoint, horizontal at md+ */}
-                  <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
-                    {base.imagePath ? (
-                      <img
-                        src={base.imagePath}
-                        alt=""
-                        loading="lazy"
-                        className="w-full h-40 sm:h-auto md:h-auto sm:aspect-[2/3] md:aspect-[2/3] object-cover transition-transform duration-300 group-hover:scale-105"
-                      />
-                    ) : (
-                      <div
-                        aria-hidden
-                        className="w-full h-40 sm:h-auto md:h-auto flex items-center justify-center text-text-tertiary text-sm font-medium sm:aspect-[2/3] md:aspect-[2/3]"
-                      >
-                        no cover
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Metadata — below cover on mobile/sm, right side at md+ */}
-                  <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
-                    <div className="flex items-start justify-between gap-2">
-                      <h3 className="font-medium text-text-primary leading-snug line-clamp-2">{r.primary}</h3>
-                      <StatusPill status={base.status} category={category} />
-                    </div>
-
-                    {r.secondary && (
-                      <div className="text-sm text-text-secondary truncate">{r.secondary}</div>
-                    )}
-                    {r.tertiary && (
-                      <div className="text-xs text-text-tertiary truncate">{r.tertiary}</div>
-                    )}
-
-                    {base.personalRating != null && (
-                      <div className={`text-sm font-medium ${category ? TITLE_CLASS[category] : 'text-brand'}`}>★ {base.personalRating}/10</div>
-                    )}
-
-                    {tags.length > 0 && (
-                      <div className="flex flex-wrap gap-1 mt-auto pt-1">
-                        {tags.slice(0, 4).map((t) => (
-                          <TagChip key={t} name={t} category={category} />
-                        ))}
-                        {tags.length > 4 && (
-                          <span className="text-xs text-text-tertiary">+{tags.length - 4}</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </Card>
+              {viewMode === 'list' && <ListCard item={base} r={r} category={category} />}
+              {viewMode === 'medium' && <MediumCard item={base} r={r} category={category} />}
+              {viewMode === 'big' && <BigCard item={base} r={r} category={category} />}
             </Link>
           );
         })}

--- a/src/client/components/ui.tsx
+++ b/src/client/components/ui.tsx
@@ -548,3 +548,69 @@ export function CoverPreview({ src, alt = '', className = '' }: CoverPreviewProp
     </>
   );
 }
+
+// ─── View switcher ──────────────────────────────────────────────
+
+import type { ViewMode } from '../hooks/useViewPreference';
+
+const VIEW_MODES: { value: ViewMode; label: string; icon: React.ReactNode }[] = [
+  {
+    value: 'list',
+    label: 'List',
+    icon: (
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+        <rect x="2" y="2" width="3" height="3" rx="0.5" />
+        <line x1="6" y1="3.5" x2="14" y2="3.5" />
+        <rect x="2" y="7" width="3" height="3" rx="0.5" />
+        <line x1="6" y1="8.5" x2="14" y2="8.5" />
+        <rect x="2" y="12" width="3" height="3" rx="0.5" />
+        <line x1="6" y1="13.5" x2="14" y2="13.5" />
+      </svg>
+    ),
+  },
+  {
+    value: 'medium',
+    label: 'Medium',
+    icon: (
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+        <rect x="2" y="2" width="5" height="5" rx="1" />
+        <rect x="9" y="2" width="5" height="5" rx="1" />
+        <rect x="2" y="9" width="5" height="5" rx="1" />
+        <rect x="9" y="9" width="5" height="5" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    value: 'big',
+    label: 'Big',
+    icon: (
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+        <rect x="2" y="2" width="12" height="12" rx="1.5" />
+      </svg>
+    ),
+  },
+];
+
+export function ViewSwitcher({ value, onChange }: { value: ViewMode; onChange: (v: ViewMode) => void }) {
+  return (
+    <div className="inline-flex rounded-md border border-border overflow-hidden">
+      {VIEW_MODES.map((mode, i) => {
+        const active = mode.value === value;
+        return (
+          <button
+            key={mode.value}
+            type="button"
+            aria-pressed={active}
+            title={mode.label}
+            onClick={() => onChange(mode.value)}
+            className={`inline-flex items-center justify-center w-9 h-8 transition-colors ${
+              active ? 'bg-brand/10 text-brand' : 'text-text-secondary hover:text-text-primary bg-card'
+            } ${i > 0 ? 'border-l border-border' : ''}`}
+          >
+            {mode.icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/client/hooks/useViewPreference.ts
+++ b/src/client/hooks/useViewPreference.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+import type { MediaType } from '../services/types';
+
+export type ViewMode = 'list' | 'medium' | 'big';
+
+const VALID_MODES: ViewMode[] = ['list', 'medium', 'big'];
+const STORAGE_KEY_PREFIX = 'collectify:view:';
+
+function read(key: string): ViewMode {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + key);
+    if (raw && VALID_MODES.includes(raw as ViewMode)) return raw as ViewMode;
+  } catch { /* ignore */ }
+  return 'big';
+}
+
+export function useViewPreference(key: MediaType | 'dashboard'): [ViewMode, (v: ViewMode) => void] {
+  const [mode, setMode] = useState<ViewMode>(read(String(key)));
+
+  const write = useCallback((next: ViewMode) => {
+    try {
+      localStorage.setItem(STORAGE_KEY_PREFIX + String(key), next);
+    } catch { /* ignore */ }
+    setMode(next);
+  }, [key]);
+
+  return [mode, write];
+}

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useDashboard, type DashboardRecent } from '../services/collection';
-import { Card } from '../components/ui';
+import { Card, ViewSwitcher } from '../components/ui';
+import { useViewPreference, type ViewMode } from '../hooks/useViewPreference';
 
 const TYPE_LABEL: Record<DashboardRecent['type'], string> = {
   movies: 'Movie',
@@ -18,6 +19,8 @@ export default function Dashboard() {
   const dashboard = useDashboard();
   const summary = dashboard.data;
   const counts = summary?.counts;
+  // P3 fix: dashboard uses its own storage key, not coupled to movies
+  const [viewMode, setViewMode] = useViewPreference('dashboard');
 
   const tiles = [
     { to: '/movies', label: 'Movies', count: counts?.movies, type: 'movies' as const },
@@ -27,7 +30,10 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-8">
-      <h1 className="text-xl font-medium text-text-primary tracking-tight">Your collection</h1>
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-xl font-medium text-text-primary tracking-tight">Your collection</h1>
+        <ViewSwitcher value={viewMode} onChange={setViewMode} />
+      </div>
 
       <div className="grid sm:grid-cols-3 gap-3">
         {tiles.map((t) => (
@@ -42,7 +48,7 @@ export default function Dashboard() {
         ))}
       </div>
 
-      <RecentSection summary={summary} loading={dashboard.isLoading} error={dashboard.error} />
+      <RecentSection summary={summary} loading={dashboard.isLoading} error={dashboard.error} viewMode={viewMode} />
     </div>
   );
 }
@@ -51,11 +57,19 @@ function RecentSection({
   summary,
   loading,
   error,
+  viewMode,
 }: {
   summary: { recent: DashboardRecent[] } | undefined;
   loading: boolean;
   error: unknown;
+  viewMode: ViewMode;
 }) {
+  const gridClass = viewMode === 'list'
+    ? 'grid-cols-1 gap-2'
+    : viewMode === 'medium'
+      ? 'grid-cols-1 sm:grid-cols-2 gap-3'
+      : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4';
+
   return (
     <section className="space-y-3">
       <h2 className="text-xs font-medium uppercase tracking-wide text-text-tertiary">
@@ -69,43 +83,86 @@ function RecentSection({
         </Card>
       )}
       {summary && summary.recent.length > 0 && (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className={`grid ${gridClass}`}>
           {summary.recent.map((r) => (
             <Link key={`${r.type}-${r.id}`} to={`/${r.type}/${r.id}`} className="group block">
-              <Card className="h-full !p-0 overflow-hidden transition-shadow hover:shadow-md group-hover:border-brand/30 dark:hover:bg-card/80">
-                <div className="flex flex-col md:flex-row">
-                  {/* Cover art — scales with breakpoint, horizontal at md+ */}
-                  <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
-                    {r.imagePath ? (
-                      <img
-                        src={r.imagePath}
-                        alt=""
-                        loading="lazy"
-                        className="w-full h-40 sm:h-auto md:h-auto sm:aspect-[2/3] md:aspect-[2/3] object-cover transition-transform duration-300 group-hover:scale-105"
-                      />
-                    ) : (
-                      <div
-                        aria-hidden
-                        className="w-full h-40 sm:h-auto md:h-auto flex items-center justify-center text-text-tertiary text-sm font-medium sm:aspect-[2/3] md:aspect-[2/3]"
-                      >
-                        no cover
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Metadata — below cover on mobile/sm, right side at md+ */}
-                  <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
-                    <h3 className="font-medium text-text-primary leading-snug line-clamp-2">{r.title}</h3>
-                    <div className="text-xs uppercase tracking-wide text-text-tertiary">
-                      {TYPE_LABEL[r.type]}{r.year != null ? ` · ${r.year}` : ''}
-                    </div>
-                  </div>
-                </div>
-              </Card>
+              {viewMode === 'list' ? (
+                <ListRecentCard r={r} />
+              ) : viewMode === 'medium' ? (
+                <MediumRecentCard r={r} />
+              ) : (
+                <BigRecentCard r={r} />
+              )}
             </Link>
           ))}
         </div>
       )}
     </section>
+  );
+}
+
+function ListRecentCard({ r }: { r: DashboardRecent }) {
+  return (
+    <Card className="!p-0 overflow-hidden transition-shadow hover:shadow-md group-hover:border-brand/30 dark:hover:bg-card/80">
+      <div className="flex items-center gap-3 p-2">
+        <div className="w-16 shrink-0 bg-imgPlaceholder overflow-hidden rounded">
+          {r.imagePath ? (
+            <img src={r.imagePath} alt="" loading="lazy" className="w-full aspect-[2/3] object-cover group-hover:scale-105 transition-transform duration-300" />
+          ) : (
+            <div aria-hidden className="w-full aspect-[2/3] flex items-center justify-center text-text-tertiary text-xs font-medium bg-imgPlaceholder">no cover</div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium text-text-primary leading-snug truncate">{r.title}</h3>
+          <div className="text-xs uppercase tracking-wide text-text-tertiary">
+            {TYPE_LABEL[r.type]}{r.year != null ? ` · ${r.year}` : ''}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function MediumRecentCard({ r }: { r: DashboardRecent }) {
+  return (
+    <Card className="!p-0 overflow-hidden transition-shadow hover:shadow-md group-hover:border-brand/30 dark:hover:bg-card/80">
+      <div className="flex gap-3 p-3">
+        <div className="w-24 shrink-0 bg-imgPlaceholder overflow-hidden rounded">
+          {r.imagePath ? (
+            <img src={r.imagePath} alt="" loading="lazy" className="w-full aspect-[2/3] object-cover group-hover:scale-105 transition-transform duration-300" />
+          ) : (
+            <div aria-hidden className="w-full aspect-[2/3] flex items-center justify-center text-text-tertiary text-xs font-medium bg-imgPlaceholder">no cover</div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+          <h3 className="font-medium text-text-primary leading-snug line-clamp-2">{r.title}</h3>
+          <div className="text-xs uppercase tracking-wide text-text-tertiary">
+            {TYPE_LABEL[r.type]}{r.year != null ? ` · ${r.year}` : ''}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function BigRecentCard({ r }: { r: DashboardRecent }) {
+  return (
+    <Card className="h-full !p-0 overflow-hidden transition-shadow hover:shadow-md group-hover:border-brand/30 dark:hover:bg-card/80">
+      <div className="flex flex-col md:flex-row">
+        <div className="relative w-full shrink-0 bg-imgPlaceholder overflow-hidden sm:w-24 md:w-36 lg:w-48">
+          {r.imagePath ? (
+            <img src={r.imagePath} alt="" loading="lazy" className="w-full h-40 sm:h-auto md:h-auto sm:aspect-[2/3] md:aspect-[2/3] object-cover transition-transform duration-300 group-hover:scale-105" />
+          ) : (
+            <div aria-hidden className="w-full h-40 sm:h-auto md:h-auto flex items-center justify-center text-text-tertiary text-sm font-medium sm:aspect-[2/3] md:aspect-[2/3]">no cover</div>
+          )}
+        </div>
+        <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
+          <h3 className="font-medium text-text-primary leading-snug line-clamp-2">{r.title}</h3>
+          <div className="text-xs uppercase tracking-wide text-text-tertiary">
+            {TYPE_LABEL[r.type]}{r.year != null ? ` · ${r.year}` : ''}
+          </div>
+        </div>
+      </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #49

Adds three view size options to each collection list page and the dashboard, persisted per-type in localStorage.

### Changes

- **ViewSwitcher** component (`ui.tsx`) — segmented control with 3 SVG icon buttons (list/medium/big)
- **useViewPreference** hook (`hooks/useViewPreference.ts`) — reads/writes `collectify:view:<type>` to localStorage, defaults to "big"
- **CollectionList** refactored into ListCard/MediumCard/BigCard variants:
  - **List**: compact single-row cards with small thumbnails (64px), title + secondary info inline
  - **Medium**: balanced horizontal layout with medium covers (128px), two-column metadata
  - **Big**: current cover-first layout (large poster, full metadata) — default
- **Dashboard** recent additions also respect the view mode switcher

### Review Fixes Applied

- **P1:** Branch rebased onto latest `main` (includes PR #50 accent colors and PR #51 detail page)
- **P2:** localStorage value validated against known modes (`list`/`medium`/`big`) — invalid values fall back to "big"
- **P3:** Dashboard uses its own storage key (`collectify:view:dashboard`) instead of coupling to movies preference

### View Mode Details

| Aspect | List | Medium | Big |
|---|---|---|---|
| Cover width | 64px | 128px | 192px (responsive) |
| Grid columns | 1 column | 1-2 columns | 1-3 columns |
| Info shown | title + secondary | title + secondary + rating + tags | full metadata |

### Verification

- [x] `npm run build` clean (tsc + vite)
- [x] All 91 client tests pass