### PR TITLE
fix(client): align enum labels and filter controls

### DIFF
--- a/src/client/components/DetailView.test.tsx
+++ b/src/client/components/DetailView.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import DetailView from './DetailView';
+import type { Album, Game, MusicFormat } from '../services/types';
+
+const album: Album = {
+  title: 'Kind of Blue',
+  artistName: 'Miles Davis',
+  format: 'Cd',
+  status: 'Owned',
+  listenCount: 0,
+};
+
+const game: Game = {
+  title: 'Journey',
+  platform: 'Ps5',
+  isDigital: true,
+  digitalStore: 'Psn',
+  status: 'Owned',
+  completionStatus: 'Beaten',
+};
+
+function renderDetail(item: Album | Game, type: 'music' | 'games') {
+  render(
+    <MemoryRouter>
+      <DetailView item={item} type={type} onEdit={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+describe('DetailView enum labels', () => {
+  it('renders the music format label and preserves unknown runtime values', () => {
+    renderDetail(album, 'music');
+    expect(screen.getByText('CD')).toBeInTheDocument();
+
+    renderDetail({ ...album, title: 'Tape', format: 'Cassette' as MusicFormat }, 'music');
+    expect(screen.getByText('Cassette')).toBeInTheDocument();
+  });
+
+  it('renders the digital store display label', () => {
+    renderDetail(game, 'games');
+    expect(screen.getByText('PlayStation Network', { exact: false })).toBeInTheDocument();
+    expect(screen.queryByText('Psn', { exact: false })).not.toBeInTheDocument();
+  });
+});

--- a/src/client/components/DetailView.tsx
+++ b/src/client/components/DetailView.tsx
@@ -2,7 +2,14 @@ import { Link } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { Card, CoverPreview, StatusPill, TagChip } from './ui';
 import type { Album, Game, MediaType, Movie } from '../services/types';
-import { completionStatusLabel, gamePlatformLabel, MOVIE_FORMAT_FLAGS, watchStatusLabel } from '../services/types';
+import {
+  completionStatusLabel,
+  digitalStoreLabel,
+  gamePlatformLabel,
+  MOVIE_FORMAT_FLAGS,
+  musicFormatLabel,
+  watchStatusLabel,
+} from '../services/types';
 import MediaIcon from './MediaIcon';
 
 interface Props<T> {
@@ -229,7 +236,7 @@ function MusicDetail({ item }: { item: Album }) {
             {item.year && <span className="shrink-0">{item.year}</span>}
             {item.format && (
               <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.music.accent}`}>
-                {item.format === 'Cd' ? 'CD' : item.format === 'Vinyl' ? 'Vinyl' : 'Other'}
+                {musicFormatLabel(item.format) ?? item.format}
               </span>
             )}
           </div>
@@ -335,7 +342,7 @@ function GameDetail({ item }: { item: Game }) {
             {item.year && <span className="shrink-0">{item.year}</span>}
             {item.isDigital ? (
               <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme.games.accent}`}>
-                Digital{item.digitalStore && <span className="min-w-0 truncate"> ({item.digitalStore})</span>}
+                Digital{item.digitalStore && <span className="min-w-0 truncate"> ({digitalStoreLabel(item.digitalStore) ?? item.digitalStore})</span>}
               </span>
             ) : (
               <span className="inline-flex items-center shrink-0 px-2 py-0.5 rounded-full text-xs font-medium bg-pill-bg text-text-secondary border border-border">

--- a/src/client/components/FiltersPanel.test.tsx
+++ b/src/client/components/FiltersPanel.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { Filters } from '../services/filters';
+import type { MediaType } from '../services/types';
+import FiltersPanel from './FiltersPanel';
+
+function renderPanel<T extends MediaType>(type: T, value: Filters<T>, onChange = vi.fn()) {
+  render(<FiltersPanel type={type} value={value} onChange={onChange} onClear={vi.fn()} />);
+  return onChange;
+}
+
+describe('FiltersPanel', () => {
+  it.each(['movies', 'music', 'games'] as const)('exposes a Tags field for %s', async (type) => {
+    renderPanel(type, {});
+    await userEvent.click(screen.getByRole('button', { name: /Filters/ }));
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByLabelText('Add tag')).toBeInTheDocument();
+  });
+
+  it('updates tags while preserving unrelated filters', async () => {
+    const onChange = renderPanel('movies', { director: 'Nolan', tag: ['imax'] });
+    await userEvent.click(screen.getByRole('button', { name: /Filters/ }));
+    await userEvent.type(screen.getByLabelText('Add tag'), 'Sci-Fi{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith({ director: 'Nolan', tag: ['imax', 'sci-fi'] });
+  });
+
+  it('counts one rendered year-range chip as one active filter', () => {
+    renderPanel('movies', { yearFrom: 2000, yearTo: 2020 });
+    expect(screen.getByRole('button', { name: /Filters \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByText('2000–2020')).toBeInTheDocument();
+  });
+
+  it('clears both year bounds when removing the Year chip', async () => {
+    const onChange = renderPanel('movies', { yearFrom: 2000, yearTo: 2020, director: 'Nolan' });
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Year filter' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      yearFrom: undefined,
+      yearTo: undefined,
+      director: 'Nolan',
+    });
+  });
+});

--- a/src/client/components/FiltersPanel.test.tsx
+++ b/src/client/components/FiltersPanel.test.tsx
@@ -42,4 +42,11 @@ describe('FiltersPanel', () => {
       director: 'Nolan',
     });
   });
+
+  it('renders the digital-store display label in the active-filter chip', () => {
+    renderPanel('games', { digitalStore: 'Psn' });
+
+    expect(screen.getByText('PlayStation Network')).toBeInTheDocument();
+    expect(screen.queryByText('Psn')).not.toBeInTheDocument();
+  });
 });

--- a/src/client/components/FiltersPanel.tsx
+++ b/src/client/components/FiltersPanel.tsx
@@ -14,10 +14,12 @@ import {
   COLLECTION_STATUSES,
   COMPLETION_STATUSES,
   DIGITAL_STORES,
+  digitalStoreLabel,
   GAME_PLATFORMS,
   MOVIE_FORMAT_FLAGS,
   MUSIC_FORMATS,
   WATCH_STATUSES,
+  type DigitalStore,
   type MediaType,
 } from '../services/types';
 
@@ -325,7 +327,11 @@ function describeActive<T extends MediaType>(_type: T, filters: Filters<T>): { k
   for (const [key, value] of Object.entries(f)) {
     if (key === 'yearFrom' || key === 'yearTo' || key === 'tag') continue;
     if (value === undefined || value === null || value === '') continue;
-    const display = typeof value === 'boolean' ? (value ? 'Digital' : 'Physical') : String(value);
+    const display = key === 'digitalStore'
+      ? digitalStoreLabel(value as DigitalStore) ?? String(value)
+      : typeof value === 'boolean'
+        ? (value ? 'Digital' : 'Physical')
+        : String(value);
     out.push({ key, label: labels[key] ?? key, display });
   }
   if (Array.isArray(f.tag) && f.tag.length > 0) {

--- a/src/client/components/FiltersPanel.tsx
+++ b/src/client/components/FiltersPanel.tsx
@@ -7,6 +7,7 @@ import {
   SearchableSelect,
   Select,
   TagChip,
+  TagInput,
 } from './ui';
 import { activeFilterCount, type Filters } from '../services/filters';
 import {
@@ -70,6 +71,13 @@ export default function FiltersPanel<T extends MediaType>({ type, value, onChang
             {type === 'movies' && <MovieFields value={value as Filters<'movies'>} onChange={onChange as (v: Filters<'movies'>) => void} />}
             {type === 'music' && <AlbumFields value={value as Filters<'music'>} onChange={onChange as (v: Filters<'music'>) => void} />}
             {type === 'games' && <GameFields value={value as Filters<'games'>} onChange={onChange as (v: Filters<'games'>) => void} />}
+            <Field label="Tags">
+              <TagInput
+                value={value.tag ?? []}
+                onChange={(tag) => onChange({ ...value, tag } as Filters<T>)}
+                category={type}
+              />
+            </Field>
           </div>
         </Card>
       )}
@@ -274,7 +282,11 @@ function ActiveChips<T extends MediaType>({ type, value, onChange }: ChipProps<T
           <span className="text-text-secondary mr-1">{e.label}:</span> {e.display}
           <button
             type="button"
-            onClick={() => onChange({ ...value, [e.key]: undefined } as Filters<T>)}
+            onClick={() => onChange(
+              e.key === 'yearFrom'
+                ? { ...value, yearFrom: undefined, yearTo: undefined } as Filters<T>
+                : { ...value, [e.key]: undefined } as Filters<T>,
+            )}
             aria-label={`Remove ${e.label} filter`}
             className="ml-0.5 text-text-secondary hover:text-error"
           >

--- a/src/client/pages/GamesList.test.tsx
+++ b/src/client/pages/GamesList.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { Game } from '../services/types';
+import GamesList from './GamesList';
+
+vi.mock('../components/CollectionList', () => ({
+  default: ({ renderItem }: { renderItem: (game: Game) => { tertiary?: string } }) => {
+    const rendered = renderItem({
+      title: 'Journey',
+      platform: 'Ps5',
+      isDigital: true,
+      digitalStore: 'Psn',
+      status: 'Owned',
+      completionStatus: 'Beaten',
+    });
+    return <div>{rendered.tertiary}</div>;
+  },
+}));
+
+describe('GamesList enum labels', () => {
+  it('renders the digital store display label in list rows', () => {
+    render(
+      <MemoryRouter>
+        <GamesList />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Digital · PlayStation Network')).toBeInTheDocument();
+    expect(screen.queryByText('Digital · Psn')).not.toBeInTheDocument();
+  });
+});

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import CollectionList from '../components/CollectionList';
-import { gamePlatformLabel, type Game } from '../services/types';
+import { digitalStoreLabel, gamePlatformLabel, type Game } from '../services/types';
 
 export default function GamesList() {
   return (
@@ -35,7 +35,9 @@ export default function GamesList() {
           return {
             primary: g.title,
             secondary: [platform, g.year].filter(Boolean).join(' · '),
-            tertiary: g.isDigital ? `Digital${g.digitalStore ? ` · ${g.digitalStore}` : ''}` : 'Physical',
+            tertiary: g.isDigital
+              ? `Digital${g.digitalStore ? ` · ${digitalStoreLabel(g.digitalStore) ?? g.digitalStore}` : ''}`
+              : 'Physical',
           };
         }}
       />

--- a/src/client/services/filters.test.ts
+++ b/src/client/services/filters.test.ts
@@ -44,6 +44,13 @@ describe('activeFilterCount', () => {
     expect(activeFilterCount({ tag: ['scifi', 'noir'] })).toBe(1);
   });
 
+  it('treats a year range as one filter bucket', () => {
+    expect(activeFilterCount({ yearFrom: 2000, yearTo: 2020 })).toBe(1);
+    expect(activeFilterCount({ yearFrom: 2000 })).toBe(1);
+    expect(activeFilterCount({ yearTo: 2020 })).toBe(1);
+    expect(activeFilterCount({ yearFrom: 2000, yearTo: 2020, studio: 'Warner' })).toBe(2);
+  });
+
   it('ignores empty strings', () => {
     expect(activeFilterCount({ director: '', studio: 'Warner' })).toBe(1);
   });

--- a/src/client/services/filters.ts
+++ b/src/client/services/filters.ts
@@ -188,8 +188,9 @@ export function useFiltersState<T extends MediaType>(type: T) {
 
 /** Number of active (non-default) filter fields on the given object. */
 export function activeFilterCount(filters: Record<string, unknown>): number {
-  let n = 0;
-  for (const v of Object.values(filters)) {
+  let n = filters.yearFrom != null || filters.yearTo != null ? 1 : 0;
+  for (const [key, v] of Object.entries(filters)) {
+    if (key === 'yearFrom' || key === 'yearTo') continue;
     if (v === undefined || v === null || v === '') continue;
     if (Array.isArray(v) && v.length === 0) continue;
     n++;

--- a/src/client/services/types.test.ts
+++ b/src/client/services/types.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { digitalStoreLabel, musicFormatLabel, type DigitalStore, type MusicFormat } from './types';
+
+describe('enum label helpers', () => {
+  it('maps music formats and leaves unknown values to the call site', () => {
+    expect(musicFormatLabel('Cd')).toBe('CD');
+    expect(musicFormatLabel('Cassette' as MusicFormat)).toBeUndefined();
+  });
+
+  it('maps digital stores and leaves unknown values to the call site', () => {
+    expect(digitalStoreLabel('Psn')).toBe('PlayStation Network');
+    expect(digitalStoreLabel('Itch' as DigitalStore)).toBeUndefined();
+  });
+});

--- a/src/client/services/types.ts
+++ b/src/client/services/types.ts
@@ -205,6 +205,10 @@ export function musicFormatLabel(value: MusicFormat): string | undefined {
   return MUSIC_FORMATS.find((f) => f.value === value)?.label;
 }
 
+export function digitalStoreLabel(value: DigitalStore): string | undefined {
+  return DIGITAL_STORES.find((s) => s.value === value)?.label;
+}
+
 export interface Game extends CollectionItemBase {
   id?: number;
   title: string;


### PR DESCRIPTION
Closes #93

Fixes four client-only bugs around enum label lookup and filter-consistency.

## Changes

1. **Music format label bypasses `MUSIC_FORMATS`**
   Music detail no longer hard-codes `'Cd' → 'CD'`, `'Vinyl' → 'Vinyl'`, else `'Other'`. It now derives the label from `MUSIC_FORMATS` via `musicFormatLabel`, and an unknown runtime value surfaces its raw value instead of silently collapsing to `Other`.

2. **Digital store label**
   Raw `digitalStore` enum names (e.g. `Psn`) rendered in the game detail view and the games list. Added a shared `digitalStoreLabel` helper and used it in both call sites; unknown runtime values fall back to the raw value.

3. **Dead tag filter**
   The `tag: string[]` filter was declared in the schema and rendered as chips but had no control. Added a shared `TagInput` control to the movie, music, and game filter panels.

4. **Active-filter count vs chips**
   A year range counted as two filters (`yearFrom` + `yearTo`) in `activeFilterCount` while rendering one chip. The range now counts as a single bucket, and removing the Year chip clears both bounds.

## Verification

- Local client gate: 31/31 self-tests
- npm audits: 0 vulnerabilities
- Enum parity: 8/8 tables pass
- Vitest: 133/133 passing (21 files)
- Production build: succeeded
- `git diff --check` clean; all changed files under `src/client/`

### Compiling mutation checks (each killed its named test, then restored GREEN)

| # | Mutation | Killed test | Observed |
|---|----------|-------------|----------|
| 1 | Revert `activeFilterCount` to count `yearFrom`+`yearTo` independently | `treats a year range as one filter bucket` | expected 2 to be 1 (RED) → 8 passed (GREEN) |
| 2 | Year chip removal clears only `yearFrom` | `clears both year bounds when removing the Year chip` | `vi.fn()` args mismatch (RED) → 6 passed (GREEN) |
| 3 | `digitalStoreLabel` returns raw value | `maps digital stores and leaves unknown values to the call site` | RED → 2 passed (GREEN) |
| 4 | Music detail always renders `Other` | `renders the music format label and preserves unknown runtime values` | RED → 2 passed (GREEN) |
| 5 | Disable the Tags control | `exposes a Tags field for movies/music/games` + `updates tags while preserving unrelated filters` | 4 RED → 6 passed (GREEN) |

## Attribution

- **Implemented by:** background gpt-5.6-sol
- **Independently verified by:** foreground Kyo (re-ran all five mutation checks, full client CI, file-scope check)

Changed files (10, all under `src/client/`):
`components/DetailView.tsx(.test)`, `components/FiltersPanel.tsx(.test)`, `pages/GamesList.tsx(.test)`, `services/filters.ts(.test)`, `services/types.ts(.test)`