### PR TITLE
feat: add LinuxServer-style container startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --logger "console;verbosity=normal"
 
+  docker:
+    name: Docker entrypoint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test entrypoint
+        run: ./scripts/test-docker-entrypoint.sh
+
   client:
     name: Client (Vite/TS)
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,19 +30,27 @@ WORKDIR /app
 # it. Pulls in ~14 transitive deps for ~6 MiB of overhead, in exchange
 # for a self-contained image that doesn't depend on the host
 # orchestrator providing its own probe.
+ARG DEFAULT_PUID=1000
+ARG DEFAULT_PGID=1000
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends curl gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && if ! getent group app >/dev/null; then groupadd -o -g "$DEFAULT_PGID" app; fi \
+    && if ! id -u app >/dev/null 2>&1; then useradd -o -u "$DEFAULT_PUID" -g app -d /app -s /usr/sbin/nologin app; fi
 ENV ASPNETCORE_URLS=http://+:8080 \
     ASPNETCORE_ENVIRONMENT=Production \
-    Collectify__DataDir=/data
+    Collectify__DataDir=/data \
+    PUID=${DEFAULT_PUID} \
+    PGID=${DEFAULT_PGID}
 COPY --from=server-build /app/publish ./
-RUN mkdir -p /data && chown -R 1000:1000 /data
-USER 1000:1000
+COPY docker/entrypoint.sh /usr/local/bin/collectify-entrypoint
+RUN chmod +x /usr/local/bin/collectify-entrypoint \
+    && mkdir -p /data \
+    && chown -R app:app /data
 EXPOSE 8080
 # Hits /api/health (anonymous, DB-free) so a migration-in-progress or
 # write-stall doesn't flap the container. Orchestrators / Watchtower /
 # Docker compose all key off this.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
     CMD curl -fsS http://localhost:8080/api/health || exit 1
-ENTRYPOINT ["dotnet", "Collectify.Api.dll"]
+ENTRYPOINT ["collectify-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Open <http://localhost:8080>. The first visit sends you to **/setup** to create 
 
 Data is persisted to a named Docker volume `collectify-data` (mounted at `/data` inside the container, holds `collectify.db`).
 
+The container follows the LinuxServer-style `PUID`/`PGID` convention. On startup it runs a small root entrypoint, ensures `/data` is owned by the configured IDs, then drops privileges before launching Collectify. Both values default to `1000`:
+
+```bash
+PUID=$(id -u) PGID=$(id -g) docker compose up -d
+```
+
+For named volumes the defaults usually work. For bind mounts, set `PUID` and `PGID` to the host user that should own the data directory.
+
 ### Configuration
 
 Copy `.env.example` to `.env` and set provider keys for internet metadata lookup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     environment:
       ASPNETCORE_URLS: http://+:8080
       Collectify__DataDir: /data
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
     env_file:
       - path: .env
         required: false

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" != "0" ]; then
+    exec dotnet Collectify.Api.dll
+fi
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+DATA_DIR="${Collectify__DataDir:-${COLLECTIFY_DATA_DIR:-/data}}"
+
+groupmod -o -g "$PGID" app
+usermod -o -u "$PUID" app
+
+mkdir -p "$DATA_DIR"
+chown -R "$PUID:$PGID" "$DATA_DIR"
+
+exec gosu "$PUID:$PGID" dotnet Collectify.Api.dll

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -7,6 +7,7 @@
 #   ./scripts/ci-local.sh             # both jobs
 #   ./scripts/ci-local.sh server      # server only (.NET build + xUnit)
 #   ./scripts/ci-local.sh client      # client only (npm ci + build)
+#   ./scripts/ci-local.sh docker      # Docker entrypoint smoke tests
 
 set -Eeuo pipefail
 
@@ -33,14 +34,21 @@ client_job() {
   npm run build
 }
 
+docker_job() {
+  bold "==> docker"
+  cd "$REPO_ROOT"
+  ./scripts/test-docker-entrypoint.sh
+}
+
 start_ts=$(date +%s)
 trap 'red "ci-local: FAILED (job exited non-zero)"; exit 1' ERR
 
 case "$TARGET" in
   server) server_job ;;
   client) client_job ;;
