### PR TITLE
fix(client): drop removed BrowserRouter future prop for react-router v7

### DIFF
--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -17,17 +17,12 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter
-        future={{
-          // Opt into React Router v7's behaviour now to silence the
-          // "Future Flag Warning" pair printed at startup. v7_startTransition
-          // wraps state updates in React.startTransition so route changes
-          // can be interrupted; v7_relativeSplatPath fixes how relative
-          // links resolve inside splat ("*") routes.
-          v7_startTransition: true,
-          v7_relativeSplatPath: true,
-        }}
-      >
+      {/*
+        React Router v7 makes the former v7_startTransition and
+        v7_relativeSplatPath behaviours the default and removes the `future`
+        prop, so there is nothing left to opt into here.
+      */}
+      <BrowserRouter>
         <App />
       </BrowserRouter>
     </QueryClientProvider>


### PR DESCRIPTION
## What

Remove the `future={{ v7_startTransition, v7_relativeSplatPath }}` prop from `<BrowserRouter>` in `src/client/main.tsx`.

## Why

`main` is red. #124 bumped `react-router-dom` 6 → 7.18.2, but the accompanying code migration didn't land. In v7 those two behaviours are the default and the `future` prop was **removed** from `BrowserRouterProps`, so `tsc -b` fails:

```
main.tsx(21,9): error TS2322: Property 'future' does not exist on type 'IntrinsicAttributes & BrowserRouterProps'.
```

That single type error broke two CI jobs on main:

- **Client (Vite/TS)** → the *Build* step (`tsc -b && vite build`)
- **Image build + Trivy scan** → the Docker build compiles the client, so it failed identically (and skipped Trivy/smoke-test/publish downstream)

The Server (.NET) job and all client **tests** passed — the extra prop is ignored at runtime, so only the typecheck in the build caught it.

## Verification

Against the actual v7 install (`npm ci` → react-router-dom 7.18.2):

- `npm run build` → ✅ `tsc -b` clean, vite build succeeds
- `npm test` → ✅ 108/108
- pre-commit hook (typecheck + build) → ✅

Audited every other `react-router-dom` import in the client (`Link`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`, `Routes`, `Route`, `Navigate`, `NavLink`, `MemoryRouter`) — all unchanged in v7, so `main.tsx` was the only breakage.