### PR TITLE
ci: update actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       run:
         working-directory: src/server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -37,7 +37,7 @@ jobs:
     name: Docker entrypoint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test entrypoint
         run: ./scripts/test-docker-entrypoint.sh
@@ -49,10 +49,10 @@ jobs:
       run:
         working-directory: src/client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,11 @@ jobs:
       run:
         working-directory: src/server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -75,11 +75,11 @@ jobs:
       run:
         working-directory: src/client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -102,7 +102,7 @@ jobs:
       # with the workflow's GITHUB_TOKEN. Harmless for other registries.
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -130,11 +130,11 @@ jobs:
           apt-get install -y --no-install-recommends docker.io
           docker --version
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USER || github.actor }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Derive image tags and OCI labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # metadata-action also adds :latest automatically for non-prerelease
@@ -163,7 +163,7 @@ jobs:
             org.opencontainers.image.revision=${{ steps.tag.outputs.sha }}
 
       - name: Build and push (linux/amd64, linux/arm64)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- Update CI workflow actions to Node 24-compatible releases.
- Update release workflow actions, including Docker actions, to Node 24-compatible releases.

Fixes #73

## Test Plan
- `npm test`
- `npm run build`
- Parsed `.github/workflows/*.yml` with PyYAML
- Verified referenced JavaScript actions declare `runs.using: node24`
