### PR TITLE
ci: disable buildx gha cache for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,8 +172,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.tag.outputs.version }}
-          # GitHub Actions cache. First release is a cold build; subsequent
-          # ones reuse layers (apt-get curl install, npm install, dotnet
-          # restore) and finish in a fraction of the time.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,3 +172,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.tag.outputs.version }}
+          # GitHub Actions cache. Keep disabled for Gitea act_runner because
+          # its cache endpoint has timed out during release builds. Re-enable
+          # these lines if this workflow moves back to GitHub Actions.
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Remove `type=gha` BuildKit cache from the release image build.
- Gitea `act_runner` exposes a cache endpoint, but this release run timed out/folded the cache export into the image push failure.
- The Docker host/buildx cache can still be reused by the persistent runner without relying on GitHub Actions cache APIs.

## Test plan

- [x] Parsed `.github/workflows/release.yml` with PyYAML.
