### PR TITLE
ci: install docker cli for release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,16 @@ jobs:
           # not necessarily the checked-out tag — so we resolve it explicitly.
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Install Docker CLI when runner image does not include it
+        run: |
+          if command -v docker >/dev/null 2>&1; then
+            docker --version
+            exit 0
+          fi
+          apt-get update
+          apt-get install -y --no-install-recommends docker.io
+          docker --version
+
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary

- Add a release-workflow preflight step that installs the Docker CLI when the Gitea/act_runner job image does not include it.
- Keeps GitHub-hosted behavior fast by no-oping when `docker` is already on `PATH`.

## Why

Gitea release publish reached `docker/setup-qemu-action@v3` but failed with:

```text
Unable to locate executable file: docker
```

The runner is using a job image that does not ship the Docker CLI, while the Docker actions require `docker` on `PATH`.

## Test plan

- [x] Parsed `.github/workflows/release.yml` with PyYAML.
