### PR TITLE
fix(cache): treat stale lookup JSON as cache miss

### DIFF
--- a/src/server/Collectify.Infrastructure/Lookup/ILookupCache.cs
+++ b/src/server/Collectify.Infrastructure/Lookup/ILookupCache.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Collectify.Domain.Entities;
 using Collectify.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Collectify.Infrastructure.Lookup;
 
@@ -19,15 +21,20 @@ public interface ILookupCache
 
 public sealed class LookupCache : ILookupCache
 {
-    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter(allowIntegerValues: true) },
+    };
 
     private readonly CollectifyDbContext _db;
     private readonly TimeProvider _clock;
+    private readonly ILogger<LookupCache> _log;
 
-    public LookupCache(CollectifyDbContext db, TimeProvider clock)
+    public LookupCache(CollectifyDbContext db, TimeProvider clock, ILogger<LookupCache>? log = null)
     {
         _db = db;
         _clock = clock;
+        _log = log ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<LookupCache>.Instance;
     }
 
     public async Task<T?> GetAsync<T>(string provider, string key, TimeSpan ttl, CancellationToken ct = default)
@@ -36,7 +43,22 @@ public sealed class LookupCache : ILookupCache
             .FirstOrDefaultAsync(e => e.Provider == provider && e.Key == key, ct);
         if (entry is null) return default;
         if (_clock.GetUtcNow().UtcDateTime - entry.FetchedAt > ttl) return default;
-        return JsonSerializer.Deserialize<T>(entry.JsonResponse, Json);
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(entry.JsonResponse, Json);
+        }
+        catch (JsonException ex)
+        {
+            _log.LogWarning(
+                ex,
+                "Ignoring stale or incompatible lookup cache entry for provider {Provider}, key {Key}, type {Type}",
+                provider,
+                key,
+                typeof(T).FullName);
+            await DeleteAsync(provider, key, ct);
+            return default;
+        }
     }
 
     public async Task SetAsync<T>(string provider, string key, T value, CancellationToken ct = default)
@@ -60,5 +82,12 @@ public sealed class LookupCache : ILookupCache
             existing.FetchedAt = _clock.GetUtcNow().UtcDateTime;
         }
         await _db.SaveChangesAsync(ct);
