### PR TITLE
Fix auth screen brand artwork

### DIFF
--- a/src/client/components/AuthBrandPanel.tsx
+++ b/src/client/components/AuthBrandPanel.tsx
@@ -1,0 +1,13 @@
+export default function AuthBrandPanel({ imageSrc = '/brand/collectify-sample.png' }: { imageSrc?: string }) {
+  return (
+    <aside className="hidden min-h-screen items-center justify-center border-r border-border bg-card px-8 py-10 lg:flex">
+      <div className="w-full max-w-4xl">
+        <img
+          src={imageSrc}
+          alt=""
+          className="w-full rounded-2xl border border-border bg-white object-contain shadow-card"
+        />
+      </div>
+    </aside>
+  );
+}

--- a/src/client/pages/Login.tsx
+++ b/src/client/pages/Login.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth, useLogin } from '../services/auth';
 import { useToast } from '../components/toaster';
 import { Button, Card, Field, Input } from '../components/ui';
+import AuthBrandPanel from '../components/AuthBrandPanel';
 
 export default function Login() {
   const [userName, setUserName] = useState('');
@@ -12,15 +13,9 @@ export default function Login() {
   const toast = useToast();
 
   return (
-    <div className="grid min-h-screen bg-surface lg:grid-cols-[1fr_440px]">
-      <div className="relative hidden overflow-hidden bg-[#071333] lg:block">
-        <img
-          src="/brand/collectify-sample.png"
-          alt=""
-          className="absolute inset-0 h-full w-full object-cover object-center"
-        />
-      </div>
-      <div className="flex items-center justify-center p-4 sm:p-8">
+    <div className="grid min-h-screen bg-surface lg:grid-cols-[minmax(0,1fr)_480px]">
+      <AuthBrandPanel />
+      <div className="flex items-center justify-center p-4 sm:p-8 lg:bg-surface">
       <Card className="w-full max-w-md !p-6 sm:!p-8">
         <div className="mb-6 flex items-center gap-3">
           <img src="/brand/collectify-logo.png" alt="" className="h-12 w-12 rounded-2xl shadow-sm" />

--- a/src/client/pages/Register.tsx
+++ b/src/client/pages/Register.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useRegister } from '../services/auth';
 import { useToast } from '../components/toaster';
 import { Button, Card, Field, Input } from '../components/ui';
+import AuthBrandPanel from '../components/AuthBrandPanel';
 
 export default function Register() {
   const [userName, setUserName] = useState('');
@@ -14,15 +15,9 @@ export default function Register() {
   const mismatched = confirm.length > 0 && password !== confirm;
 
   return (
-    <div className="grid min-h-screen bg-surface lg:grid-cols-[1fr_440px]">
-      <div className="relative hidden overflow-hidden bg-[#071333] lg:block">
-        <img
-          src="/brand/collectify-banner-dark.png"
-          alt=""
-          className="absolute inset-0 h-full w-full object-cover object-center"
-        />
-      </div>
-      <div className="flex items-center justify-center p-4 sm:p-8">
+    <div className="grid min-h-screen bg-surface lg:grid-cols-[minmax(0,1fr)_480px]">
+      <AuthBrandPanel imageSrc="/brand/collectify-banner-dark.png" />
+      <div className="flex items-center justify-center p-4 sm:p-8 lg:bg-surface">
       <Card className="w-full max-w-md !p-6 sm:!p-8">
         <div className="mb-6 flex items-center gap-3">
           <img src="/brand/collectify-logo.png" alt="" className="h-12 w-12 rounded-2xl shadow-sm" />

--- a/src/client/pages/Setup.tsx
+++ b/src/client/pages/Setup.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useSetup } from '../services/auth';
 import { useToast } from '../components/toaster';
 import { Button, Card, Field, Input } from '../components/ui';
+import AuthBrandPanel from '../components/AuthBrandPanel';
 
 export default function Setup() {
   const [userName, setUserName] = useState('');
@@ -12,15 +13,9 @@ export default function Setup() {
   const mismatch = password.length > 0 && confirm.length > 0 && password !== confirm;
 
   return (
-    <div className="grid min-h-screen bg-surface lg:grid-cols-[1fr_460px]">
-      <div className="relative hidden overflow-hidden bg-[#071333] lg:block">
-        <img
-          src="/brand/collectify-banner-light.png"
-          alt=""
-          className="absolute inset-0 h-full w-full object-cover object-center"
-        />
-      </div>
-      <div className="flex items-center justify-center p-4 sm:p-8">
+    <div className="grid min-h-screen bg-surface lg:grid-cols-[minmax(0,1fr)_480px]">
+      <AuthBrandPanel imageSrc="/brand/collectify-banner-light.png" />
+      <div className="flex items-center justify-center p-4 sm:p-8 lg:bg-surface">
       <Card className="w-full max-w-md !p-6 sm:!p-8">
         <div className="mb-6 flex items-center gap-3">
           <img src="/brand/collectify-logo.png" alt="" className="h-12 w-12 rounded-2xl shadow-sm" />


### PR DESCRIPTION
## Summary
- replace cropped auth background images with a reusable contained brand panel
- keep login, setup, and register forms on a clean neutral surface

## Verification
- npm run build
- npm test