-  all)    server_job; client_job ;;
-  *)      red "unknown target: $TARGET (expected: server | client | all)"; exit 2 ;;
+  docker) docker_job ;;
+  all)    server_job; client_job; docker_job ;;
+  *)      red "unknown target: $TARGET (expected: server | client | docker | all)"; exit 2 ;;
 esac
 
 elapsed=$(( $(date +%s) - start_ts ))

--- a/scripts/test-docker-entrypoint.sh
+++ b/scripts/test-docker-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+entrypoint="$repo_root/docker/entrypoint.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+log="$tmpdir/calls.log"
+mkdir -p "$tmpdir/bin" "$tmpdir/data"
+
+cat > "$tmpdir/bin/id" <<'STUB'
+#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf '%s\n' "${TEST_UID:-0}"
+  exit 0
+fi
+exec /usr/bin/id "$@"
+STUB
+
+cat > "$tmpdir/bin/groupmod" <<'STUB'
+#!/bin/sh
+printf 'groupmod %s\n' "$*" >> "$ENTRYPOINT_TEST_LOG"
+STUB
+
+cat > "$tmpdir/bin/usermod" <<'STUB'
+#!/bin/sh
+printf 'usermod %s\n' "$*" >> "$ENTRYPOINT_TEST_LOG"
+STUB
+
+cat > "$tmpdir/bin/chown" <<'STUB'
+#!/bin/sh
+printf 'chown %s\n' "$*" >> "$ENTRYPOINT_TEST_LOG"
+STUB
+
+cat > "$tmpdir/bin/gosu" <<'STUB'
+#!/bin/sh
+printf 'gosu %s\n' "$*" >> "$ENTRYPOINT_TEST_LOG"
+exit 0
+STUB
+
+cat > "$tmpdir/bin/dotnet" <<'STUB'
+#!/bin/sh
+printf 'dotnet %s\n' "$*" >> "$ENTRYPOINT_TEST_LOG"
+exit 0
+STUB
+
+chmod +x "$tmpdir/bin"/*
+
+run_entrypoint() {
+  : > "$log"
+  PATH="$tmpdir/bin:$PATH" \
+  ENTRYPOINT_TEST_LOG="$log" \
+  COLLECTIFY_DATA_DIR="$tmpdir/data" \
+  "$entrypoint"
+}
+
+assert_log_contains() {
+  local expected="$1"
+  if ! grep -Fxq "$expected" "$log"; then
+    echo "Expected log line not found: $expected" >&2
+    echo "Actual log:" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+}
+
+run_entrypoint
+assert_log_contains "groupmod -o -g 1000 app"
+assert_log_contains "usermod -o -u 1000 app"
+assert_log_contains "chown -R 1000:1000 $tmpdir/data"
+assert_log_contains "gosu 1000:1000 dotnet Collectify.Api.dll"
+
+PUID=1234 PGID=5678 run_entrypoint
+assert_log_contains "groupmod -o -g 5678 app"
+assert_log_contains "usermod -o -u 1234 app"
+assert_log_contains "chown -R 1234:5678 $tmpdir/data"
+assert_log_contains "gosu 1234:5678 dotnet Collectify.Api.dll"
+
+TEST_UID=1000 run_entrypoint
+if grep -Eq 'groupmod|usermod|chown|gosu' "$log"; then
+  echo "Non-root startup should not mutate users or call gosu." >&2
+  cat "$log" >&2
+  exit 1
+fi
+assert_log_contains "dotnet Collectify.Api.dll"
+
+echo "docker entrypoint tests passed"


### PR DESCRIPTION
## Summary
- Add a root startup entrypoint that applies LinuxServer-style PUID/PGID ownership to the Collectify data directory, then drops privileges with gosu.
- Expose PUID/PGID defaults in docker-compose and document the startup/security tradeoff in the README.
- Add an entrypoint smoke test and wire it into local/GitHub CI.

## Test Plan
- [x] ./scripts/ci-local.sh docker
- [x] docker compose config >/tmp/collectify-compose-config.yml
- [x] ./scripts/ci-local.sh server
- [x] ./scripts/ci-local.sh client

Note: attempted `docker build --target runtime -t collectify:entrypoint-test .`, but this environment cannot create Docker bridge veth pairs (`operation not supported`) during RUN steps, so the image build could not be completed locally here.

Fixes #66
