### PR TITLE
ci: disable setup-node npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: src/client/package-lock.json
 
       - name: Install
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: src/client/package-lock.json
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
## Summary

- Remove `cache: npm` from `actions/setup-node` in CI and release workflows.
- Avoids the slow setup-node cache restore/save path under Gitea `act_runner`; `npm ci` still installs from the lockfile.

## Test plan

- [x] Parsed `.github/workflows/ci.yml` with PyYAML.
- [x] Parsed `.github/workflows/release.yml` with PyYAML.
