### PR TITLE
fix(api): reject undefined enum values on the write boundary (#115)

### DIFF
--- a/src/server/Collectify.Api/Endpoints/DefinedEnumConverter.cs
+++ b/src/server/Collectify.Api/Endpoints/DefinedEnumConverter.cs
@@ -17,7 +17,14 @@ namespace Collectify.Api.Endpoints;
 /// clients send) still binds, exactly as it did before. What is newly rejected
 /// is an integer that corresponds to no declared member. Strings must name a
 /// defined member (the pre-existing behaviour of <c>JsonStringEnumConverter</c>
-/// for a bad string already threw).
+/// for a bad string already threw); note <c>Enum.TryParse</c> alone is NOT
+/// sufficient because it accepts numeric strings ("999") and comma lists, so
+/// the explicit <c>Enum.IsDefined</c> check below is load-bearing.
+///
+/// The converter assumes the enum is backed by <see cref="int"/> (it reads the
+/// token via <see cref="Utf8JsonReader.GetInt32"/>). The registered write-boundary
+/// enums are all <c>int</c>-backed; registering a <c>byte</c>/<c>long</c>-backed
+/// enum would change the failure mode to a 500 instead of a 400.
 ///
 /// <c>[Flags]</c> enums are NOT handled here — they carry bitmask combinations
 /// (e.g. <c>MovieFormats</c> is bound as an <c>int</c> and validated separately).
@@ -40,6 +47,9 @@ public sealed class DefinedEnumConverter<TEnum> : JsonConverter<TEnum>
         if (reader.TokenType == JsonTokenType.String)
         {
             var raw = reader.GetString();
+            // TryParse passes numeric-looking strings ("999") and comma lists
+            // ("Owned,OnOrder"); the IsDefined below is what stops those from
+            // binding as unnamed enum values. Do not "simplify" it away.
             if (!string.IsNullOrWhiteSpace(raw)
                 && Enum.TryParse(typeof(TEnum), raw, ignoreCase: true, out var parsed)
                 && parsed is TEnum value

--- a/src/server/Collectify.Api/Endpoints/DefinedEnumConverter.cs
+++ b/src/server/Collectify.Api/Endpoints/DefinedEnumConverter.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Collectify.Api.Endpoints;
+
+/// <summary>
+/// A <see cref="JsonConverter{T}"/> for a plain (non-<c>[Flags]</c>) enum that
+/// accepts the member whether it arrives as its string name or as its numeric
+/// value, but **rejects** a value that is not a defined member — closing the
+/// write-boundary gap where the default <c>JsonStringEnumConverter</c> (with
+/// <c>allowIntegerValues: true</c>) would accept an arbitrary integer (e.g.
+/// <c>999</c>, or a retired platform value) and persist an unnamed enum value
+/// that the startup backfill then has to paper over.
+///
+/// Semantics are deliberately conservative to preserve the existing wire
+/// contract: a *defined* integer (the form <c>PostAsJsonAsync</c> and older
+/// clients send) still binds, exactly as it did before. What is newly rejected
+/// is an integer that corresponds to no declared member. Strings must name a
+/// defined member (the pre-existing behaviour of <c>JsonStringEnumConverter</c>
+/// for a bad string already threw).
+///
+/// <c>[Flags]</c> enums are NOT handled here — they carry bitmask combinations
+/// (e.g. <c>MovieFormats</c> is bound as an <c>int</c> and validated separately).
+/// Register one instance per write-boundary enum in <c>Program.cs</c>, BEFORE
+/// the global <c>JsonStringEnumConverter</c> so it wins for its type.
+/// </summary>
+public sealed class DefinedEnumConverter<TEnum> : JsonConverter<TEnum>
+    where TEnum : struct, Enum
+{
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var n = reader.GetInt32();
+            if (Enum.IsDefined(typeof(TEnum), n))
+                return (TEnum)Enum.ToObject(typeof(TEnum), n);
+            throw new JsonException($"Unknown {typeof(TEnum).Name} value {n}.");
+        }
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var raw = reader.GetString();
+            if (!string.IsNullOrWhiteSpace(raw)
+                && Enum.TryParse(typeof(TEnum), raw, ignoreCase: true, out var parsed)
+                && parsed is TEnum value
+                && Enum.IsDefined(typeof(TEnum), value))
+            {
+                return value;
+            }
+            throw new JsonException($"Unknown {typeof(TEnum).Name} value '{raw}'.");
+        }
+
+        throw new JsonException($"{typeof(TEnum).Name} must be a string or integer.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToString());
+}

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -167,6 +167,17 @@ public static class MoviesEndpoints
             return Results.BadRequest(new { error = "Title is required." });
         if (dto.PersonalRating is { } r && (r < 1 || r > 10))
             return Results.BadRequest(new { error = "PersonalRating must be between 1 and 10." });
+        // MovieFormats is bound as an int (the client sends the flags bitmask
+        // as a number), so the enum converters never see it. Guard the unchecked
+        // (MovieFormat)dto.Formats cast at the boundary (issue #115): an
+        // arbitrary integer with bits outside the defined flag set must not
+        // persist an undefined MovieFormat. None (0) and any combination of
+        // defined bits are valid.
+        const int validMovieFormatBits =
+            (int)MovieFormat.Dvd | (int)MovieFormat.BluRay | (int)MovieFormat.UhdBluRay
+            | (int)MovieFormat.Vhs | (int)MovieFormat.Digital;
+        if ((dto.Formats & ~validMovieFormatBits) != 0)
+            return Results.BadRequest(new { error = "Formats contains an undefined MovieFormat bit." });
         if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)
             return Results.BadRequest(new { error = "AcquisitionCurrency must be a 3-letter ISO 4217 code." });
         return null;

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -11,6 +11,12 @@ namespace Collectify.Api.Endpoints;
 
 public static class MoviesEndpoints
 {
+    // Union of every defined MovieFormat flag bit. Derived from the enum so a
+    // future member is covered automatically (reviewer F1); computed once, not
+    // per write request.
+    private static readonly int ValidMovieFormatBits =
+        Enum.GetValues<MovieFormat>().Aggregate(0, (mask, f) => mask | (int)f);
+
     public record MovieDto(
         int? Id,
         string Title,
@@ -172,11 +178,8 @@ public static class MoviesEndpoints
         // (MovieFormat)dto.Formats cast at the boundary (issue #115): an
         // arbitrary integer with bits outside the defined flag set must not
         // persist an undefined MovieFormat. None (0) and any combination of
-        // defined bits are valid. Derive the mask from the enum so a future
-        // member is covered automatically (reviewer F1).
-        var validMovieFormatBits = Enum.GetValues<MovieFormat>()
-            .Aggregate(0, (mask, f) => mask | (int)f);
-        if ((dto.Formats & ~validMovieFormatBits) != 0)
+        // defined bits are valid (ValidMovieFormatBits, see above).
+        if ((dto.Formats & ~ValidMovieFormatBits) != 0)
             return Results.BadRequest(new { error = "Formats contains an undefined MovieFormat bit." });
         if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)
             return Results.BadRequest(new { error = "AcquisitionCurrency must be a 3-letter ISO 4217 code." });

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -172,10 +172,10 @@ public static class MoviesEndpoints
         // (MovieFormat)dto.Formats cast at the boundary (issue #115): an
         // arbitrary integer with bits outside the defined flag set must not
         // persist an undefined MovieFormat. None (0) and any combination of
-        // defined bits are valid.
-        const int validMovieFormatBits =
-            (int)MovieFormat.Dvd | (int)MovieFormat.BluRay | (int)MovieFormat.UhdBluRay
-            | (int)MovieFormat.Vhs | (int)MovieFormat.Digital;
+        // defined bits are valid. Derive the mask from the enum so a future
+        // member is covered automatically (reviewer F1).
+        var validMovieFormatBits = Enum.GetValues<MovieFormat>()
+            .Aggregate(0, (mask, f) => mask | (int)f);
         if ((dto.Formats & ~validMovieFormatBits) != 0)
             return Results.BadRequest(new { error = "Formats contains an undefined MovieFormat bit." });
         if (dto.AcquisitionCurrency is { Length: > 0 } c && c.Length != 3)

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -3,6 +3,7 @@ using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Collectify.Api.Endpoints;
+using Collectify.Domain.Enums;
 using Collectify.Infrastructure.Data;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup;
@@ -89,6 +90,17 @@ builder.Services.ConfigureHttpJsonOptions(opt =>
     // GamePlatform keeps its own converter so retired/write paths degrade
     // (Linux -> Pc) instead of 400-ing; all other enums use the string form.
     opt.SerializerOptions.Converters.Add(new GamePlatformJsonConverter());
+    // Non-flags, write-boundary enums reject any value that is not a defined
+    // member (issue #115): a defined integer still binds (pre-existing wire
+    // contract), but an arbitrary/retired integer (e.g. 999) now 400s instead
+    // of persisting an unnamed enum value. Registered before the global
+    // converter below so each wins for its own type.
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<CollectionStatus>());
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<Condition>());
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<WatchStatus>());
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<CompletionStatus>());
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<DigitalStore>());
+    opt.SerializerOptions.Converters.Add(new DefinedEnumConverter<MusicFormat>());
     opt.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 

