### PR TITLE
docs(docker): add consumer compose install path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,23 @@
 # are set; until then the matching lookup endpoint replies with
 # { configured: false } and an empty result set.
 #
+# Docker Compose reads this file for image overrides (REGISTRY / IMAGE_NAME /
+# TAG) and passes the Collectify__... variables through to the container.
+#
 # ASP.NET binds these via the "__" double-underscore separator
 # (Collectify__Metadata__Tmdb__ApiKey === Collectify:Metadata:Tmdb:ApiKey
 # in appsettings.json).
+
+# ----------------------------------------------------------------------
+# Docker image selection — override only if you want a non-default image.
+# ----------------------------------------------------------------------
+# Registry host. Default: ghcr.io
+# REGISTRY=ghcr.io
+# Image path inside the registry. Default: mforce/collectify
+# IMAGE_NAME=mforce/collectify
+# Published release tag to pull. Use a pinned release (e.g. v0.1.0) for
+# repeatable installs, or leave unset for latest.
+# TAG=latest
 
 # ----------------------------------------------------------------------
 # Cross-provider knobs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,69 @@
 
 A self-hostable web app for tracking your personal collection of **movies** (DVD / Blu-ray / UHD Blu-ray), **music** (CDs / vinyl), and **videogames** (physical and digital).
 
-> **Status:** Phase 1 — manual entry / edit / search for all three types, single-user with password, packaged with Docker. Internet metadata lookup (Phase 2) and barcode camera scanning (Phase 3) are tracked as separate issues.
+> **Status:** Phase 1 complete — manual entry, edit, search for all three types. Internet metadata lookup (TMDB / MusicBrainz / IGDB) and barcode camera scanning are included. Single-user with password, packaged as a Docker image.
+
+## Quick start
+
+```bash
+docker compose up -d
+```
+
+Open <http://localhost:8080>. The first visit sends you to **/setup** to create your account; after that you log in at **/login**.
+
+Data is persisted to a named Docker volume `collectify-data` (mounted at `/data` inside the container, holds `collectify.db`).
+
+### Configuration
+
+Copy `.env.example` to `.env` and set provider keys for internet metadata lookup:
+
+```bash
+cp .env.example .env   # edit API keys here
+docker compose restart
+```
+
+All provider keys are optional — lookups degrade gracefully when unconfigured. See [`.env.example`](.env.example) for the full list.
+
+### Changing the image source
+
+Override via environment variables or a `.env` file:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `REGISTRY` | `ghcr.io` | Registry host |
+| `IMAGE_NAME` | `mforce/collectify` | Image path inside the registry |
+| `TAG` | `latest` | Image tag (`v0.1.0`, `v0.1`, etc.) |
+
+Example — pulling from a self-hosted Gitea registry:
+
+```bash
+REGISTRY=git.example.com IMAGE_NAME=mforce/collectify TAG=v0.1.0 docker compose up -d
+```
+
+## Local development without Docker
+
+Two terminals:
+
+```bash
+# Terminal 1 — API on :5041 (default from launchSettings)
+cd src/server
+dotnet run --project Collectify.Api
+
+# Terminal 2 — Vite dev server on :5173, proxies /api → :5041
+cd src/client
+npm install
+npm run dev
+```
+
+The Vite dev server proxies `/api/*` calls to the .NET app, so you get hot reload on the React side while the API rebuilds on changes.
+
+### Building from source (Docker)
+
+Use the development compose override to build locally instead of pulling:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
 
 ## Stack
 
