### PR TITLE
fix(ui): give cover editor full-width form layout

### DIFF
--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import CoverEditor from './CoverEditor';
+import CoverFormLayout from './CoverFormLayout';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import BarcodeLookup from './BarcodeLookup';
@@ -37,6 +38,7 @@ const empty: Album = {
 
 export default function AlbumForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [a, setA] = useState<Album>(initial ?? empty);
+  const [coverEditorExpanded, setCoverEditorExpanded] = useState(!a.imagePath);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setA(initial); }, [initial]);
 
@@ -163,39 +165,40 @@ export default function AlbumForm({ initial, prefillLookup, prefillBarcode, subm
         })}
       />
 
-      <div className="flex flex-col-reverse sm:flex-row gap-4 items-start">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 flex-1 w-full">
-          <Field label="Title">
-            <Input value={a.title} onChange={(e) => set('title', e.target.value)} required />
-          </Field>
-          <Field label="Artist">
-            <Input value={a.artistName} onChange={(e) => set('artistName', e.target.value)} required />
-          </Field>
-          <Field label="Year">
-            <Input type="number" value={a.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
-          </Field>
-          <Field label="Format">
-            <Select value={a.format} onChange={(e) => set('format', e.target.value as Album['format'])}>
-              {MUSIC_FORMATS.map((f) => (
-                <option key={f.value} value={f.value}>{f.label}</option>
-              ))}
-            </Select>
-          </Field>
-          <Field label="Label">
-            <Input value={a.label ?? ''} onChange={(e) => set('label', e.target.value || null)} />
-          </Field>
-          <Field label="Genres">
-            <Input value={a.genres ?? ''} onChange={(e) => set('genres', e.target.value || null)} />
-          </Field>
-          <Field label="Barcode">
-            <Input value={a.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
-          </Field>
-        </div>
-        <div className="w-28 sm:w-36 shrink-0 space-y-2">
-          <CoverPreview src={a.imagePath} alt={a.title ? `${a.title} cover` : ''} />
-          <CoverEditor value={a.imagePath} onChange={(v) => set('imagePath', v)} />
-        </div>
-      </div>
+      <CoverFormLayout
+        fields={(
+          <>
+            <Field label="Title">
+              <Input value={a.title} onChange={(e) => set('title', e.target.value)} required />
+            </Field>
+            <Field label="Artist">
+              <Input value={a.artistName} onChange={(e) => set('artistName', e.target.value)} required />
+            </Field>
+            <Field label="Year">
+              <Input type="number" value={a.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
+            </Field>
+            <Field label="Format">
+              <Select value={a.format} onChange={(e) => set('format', e.target.value as Album['format'])}>
+                {MUSIC_FORMATS.map((f) => (
+                  <option key={f.value} value={f.value}>{f.label}</option>
+                ))}
+              </Select>
+            </Field>
+            <Field label="Label">
+              <Input value={a.label ?? ''} onChange={(e) => set('label', e.target.value || null)} />
+            </Field>
+            <Field label="Genres">
+              <Input value={a.genres ?? ''} onChange={(e) => set('genres', e.target.value || null)} />
+            </Field>
+            <Field label="Barcode">
+              <Input value={a.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
+            </Field>
+          </>
+        )}
+        preview={<CoverPreview src={a.imagePath} alt={a.title ? `${a.title} cover` : ''} />}
+        editor={<CoverEditor value={a.imagePath} onChange={(v) => set('imagePath', v)} expanded={coverEditorExpanded} onExpandedChange={setCoverEditorExpanded} />}
+        editorExpanded={coverEditorExpanded}
+      />
 
       <PersonalAcquisitionSection value={a} onChange={patch} />
 

--- a/src/client/components/CoverEditor.test.tsx
+++ b/src/client/components/CoverEditor.test.tsx
@@ -107,11 +107,26 @@ describe('CoverEditor', () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
-  it('starts collapsed when a cover already exists', () => {
+  it('starts collapsed when a cover already exists and renders compact buttons', () => {
     render(<CoverEditor value="/covers/abc1234567890def" onChange={vi.fn()} />);
 
-    // The disclosure links should be visible; the URL input shouldn't.
-    expect(screen.getByRole('button', { name: /change cover/i })).toBeInTheDocument();
+    // The compact actions should be visible; the URL input shouldn't.
+    expect(screen.getByTestId('cover-collapsed-actions')).toHaveClass('flex-col');
+    expect(screen.getByRole('button', { name: /change cover/i })).toHaveClass('rounded-md');
+    expect(screen.getByRole('button', { name: /remove cover/i })).toHaveClass('rounded-md');
     expect(screen.queryByPlaceholderText(/cover.jpg/i)).not.toBeInTheDocument();
+  });
+
+  it('uses wrapping, min-width-safe controls when expanded', async () => {
+    render(<CoverEditor value="/covers/abc1234567890def" onChange={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /change cover/i }));
+
+    expect(screen.getByTestId('cover-editor-card')).toHaveClass('w-full', 'min-w-0');
+    expect(screen.getByTestId('cover-url-row')).toHaveClass('flex-wrap');
+    expect(screen.getByTestId('cover-url-field')).toHaveClass('w-full', 'min-w-0', 'sm:basis-64');
+    expect(screen.getByPlaceholderText(/cover.jpg/i)).toHaveClass('min-w-0');
+    expect(screen.getByLabelText(/upload a file/i)).toHaveClass('max-w-full');
+    expect(screen.getByTestId('cover-editor-actions')).toHaveClass('flex-wrap');
   });
 });

--- a/src/client/components/CoverEditor.tsx
+++ b/src/client/components/CoverEditor.tsx
@@ -5,6 +5,8 @@ import { Button, Input } from './ui';
 interface Props {
   value: string | null | undefined;
   onChange: (next: string | null) => void;
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
 }
 
 const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp'];
@@ -30,13 +32,19 @@ const MAX_BYTES = 5 * 1024 * 1024;
  * doesn't have to wait on a round-trip to see "too big" / "not an
  * image".
  */
-export default function CoverEditor({ value, onChange }: Props) {
-  const [open, setOpen] = useState(!value);
+export default function CoverEditor({ value, onChange, expanded, onExpandedChange }: Props) {
+  const [openState, setOpenState] = useState(!value);
+  const open = expanded ?? openState;
   const [url, setUrl] = useState('');
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const toast = useToast();
+
+  const setOpen = (next: boolean) => {
+    setOpenState(next);
+    onExpandedChange?.(next);
+  };
 
   const applyUrl = () => {
     const trimmed = url.trim();
@@ -117,18 +125,18 @@ export default function CoverEditor({ value, onChange }: Props) {
   // happy path. Click "Change cover" to expand.
   if (!open) {
     return (
-      <div className="text-xs flex items-center gap-3">
+      <div data-testid="cover-collapsed-actions" className="flex flex-col gap-2 text-xs">
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="text-brand hover:text-brand-hover underline"
+          className="inline-flex min-h-[36px] items-center justify-center rounded-md border border-border bg-pill-bg px-3 py-1.5 font-semibold text-text-primary hover:bg-gray-100 dark:hover:bg-[#353840]"
         >
           Change cover
         </button>
         <button
           type="button"
           onClick={remove}
-          className="text-error hover:text-error-hover underline"
+          className="inline-flex min-h-[36px] items-center justify-center rounded-md border border-error/50 bg-transparent px-3 py-1.5 font-semibold text-error hover:bg-error/10"
         >
           Remove cover
         </button>
@@ -137,11 +145,12 @@ export default function CoverEditor({ value, onChange }: Props) {
   }
 
   return (
-    <div className="space-y-2 rounded-md border border-border bg-card/80 p-3">
-      <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
-        <div className="flex-1">
+    <div data-testid="cover-editor-card" className="w-full min-w-0 space-y-2 rounded-md border border-border bg-card/80 p-3">
+      <div data-testid="cover-url-row" className="flex flex-col flex-wrap gap-2 sm:flex-row sm:items-end">
+        <div data-testid="cover-url-field" className="w-full min-w-0 flex-1 sm:basis-64">
           <label className="block text-xs font-medium text-text-secondary mb-1">Image URL</label>
           <Input
+            className="min-w-0"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://…/cover.jpg"
@@ -153,13 +162,13 @@ export default function CoverEditor({ value, onChange }: Props) {
             }}
           />
         </div>
-        <Button type="button" variant="secondary" onClick={applyUrl} disabled={!url.trim()}>
+        <Button type="button" variant="secondary" onClick={applyUrl} disabled={!url.trim()} className="shrink-0 whitespace-nowrap">
           Apply URL
         </Button>
       </div>
 
-      <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
-        <label htmlFor="cover-editor-file" className="block text-xs font-medium text-text-secondary">
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+        <label htmlFor="cover-editor-file" className="block text-xs font-medium text-text-secondary shrink-0">
           Or upload a file
         </label>
         <input
@@ -169,7 +178,7 @@ export default function CoverEditor({ value, onChange }: Props) {
           accept={ALLOWED_MIME.join(',')}
           onChange={onFileChange}
           disabled={uploading}
-          className="text-sm text-text-primary file:mr-2 file:rounded-md file:border-0 file:bg-input-bg file:px-3 file:py-1.5 file:text-sm file:text-text-primary hover:file:bg-gray-300"
+          className="max-w-full min-w-0 text-sm text-text-primary file:mr-2 file:rounded-md file:border-0 file:bg-input-bg file:px-3 file:py-1.5 file:text-sm file:text-text-primary hover:file:bg-gray-300"
         />
         {uploading && <span className="text-xs text-text-secondary">Uploading…</span>}
       </div>
@@ -180,7 +189,7 @@ export default function CoverEditor({ value, onChange }: Props) {
         </p>
       )}
 
-      <div className="flex items-center justify-between">
+      <div data-testid="cover-editor-actions" className="flex flex-wrap items-center justify-between gap-2">
         {value ? (
           <button
             type="button"

--- a/src/client/components/CoverFormLayout.test.tsx
+++ b/src/client/components/CoverFormLayout.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CoverFormLayout from './CoverFormLayout';
+
+describe('CoverFormLayout', () => {
+  it('keeps collapsed cover actions under the compact preview', () => {
+    render(
+      <CoverFormLayout
+        fields={<input aria-label="Title" />}
+        preview={<div>Preview</div>}
+        editor={<button type="button">Change cover</button>}
+      />,
+    );
+
+    expect(screen.getByTestId('cover-form-layout')).toHaveClass('lg:grid-cols-[minmax(0,1fr)_9rem]');
+    expect(screen.getByTestId('cover-preview-column')).toHaveClass('w-28', 'sm:w-36', 'shrink-0');
+    expect(screen.getByTestId('cover-preview-column')).toContainElement(screen.getByRole('button', { name: /change cover/i }));
+    expect(screen.queryByTestId('cover-editor-row')).not.toBeInTheDocument();
+  });
+
+  it('renders the expanded editor in a full-width row', () => {
+    render(
+      <CoverFormLayout
+        fields={<input aria-label="Title" />}
+        preview={<div>Preview</div>}
+        editor={<div>Expanded editor</div>}
+        editorExpanded
+      />,
+    );
+
+    expect(screen.getByTestId('cover-preview-column')).not.toHaveTextContent('Expanded editor');
+    expect(screen.getByTestId('cover-editor-row')).toHaveClass('w-full', 'min-w-0', 'lg:col-span-2');
+    expect(screen.getByTestId('cover-editor-row')).toHaveTextContent('Expanded editor');
+  });
+});

--- a/src/client/components/CoverFormLayout.tsx
+++ b/src/client/components/CoverFormLayout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  fields: ReactNode;
+  preview: ReactNode;
+  editor: ReactNode;
+  editorExpanded?: boolean;
+}
+
+/**
+ * Responsive cover/form layout used by all media forms.
+ *
+ * The preview stays compact beside the main fields on desktop, but the
+ * expanded editor gets a full-width row so URL/file controls never have
+ * to squeeze into the narrow poster column.
+ */
+export default function CoverFormLayout({ fields, preview, editor, editorExpanded = false }: Props) {
+  return (
+    <div data-testid="cover-form-layout" className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_9rem] items-start">
+      <div data-testid="cover-form-fields" className="order-2 grid grid-cols-1 sm:grid-cols-2 gap-4 w-full lg:order-1">
+        {fields}
+      </div>
+      <div data-testid="cover-preview-column" className="order-1 w-28 sm:w-36 shrink-0 space-y-2 lg:order-2">
+        {preview}
+        {!editorExpanded && editor}
+      </div>
+      {editorExpanded && (
+        <div data-testid="cover-editor-row" className="order-3 w-full min-w-0 lg:col-span-2">
+          {editor}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SearchableSelect, SectionHeading, Select, Textarea } from './ui';
 import CoverEditor from './CoverEditor';
+import CoverFormLayout from './CoverFormLayout';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import BarcodeLookup from './BarcodeLookup';
@@ -46,6 +47,7 @@ const empty: Game = {
 
 export default function GameForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [g, setG] = useState<Game>(initial ?? empty);
+  const [coverEditorExpanded, setCoverEditorExpanded] = useState(!g.imagePath);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setG(initial); }, [initial]);
 
@@ -140,46 +142,47 @@ export default function GameForm({ initial, prefillLookup, prefillBarcode, submi
         })}
       />
 
-      <div className="flex flex-col-reverse sm:flex-row gap-4 items-start">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 flex-1 w-full">
-          <Field label="Title">
-            <Input value={g.title} onChange={(e) => set('title', e.target.value)} required />
-          </Field>
-          <Field label="Platform">
-            <SearchableSelect
-              value={g.platform}
-              onChange={(v) => set('platform', v as GamePlatform)}
-              options={GAME_PLATFORMS}
-              placeholder="Type to search platforms…"
-            />
-            {g.platformLegacy && (
-              // Stickier than a generic placeholder -- surfaces the
-              // original free-text so the user can see what they had
-              // typed and pick the closest canonical value. Saving the
-              // form clears this field.
-              <p className="mt-1 text-xs text-amber-400">
-                Original: <span className="font-mono">{g.platformLegacy}</span> — pick a platform above to replace it.
-              </p>
-            )}
-          </Field>
-          <Field label="Year">
-            <Input type="number" value={g.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
-          </Field>
-          <Field label="Publisher">
-            <Input value={g.publisher ?? ''} onChange={(e) => set('publisher', e.target.value || null)} />
-          </Field>
-          <Field label="Developer">
-            <Input value={g.developer ?? ''} onChange={(e) => set('developer', e.target.value || null)} />
-          </Field>
-          <Field label="Barcode">
-            <Input value={g.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
-          </Field>
-        </div>
-        <div className="w-28 sm:w-36 shrink-0 space-y-2">
-          <CoverPreview src={g.imagePath} alt={g.title ? `${g.title} cover` : ''} />
-          <CoverEditor value={g.imagePath} onChange={(v) => set('imagePath', v)} />
-        </div>
-      </div>
+      <CoverFormLayout
+        fields={(
+          <>
+            <Field label="Title">
+              <Input value={g.title} onChange={(e) => set('title', e.target.value)} required />
+            </Field>
+            <Field label="Platform">
+              <SearchableSelect
+                value={g.platform}
+                onChange={(v) => set('platform', v as GamePlatform)}
+                options={GAME_PLATFORMS}
+                placeholder="Type to search platforms…"
+              />
+              {g.platformLegacy && (
+                // Stickier than a generic placeholder -- surfaces the
+                // original free-text so the user can see what they had
+                // typed and pick the closest canonical value. Saving the
+                // form clears this field.
+                <p className="mt-1 text-xs text-amber-400">
+                  Original: <span className="font-mono">{g.platformLegacy}</span> — pick a platform above to replace it.
+                </p>
+              )}
+            </Field>
+            <Field label="Year">
+              <Input type="number" value={g.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
+            </Field>
+            <Field label="Publisher">
+              <Input value={g.publisher ?? ''} onChange={(e) => set('publisher', e.target.value || null)} />
+            </Field>
+            <Field label="Developer">
+              <Input value={g.developer ?? ''} onChange={(e) => set('developer', e.target.value || null)} />
+            </Field>
+            <Field label="Barcode">
+              <Input value={g.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
+            </Field>
+          </>
+        )}
+        preview={<CoverPreview src={g.imagePath} alt={g.title ? `${g.title} cover` : ''} />}
+        editor={<CoverEditor value={g.imagePath} onChange={(v) => set('imagePath', v)} expanded={coverEditorExpanded} onExpandedChange={setCoverEditorExpanded} />}
+        editorExpanded={coverEditorExpanded}
+      />
 
       <div className="grid sm:grid-cols-2 gap-4 items-end">
         <label className="flex items-center gap-2 text-sm text-text-primary">

--- a/src/client/components/MovieForm.test.tsx
+++ b/src/client/components/MovieForm.test.tsx
@@ -22,11 +22,11 @@ vi.mock('../services/tags', () => ({
   useTags: () => ({ data: [], isLoading: false, error: null }),
 }));
 
-function renderForm(onSubmit = vi.fn()) {
+function renderForm(onSubmit = vi.fn(), props: Partial<Parameters<typeof MovieForm>[0]> = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
     <QueryClientProvider client={client}>
-      <MovieForm onSubmit={onSubmit} />
+      <MovieForm onSubmit={onSubmit} {...props} />
     </QueryClientProvider>,
   );
   return { onSubmit };
@@ -155,6 +155,25 @@ describe('MovieForm — Fetch metadata by TMDB ID', () => {
     await user.click(screen.getByRole('button', { name: /fetch metadata by imdb id/i }));
 
     expect(await screen.findByText(/no movie with imdb id tt9999999/i)).toBeInTheDocument();
+  });
+
+  it('opens the cover editor with one click when an existing cover is collapsed', async () => {
+    renderForm(vi.fn(), {
+      initial: {
+        title: 'Inception',
+        formats: 0,
+        status: 'Owned',
+        watchStatus: 'Unwatched',
+        watchCount: 0,
+        imagePath: '/covers/abc1234567890def',
+        tags: [],
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /change cover/i }));
+
+    expect(screen.getByPlaceholderText(/cover.jpg/i)).toBeInTheDocument();
+    expect(screen.getByTestId('cover-editor-row')).toContainElement(screen.getByPlaceholderText(/cover.jpg/i));
   });
 
   it('picking a TMDB search result enriches director and runtime via a follow-up by-id call', async () => {

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, CoverPreview, ExternalIdField, Field, Input, SectionHeading, Select, Textarea } from './ui';
 import CoverEditor from './CoverEditor';
+import CoverFormLayout from './CoverFormLayout';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
 import OnlineSearch from './OnlineSearch';
 import BarcodeLookup from './BarcodeLookup';
@@ -40,6 +41,7 @@ const empty: Movie = {
 
 export default function MovieForm({ initial, prefillLookup, prefillBarcode, submitting, submitLabel = 'Save', onSubmit, onDelete }: Props) {
   const [m, setM] = useState<Movie>(initial ?? empty);
+  const [coverEditorExpanded, setCoverEditorExpanded] = useState(!m.imagePath);
   const [fetchState, setFetchState] = useState<{ status: 'idle' | 'loading'; message?: string }>({ status: 'idle' });
   useEffect(() => { if (initial) setM(initial); }, [initial]);
 
@@ -171,41 +173,44 @@ export default function MovieForm({ initial, prefillLookup, prefillBarcode, subm
         })}
       />
 
-      <div className="flex flex-col-reverse sm:flex-row gap-4 items-start">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 flex-1 w-full">
-          <Field label="Title">
-            <Input value={m.title} onChange={(e) => set('title', e.target.value)} required />
-          </Field>
-          <Field label="Original title">
-            <Input value={m.originalTitle ?? ''} onChange={(e) => set('originalTitle', e.target.value || null)} />
-          </Field>
-          <Field label="Year">
-            <Input type="number" value={m.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
-          </Field>
-          <Field label="Director">
-            <Input value={m.director ?? ''} onChange={(e) => set('director', e.target.value || null)} />
-          </Field>
-          <Field label="Runtime (min)">
-            <Input type="number" value={m.runtimeMinutes ?? ''} onChange={(e) => set('runtimeMinutes', e.target.value ? Number(e.target.value) : null)} />
-          </Field>
-          <Field label="Studio">
-            <Input value={m.studio ?? ''} onChange={(e) => set('studio', e.target.value || null)} />
-          </Field>
-          <Field label="Genres (comma separated)">
-            <Input value={m.genres ?? ''} onChange={(e) => set('genres', e.target.value || null)} />
-          </Field>
-          <Field label="Barcode">
-            <Input value={m.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
-          </Field>
-        </div>
-        <div className="w-28 sm:w-36 shrink-0 space-y-2">
+      <CoverFormLayout
+        fields={(
+          <>
+            <Field label="Title">
+              <Input value={m.title} onChange={(e) => set('title', e.target.value)} required />
+            </Field>
+            <Field label="Original title">
+              <Input value={m.originalTitle ?? ''} onChange={(e) => set('originalTitle', e.target.value || null)} />
+            </Field>
+            <Field label="Year">
+              <Input type="number" value={m.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
+            </Field>
+            <Field label="Director">
+              <Input value={m.director ?? ''} onChange={(e) => set('director', e.target.value || null)} />
+            </Field>
+            <Field label="Runtime (min)">
+              <Input type="number" value={m.runtimeMinutes ?? ''} onChange={(e) => set('runtimeMinutes', e.target.value ? Number(e.target.value) : null)} />
+            </Field>
+            <Field label="Studio">
+              <Input value={m.studio ?? ''} onChange={(e) => set('studio', e.target.value || null)} />
+            </Field>
+            <Field label="Genres (comma separated)">
+              <Input value={m.genres ?? ''} onChange={(e) => set('genres', e.target.value || null)} />
+            </Field>
+            <Field label="Barcode">
+              <Input value={m.barcode ?? ''} onChange={(e) => set('barcode', e.target.value || null)} />
+            </Field>
+          </>
+        )}
+        preview={(
           <CoverPreview
             src={m.imagePath}
             alt={m.title ? `${m.title} poster` : ''}
           />
-          <CoverEditor value={m.imagePath} onChange={(v) => set('imagePath', v)} />
-        </div>
-      </div>
+        )}
+        editor={<CoverEditor value={m.imagePath} onChange={(v) => set('imagePath', v)} expanded={coverEditorExpanded} onExpandedChange={setCoverEditorExpanded} />}
+        editorExpanded={coverEditorExpanded}
+      />
 
       <div>
         <div className="text-xs font-medium text-text-secondary mb-2">Formats owned</div>


### PR DESCRIPTION
## Summary

- Add a shared `CoverFormLayout` used by movie, music, and game forms.
- Keep the cover preview compact on desktop while moving the expanded `CoverEditor` into a full-width row below the field grid.
- Make `CoverEditor` controls wrap/min-width safely so URL input, Apply URL, file upload, and action links do not overflow narrow containers.
- Add component coverage for the responsive cover layout and expanded editor control classes.

Fixes #58

## Test plan

- [x] `npm test -- CoverFormLayout.test CoverEditor.test MovieForm.test AlbumForm.test`
- [x] `npm test`
- [x] `npm run build`
