### PR TITLE
fix: mobile layout overflow and truncation on list/detail pages

### DIFF
--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -82,7 +82,7 @@ function ListCard({ item, r, category }: { item: BaseItem; r: RenderedItem; cate
         </div>
         <div className="min-w-0 flex-1 flex flex-col gap-1">
           <div className="flex items-start justify-between gap-2">
-            <h3 className={`font-medium text-text-primary leading-snug truncate ${titleClass}`}>{r.primary}</h3>
+            <h3 className={`min-w-0 flex-1 font-medium text-text-primary leading-snug truncate ${titleClass}`}>{r.primary}</h3>
             <StatusPill status={item.status} category={category} />
           </div>
           {r.secondary && (
@@ -108,7 +108,7 @@ function MediumCard({ item, r, category }: { item: BaseItem; r: RenderedItem; ca
         </div>
         <div className="min-w-0 flex-1 flex flex-col gap-1.5">
           <div className="flex items-start justify-between gap-2">
-            <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
+            <h3 className={`min-w-0 flex-1 font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
             <StatusPill status={item.status} category={category} />
           </div>
           {r.secondary && (
@@ -145,7 +145,7 @@ function BigCard({ item, r, category }: { item: BaseItem; r: RenderedItem; categ
         </div>
         <div className="flex flex-col gap-1.5 p-3 min-w-0">
           <div className="flex items-start justify-between gap-2">
-            <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
+            <h3 className={`min-w-0 flex-1 font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
             <StatusPill status={item.status} category={category} />
           </div>
           {r.secondary && (

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -80,11 +80,18 @@ function ListCard({ item, r, category }: { item: BaseItem; r: RenderedItem; cate
         <div className="w-16 shrink-0 overflow-hidden rounded-xl bg-imgPlaceholder">
           <CoverBlock src={item.imagePath} />
         </div>
-        <div className="flex-1 min-w-0 flex items-center gap-2">
-          <h3 className={`font-medium text-text-primary leading-snug truncate ${titleClass}`}>{r.primary}</h3>
-          {r.secondary && <span className="text-sm text-text-secondary shrink-0">{r.secondary}</span>}
+        <div className="min-w-0 flex-1 flex flex-col gap-1">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className={`font-medium text-text-primary leading-snug truncate ${titleClass}`}>{r.primary}</h3>
+            <StatusPill status={item.status} category={category} />
+          </div>
+          {r.secondary && (
+            <span className="text-sm text-text-secondary truncate shrink-0">{r.secondary}</span>
+          )}
+          {r.tertiary && (
+            <span className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</span>
+          )}
         </div>
-        <StatusPill status={item.status} category={category} />
       </div>
     </Card>
   );
@@ -99,12 +106,17 @@ function MediumCard({ item, r, category }: { item: BaseItem; r: RenderedItem; ca
         <div className="w-24 shrink-0 overflow-hidden rounded-xl bg-imgPlaceholder">
           <CoverBlock src={item.imagePath} />
         </div>
-        <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+        <div className="min-w-0 flex-1 flex flex-col gap-1.5">
           <div className="flex items-start justify-between gap-2">
             <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
             <StatusPill status={item.status} category={category} />
           </div>
-          {r.secondary && <div className="text-sm text-text-secondary truncate">{r.secondary}</div>}
+          {r.secondary && (
+            <div className="text-sm text-text-secondary truncate shrink-0">{r.secondary}</div>
+          )}
+          {r.tertiary && (
+            <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
+          )}
           {item.personalRating != null && (
             <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
           )}
@@ -127,17 +139,21 @@ function BigCard({ item, r, category }: { item: BaseItem; r: RenderedItem; categ
   const tags = item.tags ?? [];
   return (
     <Card className={`!p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
-      <div className="flex flex-col md:flex-row">
+      <div className="flex flex-col gap-3 md:flex-row">
         <div className="relative w-full shrink-0 overflow-hidden bg-imgPlaceholder sm:w-24 md:w-36 lg:w-48">
           <CoverBlock src={item.imagePath} />
         </div>
-        <div className="flex-1 p-3 flex flex-col gap-1.5 min-w-0">
+        <div className="flex flex-col gap-1.5 p-3 min-w-0">
           <div className="flex items-start justify-between gap-2">
             <h3 className={`font-medium text-text-primary leading-snug line-clamp-2 ${titleClass}`}>{r.primary}</h3>
             <StatusPill status={item.status} category={category} />
           </div>
-          {r.secondary && <div className="text-sm text-text-secondary truncate">{r.secondary}</div>}
-          {r.tertiary && <div className="text-xs text-text-tertiary truncate">{r.tertiary}</div>}
+          {r.secondary && (
+            <div className="text-sm text-text-secondary truncate shrink-0">{r.secondary}</div>
+          )}
+          {r.tertiary && (
+            <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
+          )}
           {item.personalRating != null && (
             <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
           )}

--- a/src/client/components/DetailView.tsx
+++ b/src/client/components/DetailView.tsx
@@ -30,9 +30,9 @@ function formatDate(date?: string | null): string {
 function InfoRow({ label, value }: { label: string; value?: string | null }) {
   if (!value) return null;
   return (
-    <div className="flex items-start gap-2 py-1.5">
-      <dt className="w-36 shrink-0 text-sm text-text-secondary">{label}</dt>
-      <dd className="text-sm text-text-primary break-words">{value}</dd>
+    <div className="flex flex-col sm:flex-row gap-1 py-1.5">
+      <dt className="w-24 shrink-0 sm:w-36 text-sm text-text-secondary">{label}</dt>
+      <dd className="text-sm text-text-primary break-words min-w-0">{value}</dd>
     </div>
   );
 }
@@ -65,13 +65,13 @@ function ThemedCard({ type, children, className = '' }: { type: MediaType; child
 
 function HeroTitle({ type, title, subtitle }: { type: MediaType; title: string; subtitle?: string | null }) {
   return (
-    <div className="flex items-start gap-3">
+    <div className="flex items-start gap-3 min-w-0">
       <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-card shadow-sm">
         <MediaIcon type={type} className="h-7 w-7" />
       </span>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <h2 className={`text-2xl font-extrabold leading-tight tracking-tight ${detailTheme[type].title}`}>{title}</h2>
-        {subtitle && <p className="mt-0.5 text-sm text-text-secondary">{subtitle}</p>}
+        {subtitle && <p className="mt-0.5 text-sm text-text-secondary truncate">{subtitle}</p>}
       </div>
     </div>
   );
@@ -86,8 +86,8 @@ function MovieDetail({ item }: { item: Movie }) {
   return (
     <div className="space-y-6">
       {/* Hero section */}
-      <div className="flex flex-col md:flex-row gap-6 items-start">
-        <div className="w-48 shrink-0 mx-auto md:mx-0">
+      <div className="flex flex-col gap-4 md:flex-row items-start">
+        <div className="w-36 shrink-0 sm:w-40 md:w-48 mx-auto">
           {item.imagePath ? (
             <CoverPreview src={item.imagePath} alt={`${item.title} cover`} />
           ) : (
@@ -96,7 +96,7 @@ function MovieDetail({ item }: { item: Movie }) {
             </div>
           )}
         </div>
-        <div className="flex-1 space-y-3 min-w-0">
+        <div className="min-w-0 flex-1 space-y-3">
           <div>
             <HeroTitle
               type="movies"
@@ -107,9 +107,9 @@ function MovieDetail({ item }: { item: Movie }) {
 
           {/* Year / Director / Runtime row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
-            {item.year && <span>{item.year}</span>}
-            {item.director && <span>{item.director}</span>}
-            {item.runtimeMinutes && <span>{item.runtimeMinutes} min</span>}
+            {item.year && <span className="shrink-0">{item.year}</span>}
+            {item.director && <span className="shrink-0 min-w-0 truncate">{item.director}</span>}
+            {item.runtimeMinutes && <span className="shrink-0">{item.runtimeMinutes} min</span>}
           </div>
 
           {/* Formats */}
@@ -209,8 +209,8 @@ function MusicDetail({ item }: { item: Album }) {
   return (
     <div className="space-y-6">
       {/* Hero section */}
-      <div className="flex flex-col md:flex-row gap-6 items-start">
-        <div className="w-48 shrink-0 mx-auto md:mx-0">
+      <div className="flex flex-col gap-4 md:flex-row items-start">
+        <div className="w-36 shrink-0 sm:w-40 md:w-48 mx-auto">
           {item.imagePath ? (
             <CoverPreview src={item.imagePath} alt={`${item.title} cover`} />
           ) : (
@@ -219,16 +219,16 @@ function MusicDetail({ item }: { item: Album }) {
             </div>
           )}
         </div>
-        <div className="flex-1 space-y-3 min-w-0">
+        <div className="min-w-0 flex-1 space-y-3">
           <div>
             <HeroTitle type="music" title={item.title} subtitle={item.artistName} />
           </div>
 
           {/* Year / Format row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
-            {item.year && <span>{item.year}</span>}
+            {item.year && <span className="shrink-0">{item.year}</span>}
             {item.format && (
-              <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.music.accent}`}>
+              <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.music.accent}`}>
                 {item.format === 'Cd' ? 'CD' : item.format === 'Vinyl' ? 'Vinyl' : 'Other'}
               </span>
             )}
@@ -315,8 +315,8 @@ function GameDetail({ item }: { item: Game }) {
   return (
     <div className="space-y-6">
       {/* Hero section */}
-      <div className="flex flex-col md:flex-row gap-6 items-start">
-        <div className="w-48 shrink-0 mx-auto md:mx-0">
+      <div className="flex flex-col gap-4 md:flex-row items-start">
+        <div className="w-36 shrink-0 sm:w-40 md:w-48 mx-auto">
           {item.imagePath ? (
             <CoverPreview src={item.imagePath} alt={`${item.title} cover`} />
           ) : (
@@ -325,20 +325,20 @@ function GameDetail({ item }: { item: Game }) {
             </div>
           )}
         </div>
-        <div className="flex-1 space-y-3 min-w-0">
+        <div className="min-w-0 flex-1 space-y-3">
           <div>
             <HeroTitle type="games" title={item.title} subtitle={gamePlatformLabel(item.platform)} />
           </div>
 
           {/* Year / Platform row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
-            {item.year && <span>{item.year}</span>}
+            {item.year && <span className="shrink-0">{item.year}</span>}
             {item.isDigital ? (
-              <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.games.accent}`}>
-                Digital{item.digitalStore ? ` (${item.digitalStore})` : ''}
+              <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.games.accent}`}>
+                Digital{item.digitalStore && <span className="min-w-0 truncate"> ({item.digitalStore})</span>}
               </span>
             ) : (
-              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-pill-bg text-text-secondary border border-border">
+              <span className="inline-flex items-center shrink-0 px-2 py-0.5 rounded-full text-xs font-medium bg-pill-bg text-text-secondary border border-border">
                 Physical
               </span>
             )}

--- a/src/client/components/DetailView.tsx
+++ b/src/client/components/DetailView.tsx
@@ -108,7 +108,7 @@ function MovieDetail({ item }: { item: Movie }) {
           {/* Year / Director / Runtime row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
             {item.year && <span className="shrink-0">{item.year}</span>}
-            {item.director && <span className="shrink-0 min-w-0 truncate">{item.director}</span>}
+            {item.director && <span className="flex-1 min-w-0 truncate">{item.director}</span>}
             {item.runtimeMinutes && <span className="shrink-0">{item.runtimeMinutes} min</span>}
           </div>
 


### PR DESCRIPTION
Fixes #78

## Problem

Collection list cards and detail pages overflow / collide on narrow mobile screens (360–430px).

## Changes

### CollectionList cards ()

| Card | Fix |
|---|---|
| `ListCard` | Moved `StatusPill` into the metadata column so it stacks above secondary/tertiary on narrow widths instead of crowding the title in a single row. Added `truncate` to all metadata spans. |
| `MediumCard` / `BigCard` | Added `shrink-0` + `truncate` to secondary and tertiary fields to prevent overflow. |

### Detail pages ()

| Fix | Why |
|---|---|
| `InfoRow` label narrower on mobile (`w-24` → `w-36`) | Leaves more room for long values like MusicBrainz IDs |
| `InfoRow` stacks vertically on mobile (`flex-col sm:flex-row`) | Prevents horizontal overflow at narrow widths |
| `InfoRow` value gets `min-w-0` | Allows `break-words` to work |
| `HeroTitle` subtitle gets `flex-1` + `truncate` | Prevents long subtitle text from pushing the icon off-screen |
| All hero cover images smaller on mobile (`w-36` → `sm:w-40` → `md:w-48`) | Less space hogged by the cover, more room for text |
| Hero gap reduced on mobile (`gap-4` vs `gap-6`) | Tighter mobile spacing |
| Inline metadata items get `shrink-0` | Year/format badges don't get squished |
| Game digital store name truncated | Prevents overflow on very narrow screens |

## Verification

- ✅ No horizontal overflow at 360–430px viewport widths
- ✅ Status pills readable, no content collisions
- ✅ Long metadata wraps or clamps intentionally
- ✅ `npm run build` — clean
- ✅ `npm test` — 95/95 pass
- ✅ `dotnet build` — clean