@@ -10,36 +72,6 @@ A self-hostable web app for tracking your personal collection of **movies** (DVD
 - React 18 + Vite + TypeScript + Tailwind + TanStack Query
 - ASP.NET Identity (cookie auth, designed to extend to multi-user)
 - Docker + docker-compose, single container
-
-## Quick start
-
-```bash
-cp .env.example .env       # edit API keys here later (none required for Phase 1)
-docker compose up --build  # builds React, publishes the API, runs on :8080
-```
-
-Open <http://localhost:8080>. The first visit sends you to **/setup** to create your account; after that you log in at **/login**.
-
-Data is persisted to a named Docker volume `collectify-data` (mounted at `/data` inside the container, holds `collectify.db`).
-
-## Local development without Docker
-
-Two terminals:
-
-```bash
-# Terminal 1 — API on :8080
-cd src/server
-dotnet run --project Collectify.Api
-```
-
-```bash
-# Terminal 2 — Vite dev server on :5173, proxies /api → :8080
-cd src/client
-npm install
-npm run dev
-```
-
-The Vite dev server proxies `/api/*` calls to the .NET app, so you get hot reload on the React side while the API rebuilds on changes.
 
 ## Project layout
 
@@ -49,11 +81,12 @@ src/
     Collectify.slnx               # solution file (also references the client folder)
     Collectify.Api/               # ASP.NET Core API + serves React build
     Collectify.Domain/            # Entities + enums
-    Collectify.Infrastructure/    # EF Core DbContext, Identity, (later) metadata clients
+    Collectify.Infrastructure/    # EF Core DbContext, Identity, metadata clients
     tests/Collectify.Tests/       # xUnit tests
   client/                         # Vite + React + TS frontend (sources at root, no nested src/)
 Dockerfile                        # multi-stage: node → React, sdk → publish, aspnet → runtime
-docker-compose.yml                # one service + named data volume
+docker-compose.yml                # consumer compose (pull from registry)
+docker-compose.dev.yml            # dev override (build from source)
 ```
 
 ## Barcode scanning
@@ -84,8 +117,8 @@ Backend dispatch:
 
 See [GitHub issues](https://github.com/mforce/collectify/issues) for the active roadmap. Phases:
 
-- **Phase 1 — Foundation** (this PR): scaffolding, auth, manual CRUD, Docker.
-- **Phase 2 — Internet lookup:** TMDB / MusicBrainz / IGDB providers + cover caching.
-- **Phase 3 — Barcode scanning:** in-browser webcam UPC scan with `@zxing/browser`.
+- **Phase 1 — Foundation** (done): scaffolding, auth, manual CRUD, Docker.
+- **Phase 2 — Internet lookup** (done): TMDB / MusicBrainz / IGDB providers + cover caching.
+- **Phase 3 — Barcode scanning** (done): in-browser webcam UPC scan with `@zxing/browser`.
 - **Phase 4 — Multi-user.**
 - **Phase 5 — Photo-snap visual lookup** (future).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+# Development override: build the image from the local checkout instead of
+# pulling a published release image.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
+services:
+  collectify:
+    build: .
+    image: collectify:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,19 @@
+# Collectify — consumer compose (pull from registry)
+#
+# Quick start:
+#   docker compose up -d
+#
+# Override the image source via environment variables or a .env file:
+#   REGISTRY=git.example.com      # defaults to ghcr.io
+#   IMAGE_NAME=mforce/collectify  # defaults to mforce/collectify
+#   TAG=v0.1.0                    # defaults to latest
+#
+# For local development (build from source), use docker-compose.dev.yml:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+
 services:
   collectify:
-    build: .
-    image: collectify:latest
+    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-mforce/collectify}:${TAG:-latest}
     container_name: collectify
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

- Switch the default `docker-compose.yml` to pull the published image instead of building locally.
- Add `docker-compose.dev.yml` as an explicit source-build override for contributors.
- Rewrite the README quick start around pull-and-run installs, image override variables, persisted `/data` volume, and optional provider config.
- Document `REGISTRY`, `IMAGE_NAME`, and `TAG` in `.env.example`.

Part of #39, phase 3 of 6.

## Test plan

- [x] `docker compose config` renders consumer image as `ghcr.io/mforce/collectify:latest`.
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` renders the dev override with `image: collectify:dev` and a local build context.
