### PR TITLE
docs: document metadata lookup env vars in README and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,32 @@ For named volumes the defaults usually work. For bind mounts, set `PUID` and `PG
 
 ### Configuration
 
-Copy `.env.example` to `.env` and set provider keys for internet metadata lookup:
+Copy `.env.example` to `.env`, set the variables you need, and restart:
 
 ```bash
 cp .env.example .env   # edit API keys here
 docker compose restart
 ```
 
-All provider keys are optional — lookups degrade gracefully when unconfigured. See [`.env.example`](.env.example) for the full list.
+All provider keys are optional — lookups degrade gracefully when unconfigured. The container reads `.env` via `env_file` in [`docker-compose.yml`](docker-compose.yml), so every variable flows into the runtime automatically.
+
+#### Metadata lookup providers
+
+| Provider | Variable(s) | Required? | Purpose |
+|---|---|---|---|
+| **TMDB** (movies) | `Collectify__Metadata__Tmdb__ApiKey` | Yes | Movie title search, cover images. Get a v3 key at [themoviedb.org](https://www.themoviedb.org/settings/api). |
+| **MusicBrainz** (music) | `Collectify__Metadata__MusicBrainz__UserAgent` | Yes | Music release lookup by barcode/title. Format: `"AppName/Version (contact@example.com)"`. No API key needed — the User-Agent is your identity per [their etiquette policy](https://musicbrainz.org/doc/MusicBrainz_API#etiquette). |
+| **IGDB** (games) | `Collectify__Metadata__Igdb__TwitchClientId`<br>`Collectify__Metadata__Igdb__TwitchClientSecret` | Both | Game title search and cover images. Create a Twitch app at [dev.twitch.tv](https://dev.twitch.tv/console/apps). |
+| **UPCitemdb** (barcode fallback) | *(none)* | No | Free trial endpoint, IP rate-limited (~100/day). Used for movies/games when TMDB/IGDB don't recognize a UPC. Override `Collectify__Metadata__Upc__BaseUrl` only for tests or paid-tier swaps. |
+
+#### Other settings
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `Collectify__Metadata__CacheTtl` | `30.00:00:00` | How long a cached lookup stays fresh (`.NET TimeSpan`). |
+| `Collectify__Auth__AllowRegistration` | `false` | Flip to `true` to expose `/register` and allow sign-ups. |
+
+See [`.env.example`](.env.example) for the full list including optional base URL overrides.
 
 ### Changing the image source
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@
 #   IMAGE_NAME=mforce/collectify  # defaults to mforce/collectify
 #   TAG=v0.1.0                    # defaults to latest
 #
+# Metadata provider keys (TMDB, MusicBrainz, IGDB) go in .env — see .env.example:
+#   Collectify__Metadata__Tmdb__ApiKey=your-tmdb-key
+#   Collectify__Metadata__MusicBrainz__UserAgent="Collectify/1.0 (you@example.com)"
+#   Collectify__Metadata__Igdb__TwitchClientId=your-twitch-client-id
+#   Collectify__Metadata__Igdb__TwitchClientSecret=your-twitch-secret
+#
 # For local development (build from source), use docker-compose.dev.yml:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 


### PR DESCRIPTION
## What changed

Expanded the Configuration section with tables documenting every metadata provider environment variable.

### `README.md`
- Added **Metadata lookup providers** table listing TMDB, MusicBrainz, IGDB, and UPCitemdb — required variables, purpose, and links to obtain keys.
- Added **Other settings** table for `CacheTtl` and `AllowRegistration`.
- Clarified that `.env` flows into the container via `env_file` in docker-compose.

### `docker-compose.yml`
- Added commented examples of metadata provider variables so users see the expected format without opening `.env.example`.

Fixes #68