--- a/src/server/tests/Collectify.Tests/Api/EnumWriteBoundaryTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/EnumWriteBoundaryTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Text;
+using Collectify.Tests.Infrastructure;
+
+namespace Collectify.Tests.Api;
+
+/// <summary>
+/// Issue #115 — the JSON write boundary must reject enum values that are not
+/// defined members, regardless of whether the client sends the member as a
+/// string ("Owned") or as an integer (its underlying value), and must reject
+/// arbitrary integers for [Flags] bitmask fields. Pre-#115 the default
+/// JsonStringEnumConverter(allowIntegerValues: true) bound any integer to an
+/// unnamed enum value and persisted it (e.g. "status": 999) — the row only
+/// "healed" at next restart.
+///
+/// Each enum is exercised once, through the endpoint that exposes it. Bodies
+/// carry only the exact token under test, on top of a minimal valid record so
+/// a 400 cannot be confused with a missing-required-field response.
+/// </summary>
+public class EnumWriteBoundaryTests
+{
+    private static string MovieBody(string fieldToken) =>
+        $@"{{""title"":""Inception"",""formats"":2,""watchStatus"":""Unwatched"",""watchCount"":0,{fieldToken}}}";
+
+    private static string MusicBody(string fieldToken) =>
+        $@"{{""title"":""Kind of Blue"",""artistName"":""Miles Davis"",{fieldToken}}}";
+
+    private static string GameBody(string fieldToken) =>
+        $@"{{""title"":""Hades"",""platform"":""Pc"",""isDigital"":true,{fieldToken}}}";
+
+    /// <summary>(resource/userName key, path, field, valid-integer body, valid-string body)</summary>
+    public static IEnumerable<object[]> EnumEndpoints => new List<object[]>
+    {
+        new object[] { "movie", "/api/movies/", "status",          MovieBody(@"""status"":0"),            MovieBody(@"""status"":""OnOrder""") },
+        new object[] { "movie", "/api/movies/", "watchStatus",     MovieBody(@"""watchStatus"":2"),      MovieBody(@"""watchStatus"":""Unwatched""") },
+        new object[] { "movie", "/api/movies/", "condition",       MovieBody(@"""condition"":0"),        MovieBody(@"""condition"":""Poor""") },
+        new object[] { "music", "/api/music/",  "format",          MusicBody(@"""format"":0"),           MusicBody(@"""format"":""Vinyl""") },
+        new object[] { "game",  "/api/games/",  "completionStatus",GameBody(@"""completionStatus"":2"), GameBody(@"""completionStatus"":""NotStarted""") },
+        new object[] { "game",  "/api/games/",  "digitalStore",    GameBody(@"""digitalStore"":0"),      GameBody(@"""digitalStore"":""Epic""") },
+    };
+
+    /// <summary>(resource/userName key, path, valid body with the field set to an undefined integer)</summary>
+    public static IEnumerable<object[]> BadIntBodies => new List<object[]>
+    {
+        new object[] { "movie", "/api/movies/", MovieBody(@"""status"":999") },
+        new object[] { "movie", "/api/movies/", MovieBody(@"""watchStatus"":999") },
+        new object[] { "movie", "/api/movies/", MovieBody(@"""condition"":999") },
+        new object[] { "music", "/api/music/",  MusicBody(@"""format"":999") },
+        new object[] { "game",  "/api/games/",  GameBody(@"""completionStatus"":999") },
+        new object[] { "game",  "/api/games/",  GameBody(@"""digitalStore"":999") },
+    };
+
+    /// <summary>(resource/userName key, path, valid body with the field set to an unknown string)</summary>
+    public static IEnumerable<object[]> BadStringBodies => new List<object[]>
+    {
+        new object[] { "movie", "/api/movies/", MovieBody(@"""status"":""NotARealMember""") },
+        new object[] { "movie", "/api/movies/", MovieBody(@"""watchStatus"":""NotARealMember""") },
+        new object[] { "movie", "/api/movies/", MovieBody(@"""condition"":""NotARealMember""") },
+        new object[] { "music", "/api/music/",  MusicBody(@"""format"":""NotARealMember""") },
+        new object[] { "game",  "/api/games/",  GameBody(@"""completionStatus"":""NotARealMember""") },
+        new object[] { "game",  "/api/games/",  GameBody(@"""digitalStore"":""NotARealMember""") },
+    };
+
+    // A defined-integer send must continue to bind (the pre-existing contract),
+    // and a string-name send must bind (what the real client sends).
+    [Theory]
+    [MemberData(nameof(EnumEndpoints))]
+    public async Task DefinedEnum_IntegerAndString_BothBind(string resource, string path, string field, string validIntBody, string validStringBody)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync($"u_{resource}{field}_def");
+
+        var asInt = await user.Client.PostAsync(path, Json(validIntBody));
+        Assert.Equal(HttpStatusCode.Created, asInt.StatusCode);
+
+        var asString = await user.Client.PostAsync(path, Json(validStringBody));
+        Assert.Equal(HttpStatusCode.Created, asString.StatusCode);
+    }
+
+    // The core #115 regression: an arbitrary integer must not persist.
+    [Theory]
+    [MemberData(nameof(BadIntBodies))]
+    public async Task UndefinedInteger_ReturnsBadRequest(string resource, string path, string bodyWithBadInt)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync($"u_{resource}{bodyWithBadInt.Length}_undef");
+
+        var response = await user.Client.PostAsync(path, Json(bodyWithBadInt));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // Unknown strings already 400 pre-#115 (the default converter throws);
+    // pinned here so the future can't silently regress to persisting them.
+    [Theory]
+    [MemberData(nameof(BadStringBodies))]
+    public async Task UnknownString_ReturnsBadRequest(string resource, string path, string bodyWithBadString)
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync($"u_{resource}{bodyWithBadString.Length}_str");
+
+        var response = await user.Client.PostAsync(path, Json(bodyWithBadString));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MovieFormats_UndefinedBits_ReturnsBadRequest()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync("u_fmt_undef");
+
+        // 999 = bits outside Dvd|BluRay|UhdBluRay|Vhs|Digital.
+        var response = await user.Client.PostAsync("/api/movies/",
+            Json(@"{""title"":""Inception"",""formats"":999,""watchStatus"":""Unwatched"",""watchCount"":0}"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MovieFormats_ValidCombination_ReturnsCreated()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync("u_fmt_ok");
+
+        // Dvd|BluRay = 3 is a valid flags combination.
+        var response = await user.Client.PostAsync("/api/movies/",
+            Json(@"{""title"":""Inception"",""formats"":3,""watchStatus"":""Unwatched"",""watchCount"":0}"));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MovieFormats_None_ReturnsCreated()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var user = await factory.CreateAuthenticatedUserAsync("u_fmt_none");
+
+        var response = await user.Client.PostAsync("/api/movies/",
+            Json(@"{""title"":""Inception"",""formats"":0,""watchStatus"":""Unwatched"",""watchCount"":0}"));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
+}

--- a/src/server/tests/Collectify.Tests/Api/EnumWriteBoundaryTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/EnumWriteBoundaryTests.cs
@@ -20,7 +20,7 @@ namespace Collectify.Tests.Api;
 public class EnumWriteBoundaryTests
 {
     private static string MovieBody(string fieldToken) =>
-        $@"{{""title"":""Inception"",""formats"":2,""watchStatus"":""Unwatched"",""watchCount"":0,{fieldToken}}}";
+        $@"{{""title"":""Inception"",""formats"":2,""watchCount"":0,{fieldToken}}}";
 
     private static string MusicBody(string fieldToken) =>
         $@"{{""title"":""Kind of Blue"",""artistName"":""Miles Davis"",{fieldToken}}}";
@@ -54,6 +54,10 @@ public class EnumWriteBoundaryTests
     public static IEnumerable<object[]> BadStringBodies => new List<object[]>
     {
         new object[] { "movie", "/api/movies/", MovieBody(@"""status"":""NotARealMember""") },
+        // A numeric-looking string ("999") is NOT a defined member name; the
+        // string branch's Enum.IsDefined must reject it, not TryParse-pass it
+        // into an unnamed enum value.
+        new object[] { "movie", "/api/movies/", MovieBody(@"""status"":""999""") },
         new object[] { "movie", "/api/movies/", MovieBody(@"""watchStatus"":""NotARealMember""") },
         new object[] { "movie", "/api/movies/", MovieBody(@"""condition"":""NotARealMember""") },
         new object[] { "music", "/api/music/",  MusicBody(@"""format"":""NotARealMember""") },


### PR DESCRIPTION
Closes #115

## Summary

The JSON write boundary accepted an **arbitrary integer** for any non-`[Flags]` enum
field on POST/PUT. `JsonStringEnumConverter` defaults to `allowIntegerValues: true`,
so a body like `"status": 999` (or a retired value such as `60`) bound to an unnamed
enum value and **persisted** it — the row only "healed" at the next app restart.
Unknown *strings* already 400'd; only unknown *integers* slipped through. `GamePlatform`
was already closed by its own converter (#102/#103); this closes the rest.

## What changed

- **New `DefinedEnumConverter<TEnum>`** — applies "defined member of either form":
  - number → `Enum.IsDefined` else throws (→ 400)
  - string → `Enum.TryParse(ignoreCase)` + `IsDefined` else throws (→ 400)
  - write → member name
- **`Program.cs`** — registers six instances (CollectionStatus, Condition, WatchStatus,
  CompletionStatus, DigitalStore, MusicFormat) **before** the global converter so each
  wins for its type. `GamePlatform` unchanged.
- **`MoviesEndpoints.Validate`** — `MovieFormats` is bound as an `int` (the client sends
  the flags bitmask as a number) and cast unchecked, so guard against bits outside
  `Dvd|BluRay|UhdBluRay|Vhs|Digital` → 400.
- **`EnumWriteBoundaryTests`** — 21 tests: for each of the six enums, a **defined**
  integer and a **defined** string both bind (201); an **undefined** integer → 400;
  an **unknown** string → 400; plus MovieFormats `None`(0)/valid-combination(3)/undefined-bit(999).

## Deliberately out of scope (the one judgment call)

The issue's wording was "string-only enums … reject unknown integer values." I read the
acceptance criterion as *reject unknown integers*, not *reject all integers*: a **defined**
integer still binds (preserving the pre-existing wire contract and the 80+ call-sites that
`PostAsJsonAsync` numeric enums), while an undefined/retired integer now 400s — security
equivalent, no breaking contract change. `MovieFormats` keeps its intentional integer
bitmask wire form. `GamePlatform` (retired-value remap) is intentionally untouched.
Reviewers: veto here if you disagree with the "defined integers still bind" choice.

## Verification (driver-run)

- Server: `dotnet test Collectify.slnx` → **564/564 green** (0 failures/skips).
- Api build: **0 Warning(s) 0 Error(s)**.
- New `EnumWriteBoundaryTests` red→green (7 failed pre-fix for the right reason, then 21/21).
- **Mutations** (re-run by driver, all compiling): removing the number-path `IsDefined` → all
  6 `UndefinedInteger_ReturnsBadRequest` red; inverting the MovieFormats guard →
  `MovieFormats_UndefinedBits_ReturnsBadRequest` red. Restored → green.
- **Live curl** against a booted instance (cookie jar in `/tmp/cookies.txt`):
  - `formats=0` → 201, `formats=3` → 201, `status="Owned"` → 201, `platform=60` → 201 (remap)
  - `formats=999` → 400, `status=999` → 400, `completionStatus=999` → 400,
    `digitalStore=999` → 400, `platform=999` → 400
- Client (unaffected by this change): `npm test` 134/134, `tsc -b && vite build` clean.

## Note on 400 body shape

The converter-path 400s surface the framework's `BadHttpRequestException`/
`JsonException` text (e.g. `Unknown CollectionStatus value 999.`), while the
`Validate()`-path `formats` 400 is the clean `{"error": ...}`. This matches the
pre-existing `GamePlatformJsonConverter` behavior and the repo's current
error-handling pattern; flagging for reviewer awareness (not introduced here).

## Test plan checklist
- [x] Regressions (defined int + string both bind) — no contract break
- [x] Undefined integer → 400 per enum
- [x] Unknown string → 400 (pinned; already behaved this way)
- [x] MovieFormats flags: None, valid combo, undefined bit
- [x] Full server suite green, client suite green, live curl smoke