+    }
+
+    private async Task DeleteAsync(string provider, string key, CancellationToken ct)
+    {
+        await _db.LookupCache
+            .Where(e => e.Provider == provider && e.Key == key)
+            .ExecuteDeleteAsync(ct);
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/IgdbGameProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Lookup;
@@ -57,6 +58,19 @@ public class IgdbGameProviderTests : IDisposable
           }
         ]
         """;
+
+    private async Task SeedRawCacheRowAsync(string provider, string key, string json)
+    {
+        using var ctx = new CollectifyDbContext(_dbOptions);
+        ctx.LookupCache.Add(new LookupCacheEntry
+        {
+            Provider = provider,
+            Key = key,
+            JsonResponse = json,
+            FetchedAt = _clock.GetUtcNow().UtcDateTime,
+        });
+        await ctx.SaveChangesAsync();
+    }
 
     [Fact]
     public void IsConfigured_ReflectsBothCredentials()
@@ -199,6 +213,23 @@ public class IgdbGameProviderTests : IDisposable
         await p1.SearchAsync("witcher");
         await p2.SearchAsync("WITCHER"); // case-insensitive cache key
 
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithStaleIncompatibleCachedResult_TreatsCacheAsMissAndRefreshes()
+    {
+        await SeedRawCacheRowAsync(
+            "igdb",
+            "search:witcher",
+            "[{\"provider\":\"igdb\",\"providerKey\":\"old\",\"title\":\"Old\",\"platform\":\"Windows 95\"}]");
+        var handler = new StubHandler(SingleGameJson);
+        var provider = NewProvider(handler);
+
+        var hit = Assert.Single(await provider.SearchAsync("witcher"));
+
+        Assert.Equal("The Witcher 3: Wild Hunt", hit.Title);
+        Assert.Equal(GamePlatform.Pc, hit.Platform);
         Assert.Single(handler.Requests);
     }
 

--- a/src/server/tests/Collectify.Tests/Infrastructure/LookupCacheTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/LookupCacheTests.cs
@@ -1,4 +1,5 @@
 using Collectify.Domain.Entities;
+using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Lookup;
 using Microsoft.Data.Sqlite;
@@ -27,6 +28,20 @@ public class LookupCacheTests : IDisposable
     private LookupCache NewCache() => new(new CollectifyDbContext(_options), _clock);
 
     private record Sample(string Title, int Year);
+    private record PlatformSample(GamePlatform? Platform);
+
+    private async Task SeedRawCacheRowAsync(string provider, string key, string json)
+    {
+        using var ctx = new CollectifyDbContext(_options);
+        ctx.LookupCache.Add(new LookupCacheEntry
+        {
+            Provider = provider,
+            Key = key,
+            JsonResponse = json,
+            FetchedAt = _clock.GetUtcNow().UtcDateTime,
+        });
+        await ctx.SaveChangesAsync();
+    }
 
     [Fact]
     public async Task Get_BeforeSet_ReturnsDefault()
@@ -101,5 +116,40 @@ public class LookupCacheTests : IDisposable
         Assert.Equal("tmdb", entry.Provider);
         Assert.Equal("550", entry.Key);
         Assert.IsType<LookupCacheEntry>(entry);
+    }
+
+    [Fact]
+    public async Task Get_WithStringEnumPayload_ReadsEnumValue()
+    {
+        await SeedRawCacheRowAsync("igdb", "search:witcher", "{\"platform\":\"Pc\"}");
+
+        var result = await NewCache().GetAsync<PlatformSample>("igdb", "search:witcher", TimeSpan.FromDays(30));
+
+        Assert.NotNull(result);
+        Assert.Equal(GamePlatform.Pc, result!.Platform);
+    }
+
+    [Fact]
+    public async Task Get_WithIncompatibleJson_ReturnsDefaultAndDeletesBadRow()
+    {
+        await SeedRawCacheRowAsync("igdb", "search:witcher", "{\"platform\":\"Windows 95\"}");
+
+        var result = await NewCache().GetAsync<PlatformSample>("igdb", "search:witcher", TimeSpan.FromDays(30));
+
+        Assert.Null(result);
+        using var ctx = new CollectifyDbContext(_options);
+        Assert.False(await ctx.LookupCache.AnyAsync(e => e.Provider == "igdb" && e.Key == "search:witcher"));
+    }
+
+    [Fact]
+    public async Task Get_WithCorruptJson_ReturnsDefaultAndDeletesBadRow()
+    {
+        await SeedRawCacheRowAsync("igdb", "search:witcher", "{ nope");
+
+        var result = await NewCache().GetAsync<PlatformSample>("igdb", "search:witcher", TimeSpan.FromDays(30));
+
+        Assert.Null(result);
+        using var ctx = new CollectifyDbContext(_options);
+        Assert.False(await ctx.LookupCache.AnyAsync(e => e.Provider == "igdb" && e.Key == "search:witcher"));
     }
 }


### PR DESCRIPTION
## Summary

- Make `LookupCache.GetAsync<T>` tolerant of stale/incompatible JSON payloads.
- Add `JsonStringEnumConverter(allowIntegerValues: true)` to cache serializer options so enum values can round-trip as strings or integers.
- Catch `JsonException` on cache reads, log provider/key/type, delete the bad row, and return `default` so providers re-fetch fresh data.
- Add `LookupCacheTests` coverage for string enum JSON, incompatible enum JSON, and corrupt JSON.
- Add an IGDB regression test proving a stale cached `GameLookupResult` row is treated as a miss and refreshed from upstream.

Fixes #59

## Test plan

- [x] `dotnet test --filter LookupCacheTests --no-restore`
- [x] `dotnet test --filter "LookupCacheTests|IgdbGameProviderTests" --no-restore`
- [x] `dotnet test --no-restore`
- [x] `dotnet build Collectify.slnx --no-restore`
