### PR TITLE
test: parameterize collection endpoint tests across media types (#96)

### DIFF
--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -1,0 +1,427 @@
+using System.Net;
+using System.Net.Http.Json;
+using Collectify.Tests.Infrastructure;
+using Collectify.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+
+namespace Collectify.Tests.Api;
+
+/// <summary>
+/// Shared skeleton for the three collection endpoint test classes (movies,
+/// music, games). Carries every scenario whose behavior is identical across
+/// media types; each concrete subclass supplies the per-type shape via the
+/// abstract members below and keeps only its own type-specific tests (e.g.
+/// movie <c>Formats</c> bitmask round-trips, game platform filters).
+///
+/// Concrete subclasses use <see cref="CollectifyApiFactory"/> as a
+/// class-level <c>IClassFixture</c>: the host (and its in-memory SQLite
+/// connection) is shared across every test in the class. Every test creates
+/// its own uniquely-named user(s) so ownership-scoping assertions still hold
+/// against the shared database, and xUnit runs tests within one class
+/// sequentially by default, so the shared DB is never mutated concurrently.
+/// </summary>
+public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
+    where TEntity : class
+    where TResponse : ICollectionResponse
+{
+    protected readonly CollectifyApiFactory Factory;
+
+    protected CollectionEndpointsTestsBase(CollectifyApiFactory factory) => Factory = factory;
+
+    protected abstract string RoutePrefix { get; }
+
+    protected abstract object Sample(
+        string? title = null, string[]? tags = null, string? currency = null, int? rating = null);
+
+    protected abstract object MinimalWithImage(string? imagePath);
+
+    protected abstract TEntity NewMinimalEntity(string ownerId, string title);
+
+    protected abstract int IdOf(TEntity entity);
+    protected abstract string OwnerIdOf(TEntity entity);
+    protected abstract string TitleOf(TEntity entity);
+    protected abstract DateTime UpdatedAtOf(TEntity entity);
+
+    private static string UniqueUser(string prefix) => $"{prefix}-{Guid.NewGuid():N}";
+
+    protected Task<TestExtensions.TestUser> NewAliceAsync() =>
+        Factory.CreateAuthenticatedUserAsync(UniqueUser("alice"));
+
+    protected Task<TestExtensions.TestUser> NewBobAsync() =>
+        Factory.CreateAuthenticatedUserAsync(UniqueUser("bob"));
+
+    private async Task<TEntity> FindByIdAsync(int id)
+    {
+        var all = await Factory.WithDbAsync(db => db.Set<TEntity>().AsNoTracking().ToListAsync());
+        return all.First(e => IdOf(e) == id);
+    }
+
+    private async Task<bool> ExistsAsync(int id)
+    {
+        var all = await Factory.WithDbAsync(db => db.Set<TEntity>().AsNoTracking().ToListAsync());
+        return all.Any(e => IdOf(e) == id);
+    }
+
+    // -------- Auth --------
+
+    [Fact]
+    public async Task List_Unauthenticated_ReturnsUnauthorized()
+    {
+        var client = Factory.CreateClient();
+
+        var response = await client.GetAsync(RoutePrefix);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_Unauthenticated_ReturnsUnauthorized()
+    {
+        var client = Factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(RoutePrefix, Sample());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // -------- CRUD happy path --------
+
+    [Fact]
+    public async Task Create_AsAuthenticatedUser_Returns201WithBody()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(title: "Created Title"));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.ReadJsonAsync<TResponse>();
+        Assert.NotNull(body);
+        Assert.True(body!.Id > 0);
+        Assert.Equal("Created Title", body.Title);
+    }
+
+    [Fact]
+    public async Task Create_PersistsOwnerIdFromAuthenticatedUser()
+    {
+        var alice = await NewAliceAsync();
+
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<TResponse>();
+
+        var stored = await FindByIdAsync(created!.Id);
+        Assert.Equal(alice.Id, OwnerIdOf(stored));
+    }
+
+    [Fact]
+    public async Task Get_OwnRow_ReturnsRow()
+    {
+        var alice = await NewAliceAsync();
+        var seeded = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var body = await alice.Client.GetJsonAsync<TResponse>($"{RoutePrefix}{IdOf(seeded)}");
+
+        Assert.Equal(IdOf(seeded), body!.Id);
+        Assert.Equal("Heat", body.Title);
+    }
+
+    [Fact]
+    public async Task Get_NonExistentId_Returns404()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.GetAsync($"{RoutePrefix}999999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_OwnRow_PersistsChangesAndBumpsUpdatedAt()
+    {
+        var alice = await NewAliceAsync();
+        var seeded = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Old Title"));
+        var originalUpdatedAt = UpdatedAtOf(seeded);
+
+        var response = await alice.Client.PutAsJsonAsync($"{RoutePrefix}{IdOf(seeded)}",
+            Sample(title: "New Title"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.ReadJsonAsync<TResponse>();
+        Assert.Equal("New Title", body!.Title);
+        Assert.True(body.UpdatedAt > originalUpdatedAt);
+    }
+
+    [Fact]
+    public async Task Delete_OwnRow_Returns204AndRemovesRow()
+    {
+        var alice = await NewAliceAsync();
+        var seeded = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var response = await alice.Client.DeleteAsync($"{RoutePrefix}{IdOf(seeded)}");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.False(await ExistsAsync(IdOf(seeded)));
+    }
+
+    // -------- Ownership boundary --------
+
+    [Fact]
+    public async Task Get_OtherUsersRow_Returns404()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+        var aliceRow = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var response = await bob.Client.GetAsync($"{RoutePrefix}{IdOf(aliceRow)}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_OtherUsersRow_Returns404()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+        var aliceRow = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var response = await bob.Client.PutAsJsonAsync($"{RoutePrefix}{IdOf(aliceRow)}",
+            Sample(title: "Hijacked"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var stored = await FindByIdAsync(IdOf(aliceRow));
+        Assert.Equal("Heat", TitleOf(stored));
+    }
+
+    [Fact]
+    public async Task Delete_OtherUsersRow_Returns404AndKeepsRow()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+        var aliceRow = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var response = await bob.Client.DeleteAsync($"{RoutePrefix}{IdOf(aliceRow)}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.True(await ExistsAsync(IdOf(aliceRow)));
+    }
+
+    [Fact]
+    public async Task List_OnlyReturnsRowsOwnedByCurrentUser()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+        await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Alice-Row"));
+        await Factory.SeedAsync(NewMinimalEntity(bob.Id, "Bob-Row"));
+
+        var aliceList = await alice.Client.GetJsonAsync<TResponse[]>(RoutePrefix);
+
+        Assert.Single(aliceList!);
+        Assert.Equal("Alice-Row", aliceList![0].Title);
+    }
+
+    // -------- Validation --------
+
+    [Fact]
+    public async Task Create_WithEmptyTitle_ReturnsBadRequest()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(title: ""));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithWhitespaceTitle_ReturnsBadRequest()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(title: "   "));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithEmptyTitle_ReturnsBadRequest()
+    {
+        var alice = await NewAliceAsync();
+        var seeded = await Factory.SeedAsync(NewMinimalEntity(alice.Id, "Heat"));
+
+        var response = await alice.Client.PutAsJsonAsync($"{RoutePrefix}{IdOf(seeded)}",
+            Sample(title: ""));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    [InlineData(-1)]
+    public async Task Create_WithRatingOutsideRange_ReturnsBadRequest(int rating)
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(rating: rating));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    public async Task Create_WithRatingAtBoundary_Returns201(int rating)
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(rating: rating));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_WithCurrencyOfWrongLength_ReturnsBadRequest()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(currency: "EU"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_NormalizesCurrencyToUppercase()
+    {
+        var alice = await NewAliceAsync();
+
+        var body = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(currency: "eur")))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Equal("EUR", body!.AcquisitionCurrency);
+    }
+
+    // -------- Cover image caching --------
+
+    [Fact]
+    public async Task Create_WithRemoteImageUrl_StoresLocalCoverPath()
+    {
+        var alice = await NewAliceAsync();
+
+        var dto = MinimalWithImage("https://image.tmdb.org/t/p/w342/poster.jpg");
+
+        var body = await (await alice.Client.PostAsJsonAsync(RoutePrefix, dto))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.NotNull(body);
+        Assert.NotNull(body!.ImagePath);
+        Assert.StartsWith("/covers/", body.ImagePath);
+        Assert.DoesNotContain("image.tmdb.org", body.ImagePath);
+    }
+
+    [Fact]
+    public async Task Create_WithLocalImagePath_PassesThroughUntouched()
+    {
+        var alice = await NewAliceAsync();
+
+        var dto = MinimalWithImage("/covers/already-cached.jpg");
+
+        var body = await (await alice.Client.PostAsJsonAsync(RoutePrefix, dto))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Equal("/covers/already-cached.jpg", body!.ImagePath);
+    }
+
+    // -------- Tags --------
+
+    [Fact]
+    public async Task Create_WithTags_CreatesTagsAndAttachesThem()
+    {
+        var alice = await NewAliceAsync();
+
+        var body = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            Sample(tags: ["Sci-Fi", "Heist", "Nolan"])))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Equal(new[] { "heist", "nolan", "sci-fi" }, body!.Tags);
+
+        var tagCount = await Factory.WithDbAsync(db =>
+            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
+        Assert.Equal(3, tagCount);
+    }
+
+    [Fact]
+    public async Task Create_WithDuplicateTagsInArray_DeduplicatesIgnoreCase()
+    {
+        var alice = await NewAliceAsync();
+
+        var body = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            Sample(tags: ["Sci-Fi", "sci-fi", "  Sci-Fi  ", "Heist"])))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Equal(new[] { "heist", "sci-fi" }, body!.Tags);
+    }
+
+    [Fact]
+    public async Task Update_ReplacesTagSetRatherThanMerging()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            Sample(tags: ["Sci-Fi", "Heist"])))
+            .ReadJsonAsync<TResponse>();
+
+        var updated = await (await alice.Client.PutAsJsonAsync($"{RoutePrefix}{created!.Id}",
+            Sample(tags: ["Drama"])))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Equal(new[] { "drama" }, updated!.Tags);
+    }
+
+    [Fact]
+    public async Task Update_WithEmptyTagArray_RemovesAllTags()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            Sample(tags: ["Sci-Fi", "Heist"])))
+            .ReadJsonAsync<TResponse>();
+
+        var updated = await (await alice.Client.PutAsJsonAsync($"{RoutePrefix}{created!.Id}",
+            Sample(tags: Array.Empty<string>())))
+            .ReadJsonAsync<TResponse>();
+
+        Assert.Empty(updated!.Tags);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesJoinRowsButKeepsTagEntity()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            Sample(tags: ["Sci-Fi"])))
+            .ReadJsonAsync<TResponse>();
+
+        var delete = await alice.Client.DeleteAsync($"{RoutePrefix}{created!.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+
+        var tagsLeft = await Factory.WithDbAsync(db =>
+            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
+        Assert.Equal(1, tagsLeft);
+    }
+
+    [Fact]
+    public async Task Tags_AreOwnerScoped_BetweenUsers()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+
+        await alice.Client.PostAsJsonAsync(RoutePrefix, Sample(tags: ["sci-fi"]));
+        await bob.Client.PostAsJsonAsync(RoutePrefix, Sample(title: "Bob's", tags: ["sci-fi"]));
+
+        // Owner-scoped rather than a global count: the class-level shared
+        // host fixture means the in-memory DB accumulates rows from every
+        // test in this class, so only per-owner counts stay meaningful.
+        var aliceTags = await Factory.WithDbAsync(db =>
+            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
+        var bobTags = await Factory.WithDbAsync(db =>
+            db.Tags.CountAsync(t => t.OwnerId == bob.Id));
+        Assert.Equal(1, aliceTags);
+        Assert.Equal(1, bobTags);
+    }
+}

--- a/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -6,111 +5,46 @@ using System.Text.Json.Serialization;
 using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Tests.Infrastructure;
+using Collectify.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
 
 namespace Collectify.Tests.Api;
 
-public class GamesEndpointsTests
+public class GamesEndpointsTests : CollectionEndpointsTestsBase<Game, GameResponse>, IClassFixture<CollectifyApiFactory>
 {
-    private record GameResponse(
-        int Id, string Title, GamePlatform Platform, string? PlatformLegacy, int? Year,
-        string? Publisher, string? Developer, bool IsDigital, DigitalStore? DigitalStore,
-        string? Barcode, string? IgdbId, string? ImagePath, string? Description, string? Notes,
-        int? PersonalRating, CollectionStatus Status, Condition? Condition,
-        DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
-        CompletionStatus CompletionStatus, int? HoursPlayed, DateOnly? LastPlayedOn,
-        string[] Tags,
-        DateTime AddedAt, DateTime UpdatedAt);
-
-    private static object Sample(
-        string title = "Hades",
-        GamePlatform platform = GamePlatform.Pc,
-        bool isDigital = true,
-        DigitalStore? store = DigitalStore.Steam,
-        int? rating = null,
-        CompletionStatus completion = CompletionStatus.NotStarted,
-        int? hours = null,
-        string[]? tags = null) => new
-        {
-            Title = title,
-            Platform = platform,
-            Year = (int?)2020,
-            Publisher = "Supergiant Games",
-            Developer = "Supergiant Games",
-            IsDigital = isDigital,
-            DigitalStore = store,
-            Barcode = (string?)null,
-            IgdbId = (string?)null,
-            ImagePath = (string?)null,
-            Description = "Roguelike from Supergiant.",
-            Notes = (string?)null,
-            PersonalRating = rating,
-            Status = CollectionStatus.Owned,
-            Condition = (Condition?)null,
-            AcquiredOn = (DateOnly?)new DateOnly(2024, 2, 10),
-            AcquisitionPrice = (decimal?)24.99m,
-            AcquisitionCurrency = "USD",
-            AcquisitionSource = "Steam Sale",
-            CompletionStatus = completion,
-            HoursPlayed = hours,
-            LastPlayedOn = (DateOnly?)new DateOnly(2024, 9, 1),
-            Tags = tags,
-        };
-
-    // -------- Auth --------
-
-    [Fact]
-    public async Task List_Unauthenticated_ReturnsUnauthorized()
+    public GamesEndpointsTests(CollectifyApiFactory factory) : base(factory)
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
-
-        var response = await client.GetAsync("/api/games/");
-
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
-    [Fact]
-    public async Task Create_Unauthenticated_ReturnsUnauthorized()
+    protected override string RoutePrefix => "/api/games/";
+
+    protected override object Sample(string? title = null, string[]? tags = null, string? currency = null, int? rating = null) =>
+        GameTestSupport.Sample(title: title ?? "Hades", tags: tags, currency: currency ?? "USD", rating: rating);
+
+    protected override object MinimalWithImage(string? imagePath) => new
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
+        Title = "Hades",
+        Platform = GamePlatform.Pc,
+        IsDigital = true,
+        Status = CollectionStatus.Owned,
+        CompletionStatus = CompletionStatus.NotStarted,
+        ImagePath = imagePath,
+        Tags = (string[]?)null,
+    };
 
-        var response = await client.PostAsJsonAsync("/api/games/", Sample());
-
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-    }
-
-    // -------- CRUD happy path --------
-
-    [Fact]
-    public async Task Create_AsAuthenticatedUser_Returns201WithBody()
+    protected override Game NewMinimalEntity(string ownerId, string title) => new()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        OwnerId = ownerId,
+        Title = title,
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
 
-        var response = await alice.Client.PostAsJsonAsync("/api/games/", Sample());
+    protected override int IdOf(Game entity) => entity.Id;
+    protected override string OwnerIdOf(Game entity) => entity.OwnerId;
+    protected override string TitleOf(Game entity) => entity.Title;
+    protected override DateTime UpdatedAtOf(Game entity) => entity.UpdatedAt;
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        var body = await response.ReadJsonAsync<GameResponse>();
-        Assert.True(body!.Id > 0);
-        Assert.Equal("Hades", body.Title);
-        Assert.Equal(DigitalStore.Steam, body.DigitalStore);
-    }
-
-    [Fact]
-    public async Task Create_PersistsOwnerIdFromAuthenticatedUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var created = await (await alice.Client.PostAsJsonAsync("/api/games/", Sample()))
-            .ReadJsonAsync<GameResponse>();
-
-        var stored = await factory.WithDbAsync(db =>
-            db.Games.AsNoTracking().FirstAsync(g => g.Id == created!.Id));
-        Assert.Equal(alice.Id, stored.OwnerId);
-    }
+    // -------- Legacy platform migration --------
 
     [Fact]
     public async Task Create_WithLegacyLinuxPlatform_SavesAsPc()
@@ -118,10 +52,9 @@ public class GamesEndpointsTests
         // A stale / pre-upgrade client posting "platform": "Linux" (the member
         // retired in #102) must land on Pc via GamePlatformJsonConverter, not
         // 400 on the now-removed enum name.
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
-        var baseDto = JsonSerializer.Serialize(Sample(), new JsonSerializerOptions
+        var baseDto = JsonSerializer.Serialize(GameTestSupport.Sample(), new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { new JsonStringEnumConverter() }, // serializes Platform as its name
@@ -134,158 +67,9 @@ public class GamesEndpointsTests
             "/api/games/",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
         var body = await response.ReadJsonAsync<GameResponse>();
         Assert.Equal(GamePlatform.Pc, body!.Platform);
-    }
-
-    [Fact]
-    public async Task Get_OwnRow_ReturnsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var game = await factory.SeedAsync(new Game
-        {
-            OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc, IsDigital = true, DigitalStore = DigitalStore.Steam,
-        });
-
-        var body = await alice.Client.GetJsonAsync<GameResponse>($"/api/games/{game.Id}");
-
-        Assert.Equal("Hades", body!.Title);
-        Assert.Equal(DigitalStore.Steam, body.DigitalStore);
-    }
-
-    [Fact]
-    public async Task Get_NonExistentId_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.GetAsync("/api/games/999999");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OwnRow_PersistsChangesAndBumpsUpdatedAt()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new Game
-        {
-            OwnerId = alice.Id, Title = "Old", UpdatedAt = DateTime.UtcNow.AddDays(-1),
-        });
-        var originalUpdatedAt = seeded.UpdatedAt;
-
-        var response = await alice.Client.PutAsJsonAsync($"/api/games/{seeded.Id}",
-            Sample(title: "Hollow Knight"));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await response.ReadJsonAsync<GameResponse>();
-        Assert.Equal("Hollow Knight", body!.Title);
-        Assert.True(body.UpdatedAt > originalUpdatedAt);
-    }
-
-    [Fact]
-    public async Task Delete_OwnRow_Returns204AndRemovesRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades" });
-
-        var response = await alice.Client.DeleteAsync($"/api/games/{seeded.Id}");
-
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.Games.AsNoTracking().AnyAsync(g => g.Id == seeded.Id));
-        Assert.False(stillThere);
-    }
-
-    // -------- Ownership boundary --------
-
-    [Fact]
-    public async Task Get_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var game = await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades" });
-
-        var response = await bob.Client.GetAsync($"/api/games/{game.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var game = await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades" });
-
-        var response = await bob.Client.PutAsJsonAsync($"/api/games/{game.Id}",
-            Sample(title: "Hijacked"));
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        var stored = await factory.WithDbAsync(db =>
-            db.Games.AsNoTracking().FirstAsync(g => g.Id == game.Id));
-        Assert.Equal("Hades", stored.Title);
-    }
-
-    [Fact]
-    public async Task Delete_OtherUsersRow_Returns404AndKeepsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var game = await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades" });
-
-        var response = await bob.Client.DeleteAsync($"/api/games/{game.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.Games.AsNoTracking().AnyAsync(g => g.Id == game.Id));
-        Assert.True(stillThere);
-    }
-
-    [Fact]
-    public async Task List_OnlyReturnsRowsOwnedByCurrentUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "AliceGame" });
-        await factory.SeedAsync(new Game { OwnerId = bob.Id, Title = "BobGame" });
-
-        var aliceList = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/");
-
-        Assert.Single(aliceList!);
-        Assert.Equal("AliceGame", aliceList![0].Title);
-    }
-
-    // -------- Validation --------
-
-    [Fact]
-    public async Task Create_WithEmptyTitle_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/games/", Sample(title: ""));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Create_WithRatingOutsideRange_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/games/", Sample(rating: 0));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     // -------- List filters --------
@@ -293,10 +77,9 @@ public class GamesEndpointsTests
     [Fact]
     public async Task List_FiltersByPlatform_ReturnsExactMatch()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
 
         var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=Switch");
 
@@ -309,10 +92,9 @@ public class GamesEndpointsTests
     {
         // A stale "?platform=Linux" URL (e.g. bookmarked before #102 folded
         // Linux into Pc) must degrade to Pc rather than 400 the whole list.
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
 
         var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=Linux");
 
@@ -325,10 +107,9 @@ public class GamesEndpointsTests
     {
         // "Other" is a real platform value (0) exposed in the client; the
         // filter must return only Other rows, not every platform.
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Oddball", Platform = GamePlatform.Other });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Oddball", Platform = GamePlatform.Other });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
 
         var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=Other");
 
@@ -344,10 +125,9 @@ public class GamesEndpointsTests
         // to nothing; it resolves to no filter and returns all rows. Proof no
         // filter was applied: both rows come back, and neither is on the
         // numeric value being passed.
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades", Platform = GamePlatform.Pc });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "BotW", Platform = GamePlatform.Switch });
 
         var byRetired = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=3");
         Assert.Equal(2, byRetired!.Length); // not filtered to the retired value
@@ -359,10 +139,9 @@ public class GamesEndpointsTests
     [Fact]
     public async Task List_FiltersByDigital_ReturnsMatchingRows()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Digital", IsDigital = true });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Physical", IsDigital = false });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Digital", IsDigital = true });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Physical", IsDigital = false });
 
         var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?digital=true");
 
@@ -373,11 +152,10 @@ public class GamesEndpointsTests
     [Fact]
     public async Task List_FiltersByYearRangePublisherDeveloperCompletionAndRating()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades",       Platform = GamePlatform.Pc,     Year = 2020, Publisher = "Supergiant", Developer = "Supergiant", CompletionStatus = CompletionStatus.Beaten, PersonalRating = 9 });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Witcher 3",   Platform = GamePlatform.Pc,     Year = 2015, Publisher = "CD Projekt", Developer = "CD Projekt", CompletionStatus = CompletionStatus.Playing, PersonalRating = 8 });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Tetris",      Platform = GamePlatform.GameBoy, Year = 1989, Publisher = "Nintendo",   Developer = "Bullet-Proof Software", CompletionStatus = CompletionStatus.NotStarted });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Hades",       Platform = GamePlatform.Pc,     Year = 2020, Publisher = "Supergiant", Developer = "Supergiant", CompletionStatus = CompletionStatus.Beaten, PersonalRating = 9 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Witcher 3",   Platform = GamePlatform.Pc,     Year = 2015, Publisher = "CD Projekt", Developer = "CD Projekt", CompletionStatus = CompletionStatus.Playing, PersonalRating = 8 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Tetris",      Platform = GamePlatform.GameBoy, Year = 1989, Publisher = "Nintendo",   Developer = "Bullet-Proof Software", CompletionStatus = CompletionStatus.NotStarted });
 
         var byYear = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?yearFrom=2010");
         Assert.Equal(2, byYear!.Length);
@@ -402,10 +180,9 @@ public class GamesEndpointsTests
         // Single-value enum filter today (one platform per request).
         // Documented as a future enhancement if multi-platform OR
         // becomes a real need.
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Ps5 game",  Platform = GamePlatform.Ps5 });
-        await factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Switch game", Platform = GamePlatform.Switch });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Ps5 game",  Platform = GamePlatform.Ps5 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "Switch game", Platform = GamePlatform.Switch });
 
         var hits = await alice.Client.GetJsonAsync<GameResponse[]>("/api/games/?platform=Ps5");
         Assert.Single(hits!);
@@ -416,14 +193,14 @@ public class GamesEndpointsTests
     [Fact]
     public async Task Create_RoundTripsAllNewScalarFields()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
         var response = await alice.Client.PostAsJsonAsync("/api/games/",
-            Sample(rating: 8, completion: CompletionStatus.Beaten, hours: 60));
+            GameTestSupport.Sample(rating: 8, completion: CompletionStatus.Beaten, hours: 60));
 
         var body = await response.ReadJsonAsync<GameResponse>();
-        Assert.Equal("Roguelike from Supergiant.", body!.Description);
+        Assert.Equal(DigitalStore.Steam, body!.DigitalStore);
+        Assert.Equal("Roguelike from Supergiant.", body.Description);
         Assert.Equal(8, body.PersonalRating);
         Assert.Equal(CollectionStatus.Owned, body.Status);
         Assert.Equal(new DateOnly(2024, 2, 10), body.AcquiredOn);
@@ -432,19 +209,5 @@ public class GamesEndpointsTests
         Assert.Equal(CompletionStatus.Beaten, body.CompletionStatus);
         Assert.Equal(60, body.HoursPlayed);
         Assert.Equal(new DateOnly(2024, 9, 1), body.LastPlayedOn);
-    }
-
-    // -------- Tags --------
-
-    [Fact]
-    public async Task Create_WithTags_CreatesTagsAndAttachesThem()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/games/", Sample(tags: ["Roguelike", "Indie"])))
-            .ReadJsonAsync<GameResponse>();
-
-        Assert.Equal(new[] { "indie", "roguelike" }, body!.Tags);
     }
 }

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -1,371 +1,137 @@
-using System.Net;
 using System.Net.Http.Json;
 using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Tests.Infrastructure;
+using Collectify.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
 
 namespace Collectify.Tests.Api;
 
-public class MoviesEndpointsTests
+public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieResponse>, IClassFixture<CollectifyApiFactory>
 {
-    private record MovieResponse(
-        int Id, string Title, string? OriginalTitle, int? Year,
-        int Formats, string? Director, int? RuntimeMinutes,
-        string? Studio, string? Genres, string? Barcode,
-        string? TmdbId, string? ImdbId, string? ImagePath, string? Description, string? Notes,
-        int? PersonalRating, CollectionStatus Status, Condition? Condition,
-        DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
-        WatchStatus WatchStatus, DateOnly? LastWatchedOn, int WatchCount,
-        string[] Tags,
-        DateTime AddedAt, DateTime UpdatedAt);
+    public MoviesEndpointsTests(CollectifyApiFactory factory) : base(factory)
+    {
+    }
 
-    private static object Sample(
-        string title = "Inception",
-        int? year = 2010,
-        MovieFormat formats = MovieFormat.BluRay,
-        int? rating = null,
-        CollectionStatus status = CollectionStatus.Owned,
-        Condition? condition = null,
-        string? currency = null,
-        WatchStatus watchStatus = WatchStatus.Unwatched,
-        int watchCount = 0,
-        string[]? tags = null) => new
-        {
-            Title = title,
-            OriginalTitle = (string?)null,
-            Year = year,
-            Formats = (int)formats,
-            Director = "Christopher Nolan",
-            RuntimeMinutes = 148,
-            Studio = "Warner Bros.",
-            Genres = "Sci-Fi, Thriller",
-            Barcode = (string?)null,
-            TmdbId = (string?)null,
-            ImdbId = (string?)null,
-            ImagePath = (string?)null,
-            Description = "A heist on the subconscious.",
-            Notes = (string?)null,
-            PersonalRating = rating,
-            Status = status,
-            Condition = condition,
-            AcquiredOn = (DateOnly?)new DateOnly(2024, 1, 15),
-            AcquisitionPrice = (decimal?)19.99m,
-            AcquisitionCurrency = currency,
-            AcquisitionSource = "Amazon",
-            WatchStatus = watchStatus,
-            LastWatchedOn = (DateOnly?)new DateOnly(2024, 6, 1),
-            WatchCount = watchCount,
-            Tags = tags,
-        };
+    protected override string RoutePrefix => "/api/movies/";
 
-    // -------- Auth --------
+    protected override object Sample(string? title = null, string[]? tags = null, string? currency = null, int? rating = null) =>
+        MovieTestSupport.Sample(title: title ?? "Inception", tags: tags, currency: currency, rating: rating);
+
+    protected override object MinimalWithImage(string? imagePath) => new
+    {
+        Title = "Inception",
+        Formats = (int)MovieFormat.BluRay,
+        Status = CollectionStatus.Owned,
+        WatchStatus = WatchStatus.Unwatched,
+        WatchCount = 0,
+        ImagePath = imagePath,
+        Tags = (string[]?)null,
+    };
+
+    protected override Movie NewMinimalEntity(string ownerId, string title) => new()
+    {
+        OwnerId = ownerId,
+        Title = title,
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
+
+    protected override int IdOf(Movie entity) => entity.Id;
+    protected override string OwnerIdOf(Movie entity) => entity.OwnerId;
+    protected override string TitleOf(Movie entity) => entity.Title;
+    protected override DateTime UpdatedAtOf(Movie entity) => entity.UpdatedAt;
+
+    // -------- Formats (flags enum as integer) --------
 
     [Fact]
-    public async Task List_Unauthenticated_ReturnsUnauthorized()
+    public async Task Create_WithFormatsAsInteger_RoundTripsFlags()
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
+        var alice = await NewAliceAsync();
 
-        var response = await client.GetAsync("/api/movies/");
+        // Frontend sends formats as a bitwise integer (3 = Dvd | BluRay).
+        // Use raw JSON to simulate what the browser actually sends —
+        // PostAsJsonAsync would stringify enums as the server expects.
+        var json = "{\"Title\":\"Inception\",\"Formats\":3,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
+        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        var response = await alice.Client.PostAsync("/api/movies/", content);
+        var raw = await response.Content.ReadAsStringAsync();
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        // The response must return formats as an integer so the frontend
+        // can use bitwise ops. A string like "BluyRay" breaks ((v & 1) !== 0).
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
+        Assert.Equal(3, parsed.GetProperty("formats").GetInt32());
+
+        // Verify the underlying entity stored the correct flags.
+        var stored = await Factory.WithDbAsync(db =>
+            db.Movies.Where(m => m.Title == "Inception" && m.OwnerId == alice.Id).FirstAsync());
+        Assert.Equal(MovieFormat.Dvd | MovieFormat.BluRay, stored.Formats);
     }
 
     [Fact]
-    public async Task Create_Unauthenticated_ReturnsUnauthorized()
+    public async Task Update_WithFormatsAsInteger_PersistsNewFlags()
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
+        var alice = await NewAliceAsync();
+        var movie = await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
 
-        var response = await client.PostAsJsonAsync("/api/movies/", Sample());
+        // Send all three flags as integer 7.
+        var json = "{\"Title\":\"Heat\",\"Formats\":7,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
+        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        var response = await alice.Client.PutAsync($"/api/movies/{movie.Id}", content);
+        var raw = await response.Content.ReadAsStringAsync();
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
+        Assert.Equal(7, parsed.GetProperty("formats").GetInt32());
     }
 
-    // -------- CRUD happy path --------
+    [Fact]
+    public async Task Create_WithNewFormats_VhsAndDigital()
+    {
+        var alice = await NewAliceAsync();
+
+        // Vhs(8) | Digital(16) = 24.
+        var json = "{\"Title\":\"Retro Movie\",\"Formats\":24,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
+        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        var response = await alice.Client.PostAsync("/api/movies/", content);
+        var raw = await response.Content.ReadAsStringAsync();
+
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
+        Assert.Equal(24, parsed.GetProperty("formats").GetInt32());
+
+        var createdId = parsed.GetProperty("id").GetInt32();
+        var stored = await Factory.WithDbAsync(db =>
+            db.Movies.FirstAsync(m => m.Id == createdId));
+        Assert.Equal(MovieFormat.Vhs | MovieFormat.Digital, stored.Formats);
+    }
+
+    // -------- Personal / acquisition / watch fields round-trip --------
 
     [Fact]
-    public async Task Create_AsAuthenticatedUser_Returns201WithBody()
+    public async Task Create_RoundTripsAllNewScalarFields()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample("The Matrix", 1999));
+        var response = await alice.Client.PostAsJsonAsync("/api/movies/", MovieTestSupport.Sample(
+            rating: 9,
+            condition: Condition.LikeNew,
+            currency: "USD",
+            watchStatus: WatchStatus.Watched,
+            watchCount: 3));
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var body = await response.ReadJsonAsync<MovieResponse>();
-        Assert.NotNull(body);
-        Assert.True(body!.Id > 0);
-        Assert.Equal("The Matrix", body.Title);
-        Assert.Equal(1999, body.Year);
-    }
-
-    [Fact]
-    public async Task Create_PersistsOwnerIdFromAuthenticatedUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var created = await (await alice.Client.PostAsJsonAsync("/api/movies/", Sample()))
-            .ReadJsonAsync<MovieResponse>();
-
-        var stored = await factory.WithDbAsync(db =>
-            db.Movies.AsNoTracking().FirstAsync(m => m.Id == created!.Id));
-        Assert.Equal(alice.Id, stored.OwnerId);
-    }
-
-    [Fact]
-    public async Task Get_OwnRow_ReturnsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var movie = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat", Year = 1995 });
-
-        var body = await alice.Client.GetJsonAsync<MovieResponse>($"/api/movies/{movie.Id}");
-
-        Assert.Equal(movie.Id, body!.Id);
-        Assert.Equal("Heat", body.Title);
-    }
-
-    [Fact]
-    public async Task Get_NonExistentId_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.GetAsync("/api/movies/999999");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OwnRow_PersistsChangesAndBumpsUpdatedAt()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new Movie
-        {
-            OwnerId = alice.Id,
-            Title = "Old Title",
-            Year = 2000,
-            UpdatedAt = DateTime.UtcNow.AddDays(-1),
-        });
-        var originalUpdatedAt = seeded.UpdatedAt;
-
-        var response = await alice.Client.PutAsJsonAsync($"/api/movies/{seeded.Id}",
-            Sample(title: "New Title", year: 2001));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await response.ReadJsonAsync<MovieResponse>();
-        Assert.Equal("New Title", body!.Title);
-        Assert.Equal(2001, body.Year);
-        Assert.True(body.UpdatedAt > originalUpdatedAt);
-    }
-
-    [Fact]
-    public async Task Delete_OwnRow_Returns204AndRemovesRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        var response = await alice.Client.DeleteAsync($"/api/movies/{seeded.Id}");
-
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.Movies.AsNoTracking().AnyAsync(m => m.Id == seeded.Id));
-        Assert.False(stillThere);
-    }
-
-    // -------- Ownership boundary --------
-
-    [Fact]
-    public async Task Get_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var aliceMovie = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        var response = await bob.Client.GetAsync($"/api/movies/{aliceMovie.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var aliceMovie = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        var response = await bob.Client.PutAsJsonAsync($"/api/movies/{aliceMovie.Id}",
-            Sample(title: "Hijacked"));
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-
-        var stored = await factory.WithDbAsync(db =>
-            db.Movies.AsNoTracking().FirstAsync(m => m.Id == aliceMovie.Id));
-        Assert.Equal("Heat", stored.Title);
-    }
-
-    [Fact]
-    public async Task Delete_OtherUsersRow_Returns404AndKeepsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var aliceMovie = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        var response = await bob.Client.DeleteAsync($"/api/movies/{aliceMovie.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.Movies.AsNoTracking().AnyAsync(m => m.Id == aliceMovie.Id));
-        Assert.True(stillThere);
-    }
-
-    [Fact]
-    public async Task List_OnlyReturnsRowsOwnedByCurrentUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Alice-Movie" });
-        await factory.SeedAsync(new Movie { OwnerId = bob.Id, Title = "Bob-Movie" });
-
-        var aliceList = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/");
-
-        Assert.Single(aliceList!);
-        Assert.Equal("Alice-Movie", aliceList![0].Title);
-    }
-
-    // -------- Validation --------
-
-    [Fact]
-    public async Task Create_WithEmptyTitle_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(title: ""));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Create_WithWhitespaceTitle_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(title: "   "));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_WithEmptyTitle_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        var response = await alice.Client.PutAsJsonAsync($"/api/movies/{seeded.Id}",
-            Sample(title: ""));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Theory]
-    [InlineData(0)]
-    [InlineData(11)]
-    [InlineData(-1)]
-    public async Task Create_WithRatingOutsideRange_ReturnsBadRequest(int rating)
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(rating: rating));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Theory]
-    [InlineData(1)]
-    [InlineData(10)]
-    public async Task Create_WithRatingAtBoundary_Returns201(int rating)
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(rating: rating));
-
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-    }
-
-    // -------- Cover image caching --------
-
-    [Fact]
-    public async Task Create_WithRemoteImageUrl_StoresLocalCoverPath()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var dto = (object)new
-        {
-            Title = "Inception",
-            Formats = (int)MovieFormat.BluRay,
-            Status = CollectionStatus.Owned,
-            WatchStatus = WatchStatus.Unwatched,
-            WatchCount = 0,
-            ImagePath = "https://image.tmdb.org/t/p/w342/poster.jpg",
-            Tags = (string[]?)null,
-        };
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/", dto))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.NotNull(body);
-        Assert.NotNull(body!.ImagePath);
-        Assert.StartsWith("/covers/", body.ImagePath);
-        Assert.DoesNotContain("image.tmdb.org", body.ImagePath);
-    }
-
-    [Fact]
-    public async Task Create_WithLocalImagePath_PassesThroughUntouched()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var dto = (object)new
-        {
-            Title = "Inception",
-            Formats = (int)MovieFormat.BluRay,
-            Status = CollectionStatus.Owned,
-            WatchStatus = WatchStatus.Unwatched,
-            WatchCount = 0,
-            ImagePath = "/covers/already-cached.jpg",
-            Tags = (string[]?)null,
-        };
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/", dto))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Equal("/covers/already-cached.jpg", body!.ImagePath);
-    }
-
-    [Fact]
-    public async Task Create_WithCurrencyOfWrongLength_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(currency: "EU"));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("A heist on the subconscious.", body!.Description);
+        Assert.Equal(9, body.PersonalRating);
+        Assert.Equal(CollectionStatus.Owned, body.Status);
+        Assert.Equal(Condition.LikeNew, body.Condition);
+        Assert.Equal(new DateOnly(2024, 1, 15), body.AcquiredOn);
+        Assert.Equal(19.99m, body.AcquisitionPrice);
+        Assert.Equal("USD", body.AcquisitionCurrency);
+        Assert.Equal("Amazon", body.AcquisitionSource);
+        Assert.Equal(WatchStatus.Watched, body.WatchStatus);
+        Assert.Equal(new DateOnly(2024, 6, 1), body.LastWatchedOn);
+        Assert.Equal(3, body.WatchCount);
     }
 
     // -------- List filters --------
@@ -373,11 +139,10 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByQuery_MatchesTitleSubstring()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception" });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Interstellar" });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "The Matrix" });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception" });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Interstellar" });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "The Matrix" });
 
         var hits = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?query=inter");
 
@@ -388,11 +153,10 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByYear_ReturnsExactMatches()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "A", Year = 2010 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "B", Year = 2010 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "C", Year = 2020 });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "A", Year = 2010 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "B", Year = 2010 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "C", Year = 2020 });
 
         var hits = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?year=2010");
 
@@ -403,12 +167,11 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByYearRange_InclusiveBothEnds()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Old", Year = 1999 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Mid", Year = 2010 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Top", Year = 2020 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Future", Year = 2025 });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Old", Year = 1999 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Mid", Year = 2010 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Top", Year = 2020 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Future", Year = 2025 });
 
         var hits = await alice.Client.GetJsonAsync<MovieResponse[]>(
             "/api/movies/?yearFrom=2000&yearTo=2020");
@@ -420,11 +183,10 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByDirector_StudioGenre_MatchSubstring()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi, action" });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",    Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi" });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas", Director = "Martin Scorsese", Studio = "Warner Bros", Genres = "crime" });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi, action" });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",    Director = "Christopher Nolan", Studio = "Warner Bros", Genres = "sci-fi" });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas", Director = "Martin Scorsese", Studio = "Warner Bros", Genres = "crime" });
 
         var byDirector = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?director=Nolan");
         Assert.Equal(2, byDirector!.Length);
@@ -440,11 +202,10 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByStatusAndWatchStatusAndRatingMin()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Watched-9", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, PersonalRating = 9 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Unwatched", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Unwatched, PersonalRating = 5 });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Wishlist",        Status = CollectionStatus.Wishlist });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Watched-9", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, PersonalRating = 9 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Owned-Unwatched", Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Unwatched, PersonalRating = 5 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Wishlist",        Status = CollectionStatus.Wishlist });
 
         var byStatus = await alice.Client.GetJsonAsync<MovieResponse[]>("/api/movies/?status=Wishlist");
         var hit = Assert.Single(byStatus!);
@@ -461,12 +222,11 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_FiltersByTag_OrSemanticsAcrossMultipleValues()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
-        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "scifi" });
-        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "noir" });
-        await factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "comedy" });
+        await Factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "scifi" });
+        await Factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "noir" });
+        await Factory.SeedAsync(new Tag { OwnerId = alice.Id, Name = "comedy" });
 
         await alice.Client.PostAsJsonAsync("/api/movies/",
             new { Title = "Blade Runner", Year = 1982, Formats = (int)MovieFormat.BluRay, Status = CollectionStatus.Owned, WatchStatus = WatchStatus.Watched, WatchCount = 0, Tags = new[] { "scifi", "noir" } });
@@ -490,224 +250,15 @@ public class MoviesEndpointsTests
     [Fact]
     public async Task List_CombinesFiltersWithAndSemantics()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Year = 2010, Director = "Nolan",     Status = CollectionStatus.Owned });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",     Year = 2020, Director = "Nolan",     Status = CollectionStatus.Owned });
-        await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas",Year = 1990, Director = "Scorsese",  Status = CollectionStatus.Owned });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Inception", Year = 2010, Director = "Nolan",     Status = CollectionStatus.Owned });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Tenet",     Year = 2020, Director = "Nolan",     Status = CollectionStatus.Owned });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Goodfellas",Year = 1990, Director = "Scorsese",  Status = CollectionStatus.Owned });
 
         var hits = await alice.Client.GetJsonAsync<MovieResponse[]>(
             "/api/movies/?director=Nolan&yearFrom=2015");
 
         Assert.Single(hits!);
         Assert.Equal("Tenet", hits![0].Title);
-    }
-
-    // -------- Formats (flags enum as integer) --------
-
-    [Fact]
-    public async Task Create_WithFormatsAsInteger_RoundTripsFlags()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        // Frontend sends formats as a bitwise integer (3 = Dvd | BluRay).
-        // Use raw JSON to simulate what the browser actually sends —
-        // PostAsJsonAsync would stringify enums as the server expects.
-        var json = "{\"Title\":\"Inception\",\"Formats\":3,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
-        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-        var response = await alice.Client.PostAsync("/api/movies/", content);
-        var raw = await response.Content.ReadAsStringAsync();
-
-        // The response must return formats as an integer so the frontend
-        // can use bitwise ops. A string like "BluyRay" breaks ((v & 1) !== 0).
-        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
-        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
-        Assert.Equal(3, parsed.GetProperty("formats").GetInt32());
-
-        // Verify the underlying entity stored the correct flags.
-        var stored = await factory.WithDbAsync(db =>
-            db.Movies.Where(m => m.Title == "Inception").FirstAsync());
-        Assert.Equal(MovieFormat.Dvd | MovieFormat.BluRay, stored.Formats);
-    }
-
-    [Fact]
-    public async Task Update_WithFormatsAsInteger_PersistsNewFlags()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var movie = await factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "Heat" });
-
-        // Send all three flags as integer 7.
-        var json = "{\"Title\":\"Heat\",\"Formats\":7,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
-        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-        var response = await alice.Client.PutAsync($"/api/movies/{movie.Id}", content);
-        var raw = await response.Content.ReadAsStringAsync();
-
-        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
-        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
-        Assert.Equal(7, parsed.GetProperty("formats").GetInt32());
-    }
-
-    [Fact]
-    public async Task Create_WithNewFormats_VhsAndDigital()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        // Vhs(8) | Digital(16) = 24.
-        var json = "{\"Title\":\"Retro Movie\",\"Formats\":24,\"Status\":\"Owned\",\"WatchStatus\":\"Unwatched\",\"WatchCount\":0}";
-        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-        var response = await alice.Client.PostAsync("/api/movies/", content);
-        var raw = await response.Content.ReadAsStringAsync();
-
-        var parsed = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(raw);
-        Assert.Equal(System.Text.Json.JsonValueKind.Number, parsed.GetProperty("formats").ValueKind);
-        Assert.Equal(24, parsed.GetProperty("formats").GetInt32());
-
-        var createdId = parsed.GetProperty("id").GetInt32();
-        var stored = await factory.WithDbAsync(db =>
-            db.Movies.FirstAsync(m => m.Id == createdId));
-        Assert.Equal(MovieFormat.Vhs | MovieFormat.Digital, stored.Formats);
-    }
-
-    // -------- Personal / acquisition / watch fields round-trip --------
-
-    [Fact]
-    public async Task Create_RoundTripsAllNewScalarFields()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/movies/", Sample(
-            rating: 9,
-            condition: Condition.LikeNew,
-            currency: "USD",
-            watchStatus: WatchStatus.Watched,
-            watchCount: 3));
-
-        var body = await response.ReadJsonAsync<MovieResponse>();
-        Assert.Equal("A heist on the subconscious.", body!.Description);
-        Assert.Equal(9, body.PersonalRating);
-        Assert.Equal(CollectionStatus.Owned, body.Status);
-        Assert.Equal(Condition.LikeNew, body.Condition);
-        Assert.Equal(new DateOnly(2024, 1, 15), body.AcquiredOn);
-        Assert.Equal(19.99m, body.AcquisitionPrice);
-        Assert.Equal("USD", body.AcquisitionCurrency);
-        Assert.Equal("Amazon", body.AcquisitionSource);
-        Assert.Equal(WatchStatus.Watched, body.WatchStatus);
-        Assert.Equal(new DateOnly(2024, 6, 1), body.LastWatchedOn);
-        Assert.Equal(3, body.WatchCount);
-    }
-
-    [Fact]
-    public async Task Create_NormalizesCurrencyToUppercase()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/", Sample(currency: "eur")))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Equal("EUR", body!.AcquisitionCurrency);
-    }
-
-    // -------- Tags --------
-
-    [Fact]
-    public async Task Create_WithTags_CreatesTagsAndAttachesThem()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/",
-            Sample(tags: ["Sci-Fi", "Heist", "Nolan"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Equal(new[] { "heist", "nolan", "sci-fi" }, body!.Tags);
-
-        var tagCount = await factory.WithDbAsync(db =>
-            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
-        Assert.Equal(3, tagCount);
-    }
-
-    [Fact]
-    public async Task Create_WithDuplicateTagsInArray_DeduplicatesIgnoreCase()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var body = await (await alice.Client.PostAsJsonAsync("/api/movies/",
-            Sample(tags: ["Sci-Fi", "sci-fi", "  Sci-Fi  ", "Heist"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Equal(new[] { "heist", "sci-fi" }, body!.Tags);
-    }
-
-    [Fact]
-    public async Task Update_ReplacesTagSetRatherThanMerging()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var created = await (await alice.Client.PostAsJsonAsync("/api/movies/",
-            Sample(tags: ["Sci-Fi", "Heist"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        var updated = await (await alice.Client.PutAsJsonAsync($"/api/movies/{created!.Id}",
-            Sample(tags: ["Drama"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Equal(new[] { "drama" }, updated!.Tags);
-    }
-
-    [Fact]
-    public async Task Update_WithEmptyTagArray_RemovesAllTags()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var created = await (await alice.Client.PostAsJsonAsync("/api/movies/",
-            Sample(tags: ["Sci-Fi", "Heist"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        var updated = await (await alice.Client.PutAsJsonAsync($"/api/movies/{created!.Id}",
-            Sample(tags: Array.Empty<string>())))
-            .ReadJsonAsync<MovieResponse>();
-
-        Assert.Empty(updated!.Tags);
-    }
-
-    [Fact]
-    public async Task Delete_Movie_RemovesJoinRowsButKeepsTagEntity()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var created = await (await alice.Client.PostAsJsonAsync("/api/movies/",
-            Sample(tags: ["Sci-Fi"])))
-            .ReadJsonAsync<MovieResponse>();
-
-        var delete = await alice.Client.DeleteAsync($"/api/movies/{created!.Id}");
-        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
-
-        var tagsLeft = await factory.WithDbAsync(db =>
-            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
-        Assert.Equal(1, tagsLeft);
-    }
-
-    [Fact]
-    public async Task Tags_AreOwnerScoped_BetweenUsers()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-
-        await alice.Client.PostAsJsonAsync("/api/movies/", Sample(tags: ["sci-fi"]));
-        await bob.Client.PostAsJsonAsync("/api/movies/", Sample(title: "Bob's", tags: ["sci-fi"]));
-
-        var totalTags = await factory.WithDbAsync(db => db.Tags.CountAsync());
-        Assert.Equal(2, totalTags);
-
-        var aliceTags = await factory.WithDbAsync(db =>
-            db.Tags.CountAsync(t => t.OwnerId == alice.Id));
-        Assert.Equal(1, aliceTags);
     }
 }

--- a/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
@@ -3,279 +3,54 @@ using System.Net.Http.Json;
 using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Tests.Infrastructure;
+using Collectify.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
 
 namespace Collectify.Tests.Api;
 
-public class MusicEndpointsTests
+public class MusicEndpointsTests : CollectionEndpointsTestsBase<MusicAlbum, AlbumResponse>, IClassFixture<CollectifyApiFactory>
 {
-    private record AlbumResponse(
-        int Id, string Title, string ArtistName, int? Year,
-        MusicFormat Format, string? Label, string? Genres, string? Barcode,
-        string? MusicBrainzReleaseId, string? DiscogsId, string? ImagePath, string? Description, string? Notes,
-        int? PersonalRating, CollectionStatus Status, Condition? Condition,
-        DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
-        int ListenCount, DateOnly? LastPlayedOn,
-        string[] Tags,
-        DateTime AddedAt, DateTime UpdatedAt);
-
-    private static object Sample(
-        string title = "OK Computer",
-        string artist = "Radiohead",
-        int? year = 1997,
-        MusicFormat format = MusicFormat.Cd,
-        int? rating = null,
-        string[]? tags = null,
-        int listenCount = 0) => new
-        {
-            Title = title,
-            ArtistName = artist,
-            Year = year,
-            Format = format,
-            Label = (string?)null,
-            Genres = (string?)null,
-            Barcode = (string?)null,
-            MusicBrainzReleaseId = (string?)null,
-            DiscogsId = (string?)null,
-            ImagePath = (string?)null,
-            Description = "Third studio album.",
-            Notes = (string?)null,
-            PersonalRating = rating,
-            Status = CollectionStatus.Owned,
-            Condition = (Condition?)Domain.Enums.Condition.Good,
-            AcquiredOn = (DateOnly?)new DateOnly(2024, 1, 15),
-            AcquisitionPrice = (decimal?)12.50m,
-            AcquisitionCurrency = "GBP",
-            AcquisitionSource = "Rough Trade",
-            ListenCount = listenCount,
-            LastPlayedOn = (DateOnly?)new DateOnly(2024, 8, 1),
-            Tags = tags,
-        };
-
-    // -------- Auth --------
-
-    [Fact]
-    public async Task List_Unauthenticated_ReturnsUnauthorized()
+    public MusicEndpointsTests(CollectifyApiFactory factory) : base(factory)
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
-
-        var response = await client.GetAsync("/api/music/");
-
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
-    [Fact]
-    public async Task Create_Unauthenticated_ReturnsUnauthorized()
+    protected override string RoutePrefix => "/api/music/";
+
+    protected override object Sample(string? title = null, string[]? tags = null, string? currency = null, int? rating = null) =>
+        MusicTestSupport.Sample(title: title ?? "OK Computer", tags: tags, currency: currency ?? "GBP", rating: rating);
+
+    protected override object MinimalWithImage(string? imagePath) => new
     {
-        await using var factory = new CollectifyApiFactory();
-        var client = factory.CreateClient();
+        Title = "OK Computer",
+        ArtistName = "Radiohead",
+        Format = MusicFormat.Cd,
+        Status = CollectionStatus.Owned,
+        ListenCount = 0,
+        ImagePath = imagePath,
+        Tags = (string[]?)null,
+    };
 
-        var response = await client.PostAsJsonAsync("/api/music/", Sample());
-
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-    }
-
-    // -------- CRUD happy path --------
-
-    [Fact]
-    public async Task Create_AsAuthenticatedUser_Returns201WithBody()
+    protected override MusicAlbum NewMinimalEntity(string ownerId, string title) => new()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        OwnerId = ownerId,
+        Title = title,
+        ArtistName = "Radiohead",
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
 
-        var response = await alice.Client.PostAsJsonAsync("/api/music/", Sample());
-
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        var body = await response.ReadJsonAsync<AlbumResponse>();
-        Assert.True(body!.Id > 0);
-        Assert.Equal("OK Computer", body.Title);
-        Assert.Equal("Radiohead", body.ArtistName);
-    }
-
-    [Fact]
-    public async Task Create_PersistsOwnerIdFromAuthenticatedUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var created = await (await alice.Client.PostAsJsonAsync("/api/music/", Sample()))
-            .ReadJsonAsync<AlbumResponse>();
-
-        var stored = await factory.WithDbAsync(db =>
-            db.MusicAlbums.AsNoTracking().FirstAsync(a => a.Id == created!.Id));
-        Assert.Equal(alice.Id, stored.OwnerId);
-    }
-
-    [Fact]
-    public async Task Get_OwnRow_ReturnsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var album = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead", Year = 2000,
-        });
-
-        var body = await alice.Client.GetJsonAsync<AlbumResponse>($"/api/music/{album.Id}");
-
-        Assert.Equal("Kid A", body!.Title);
-        Assert.Equal("Radiohead", body.ArtistName);
-    }
-
-    [Fact]
-    public async Task Get_NonExistentId_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.GetAsync("/api/music/999999");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OwnRow_PersistsChangesAndBumpsUpdatedAt()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Old", ArtistName = "Radiohead",
-            UpdatedAt = DateTime.UtcNow.AddDays(-1),
-        });
-        var originalUpdatedAt = seeded.UpdatedAt;
-
-        var response = await alice.Client.PutAsJsonAsync($"/api/music/{seeded.Id}",
-            Sample(title: "In Rainbows", year: 2007));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await response.ReadJsonAsync<AlbumResponse>();
-        Assert.Equal("In Rainbows", body!.Title);
-        Assert.True(body.UpdatedAt > originalUpdatedAt);
-    }
-
-    [Fact]
-    public async Task Delete_OwnRow_Returns204AndRemovesRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var seeded = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead",
-        });
-
-        var response = await alice.Client.DeleteAsync($"/api/music/{seeded.Id}");
-
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.MusicAlbums.AsNoTracking().AnyAsync(a => a.Id == seeded.Id));
-        Assert.False(stillThere);
-    }
-
-    // -------- Ownership boundary --------
-
-    [Fact]
-    public async Task Get_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var album = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead",
-        });
-
-        var response = await bob.Client.GetAsync($"/api/music/{album.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Update_OtherUsersRow_Returns404()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var album = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead",
-        });
-
-        var response = await bob.Client.PutAsJsonAsync($"/api/music/{album.Id}",
-            Sample(title: "Hijacked"));
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        var stored = await factory.WithDbAsync(db =>
-            db.MusicAlbums.AsNoTracking().FirstAsync(a => a.Id == album.Id));
-        Assert.Equal("Kid A", stored.Title);
-    }
-
-    [Fact]
-    public async Task Delete_OtherUsersRow_Returns404AndKeepsRow()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        var album = await factory.SeedAsync(new MusicAlbum
-        {
-            OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead",
-        });
-
-        var response = await bob.Client.DeleteAsync($"/api/music/{album.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        var stillThere = await factory.WithDbAsync(db =>
-            db.MusicAlbums.AsNoTracking().AnyAsync(a => a.Id == album.Id));
-        Assert.True(stillThere);
-    }
-
-    [Fact]
-    public async Task List_OnlyReturnsRowsOwnedByCurrentUser()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        var bob = await factory.CreateAuthenticatedUserAsync("bob");
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "AliceAlbum", ArtistName = "AliceArtist" });
-        await factory.SeedAsync(new MusicAlbum { OwnerId = bob.Id, Title = "BobAlbum", ArtistName = "BobArtist" });
-
-        var aliceList = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/");
-
-        Assert.Single(aliceList!);
-        Assert.Equal("AliceAlbum", aliceList![0].Title);
-    }
+    protected override int IdOf(MusicAlbum entity) => entity.Id;
+    protected override string OwnerIdOf(MusicAlbum entity) => entity.OwnerId;
+    protected override string TitleOf(MusicAlbum entity) => entity.Title;
+    protected override DateTime UpdatedAtOf(MusicAlbum entity) => entity.UpdatedAt;
 
     // -------- Validation --------
 
     [Fact]
-    public async Task Create_WithEmptyTitle_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/music/", Sample(title: ""));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
     public async Task Create_WithEmptyArtist_ReturnsBadRequest()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
-        var response = await alice.Client.PostAsJsonAsync("/api/music/", Sample(artist: ""));
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Create_WithRatingOutsideRange_ReturnsBadRequest()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/music/", Sample(rating: 11));
+        var response = await alice.Client.PostAsJsonAsync("/api/music/", MusicTestSupport.Sample(artist: ""));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -285,10 +60,9 @@ public class MusicEndpointsTests
     [Fact]
     public async Task List_FiltersByQuery_MatchesArtistSubstring()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead" });
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Funeral", ArtistName = "Arcade Fire" });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Kid A", ArtistName = "Radiohead" });
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Funeral", ArtistName = "Arcade Fire" });
 
         var hits = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?query=radio");
 
@@ -296,37 +70,13 @@ public class MusicEndpointsTests
         Assert.Equal("Radiohead", hits![0].ArtistName);
     }
 
-    // -------- Personal / acquisition / listen fields round-trip --------
-
-    [Fact]
-    public async Task Create_RoundTripsAllNewScalarFields()
-    {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-
-        var response = await alice.Client.PostAsJsonAsync("/api/music/", Sample(rating: 10, listenCount: 42));
-
-        var body = await response.ReadJsonAsync<AlbumResponse>();
-        Assert.Equal("Third studio album.", body!.Description);
-        Assert.Equal(10, body.PersonalRating);
-        Assert.Equal(CollectionStatus.Owned, body.Status);
-        Assert.Equal(Condition.Good, body.Condition);
-        Assert.Equal(new DateOnly(2024, 1, 15), body.AcquiredOn);
-        Assert.Equal(12.50m, body.AcquisitionPrice);
-        Assert.Equal("GBP", body.AcquisitionCurrency);
-        Assert.Equal("Rough Trade", body.AcquisitionSource);
-        Assert.Equal(42, body.ListenCount);
-        Assert.Equal(new DateOnly(2024, 8, 1), body.LastPlayedOn);
-    }
-
     [Fact]
     public async Task List_FiltersByYearRange_ArtistLabelGenreStatusRating()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "OK Computer", ArtistName = "Radiohead",   Year = 1997, Label = "Parlophone", Genres = "rock", PersonalRating = 9, Status = CollectionStatus.Owned });
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Funeral",     ArtistName = "Arcade Fire", Year = 2004, Label = "Merge",      Genres = "indie", PersonalRating = 7, Status = CollectionStatus.Owned });
-        await factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Pet Sounds",  ArtistName = "Beach Boys",  Year = 1966, Label = "Capitol",    Genres = "pop", PersonalRating = 10, Status = CollectionStatus.Wishlist });
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "OK Computer", ArtistName = "Radiohead",   Year = 1997, Label = "Parlophone", Genres = "rock", PersonalRating = 9, Status = CollectionStatus.Owned });
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Funeral",     ArtistName = "Arcade Fire", Year = 2004, Label = "Merge",      Genres = "indie", PersonalRating = 7, Status = CollectionStatus.Owned });
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "Pet Sounds",  ArtistName = "Beach Boys",  Year = 1966, Label = "Capitol",    Genres = "pop", PersonalRating = 10, Status = CollectionStatus.Wishlist });
 
         var byYear = await alice.Client.GetJsonAsync<AlbumResponse[]>("/api/music/?yearFrom=1990&yearTo=2000");
         var only = Assert.Single(byYear!);
@@ -348,17 +98,28 @@ public class MusicEndpointsTests
         Assert.Equal(2, byRating!.Length);
     }
 
-    // -------- Tags --------
+    // -------- Personal / acquisition / listen fields round-trip --------
 
     [Fact]
-    public async Task Create_WithTags_CreatesTagsAndAttachesThem()
+    public async Task Create_RoundTripsAllNewScalarFields()
     {
-        await using var factory = new CollectifyApiFactory();
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        var alice = await NewAliceAsync();
 
-        var body = await (await alice.Client.PostAsJsonAsync("/api/music/", Sample(tags: ["Alt-Rock", "90s"])))
-            .ReadJsonAsync<AlbumResponse>();
+        var response = await alice.Client.PostAsJsonAsync("/api/music/",
+            MusicTestSupport.Sample(rating: 10, listenCount: 42));
 
-        Assert.Equal(new[] { "90s", "alt-rock" }, body!.Tags);
+        var body = await response.ReadJsonAsync<AlbumResponse>();
+        Assert.Equal("Radiohead", body!.ArtistName);
+        Assert.Equal(MusicFormat.Cd, body.Format);
+        Assert.Equal("Third studio album.", body.Description);
+        Assert.Equal(10, body.PersonalRating);
+        Assert.Equal(CollectionStatus.Owned, body.Status);
+        Assert.Equal(Condition.Good, body.Condition);
+        Assert.Equal(new DateOnly(2024, 1, 15), body.AcquiredOn);
+        Assert.Equal(12.50m, body.AcquisitionPrice);
+        Assert.Equal("GBP", body.AcquisitionCurrency);
+        Assert.Equal("Rough Trade", body.AcquisitionSource);
+        Assert.Equal(42, body.ListenCount);
+        Assert.Equal(new DateOnly(2024, 8, 1), body.LastPlayedOn);
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/CoverImageGarbageCollectorTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CoverImageGarbageCollectorTests.cs
@@ -21,7 +21,7 @@ public class CoverImageGarbageCollectorTests : IDisposable
         _connection.Open();
         _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
         using var seed = new CollectifyDbContext(_options);
-        seed.Database.EnsureCreated();
+        seed.Database.Migrate();
     }
 
     public void Dispose() => _connection.Dispose();

--- a/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CoverImageStoreTests.cs
@@ -20,7 +20,7 @@ public class CoverImageStoreTests : IDisposable
         _connection.Open();
         _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
         using var seed = new CollectifyDbContext(_options);
-        seed.Database.EnsureCreated();
+        seed.Database.Migrate();
     }
 
     public void Dispose() => _connection.Dispose();

--- a/src/server/tests/Collectify.Tests/Infrastructure/IgdbBackfillRunnerTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/IgdbBackfillRunnerTests.cs
@@ -24,7 +24,7 @@ public class IgdbBackfillRunnerTests : IDisposable
         _connection.Open();
         _options = new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options;
         using var seed = new CollectifyDbContext(_options);
-        seed.Database.EnsureCreated();
+        seed.Database.Migrate();
     }
 
     public void Dispose() => _connection.Dispose();

--- a/src/server/tests/Collectify.Tests/Infrastructure/IgdbBackfillServiceTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/IgdbBackfillServiceTests.cs
@@ -34,7 +34,7 @@ public class IgdbBackfillServiceTests : IDisposable
         // Game fails with "no such table: Games".)
         using var setup = new CollectifyDbContext(
             new DbContextOptionsBuilder<CollectifyDbContext>().UseSqlite(_connection).Options);
-        setup.Database.EnsureCreated();
+        setup.Database.Migrate();
     }
 
     public void Dispose() => _connection.Dispose();

--- a/src/server/tests/Collectify.Tests/TestSupport/CollectionTestSupport.cs
+++ b/src/server/tests/Collectify.Tests/TestSupport/CollectionTestSupport.cs
@@ -1,0 +1,170 @@
+using Collectify.Domain.Enums;
+
+namespace Collectify.Tests.TestSupport;
+
+/// <summary>
+/// Common shape shared by the three collection response DTOs (movies, music,
+/// games) so <c>CollectionEndpointsTestsBase&lt;TEntity, TResponse&gt;</c> can
+/// assert on it generically without knowing the concrete media type.
+/// </summary>
+public interface ICollectionResponse
+{
+    int Id { get; }
+    string Title { get; }
+    int? PersonalRating { get; }
+    string? AcquisitionCurrency { get; }
+    string? ImagePath { get; }
+    string[] Tags { get; }
+    DateTime UpdatedAt { get; }
+}
+
+public record MovieResponse(
+    int Id, string Title, string? OriginalTitle, int? Year,
+    int Formats, string? Director, int? RuntimeMinutes,
+    string? Studio, string? Genres, string? Barcode,
+    string? TmdbId, string? ImdbId, string? ImagePath, string? Description, string? Notes,
+    int? PersonalRating, CollectionStatus Status, Condition? Condition,
+    DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
+    WatchStatus WatchStatus, DateOnly? LastWatchedOn, int WatchCount,
+    string[] Tags,
+    DateTime AddedAt, DateTime UpdatedAt) : ICollectionResponse;
+
+public record AlbumResponse(
+    int Id, string Title, string ArtistName, int? Year,
+    MusicFormat Format, string? Label, string? Genres, string? Barcode,
+    string? MusicBrainzReleaseId, string? DiscogsId, string? ImagePath, string? Description, string? Notes,
+    int? PersonalRating, CollectionStatus Status, Condition? Condition,
+    DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
+    int ListenCount, DateOnly? LastPlayedOn,
+    string[] Tags,
+    DateTime AddedAt, DateTime UpdatedAt) : ICollectionResponse;
+
+public record GameResponse(
+    int Id, string Title, GamePlatform Platform, string? PlatformLegacy, int? Year,
+    string? Publisher, string? Developer, bool IsDigital, DigitalStore? DigitalStore,
+    string? Barcode, string? IgdbId, string? ImagePath, string? Description, string? Notes,
+    int? PersonalRating, CollectionStatus Status, Condition? Condition,
+    DateOnly? AcquiredOn, decimal? AcquisitionPrice, string? AcquisitionCurrency, string? AcquisitionSource,
+    CompletionStatus CompletionStatus, int? HoursPlayed, DateOnly? LastPlayedOn,
+    string[] Tags,
+    DateTime AddedAt, DateTime UpdatedAt) : ICollectionResponse;
+
+/// <summary>Per-type sample-DTO factories, kept in one place so the three
+/// endpoint test classes stop each carrying their own copy.</summary>
+public static class MovieTestSupport
+{
+    public static object Sample(
+        string title = "Inception",
+        int? year = 2010,
+        MovieFormat formats = MovieFormat.BluRay,
+        int? rating = null,
+        CollectionStatus status = CollectionStatus.Owned,
+        Condition? condition = null,
+        string? currency = null,
+        WatchStatus watchStatus = WatchStatus.Unwatched,
+        int watchCount = 0,
+        string[]? tags = null) => new
+        {
+            Title = title,
+            OriginalTitle = (string?)null,
+            Year = year,
+            Formats = (int)formats,
+            Director = "Christopher Nolan",
+            RuntimeMinutes = 148,
+            Studio = "Warner Bros.",
+            Genres = "Sci-Fi, Thriller",
+            Barcode = (string?)null,
+            TmdbId = (string?)null,
+            ImdbId = (string?)null,
+            ImagePath = (string?)null,
+            Description = "A heist on the subconscious.",
+            Notes = (string?)null,
+            PersonalRating = rating,
+            Status = status,
+            Condition = condition,
+            AcquiredOn = (DateOnly?)new DateOnly(2024, 1, 15),
+            AcquisitionPrice = (decimal?)19.99m,
+            AcquisitionCurrency = currency,
+            AcquisitionSource = "Amazon",
+            WatchStatus = watchStatus,
+            LastWatchedOn = (DateOnly?)new DateOnly(2024, 6, 1),
+            WatchCount = watchCount,
+            Tags = tags,
+        };
+}
+
+public static class MusicTestSupport
+{
+    public static object Sample(
+        string title = "OK Computer",
+        string artist = "Radiohead",
+        int? year = 1997,
+        MusicFormat format = MusicFormat.Cd,
+        int? rating = null,
+        string? currency = "GBP",
+        string[]? tags = null,
+        int listenCount = 0) => new
+        {
+            Title = title,
+            ArtistName = artist,
+            Year = year,
+            Format = format,
+            Label = (string?)null,
+            Genres = (string?)null,
+            Barcode = (string?)null,
+            MusicBrainzReleaseId = (string?)null,
+            DiscogsId = (string?)null,
+            ImagePath = (string?)null,
+            Description = "Third studio album.",
+            Notes = (string?)null,
+            PersonalRating = rating,
+            Status = CollectionStatus.Owned,
+            Condition = (Condition?)Domain.Enums.Condition.Good,
+            AcquiredOn = (DateOnly?)new DateOnly(2024, 1, 15),
+            AcquisitionPrice = (decimal?)12.50m,
+            AcquisitionCurrency = currency,
+            AcquisitionSource = "Rough Trade",
+            ListenCount = listenCount,
+            LastPlayedOn = (DateOnly?)new DateOnly(2024, 8, 1),
+            Tags = tags,
+        };
+}
+
+public static class GameTestSupport
+{
+    public static object Sample(
+        string title = "Hades",
+        GamePlatform platform = GamePlatform.Pc,
+        bool isDigital = true,
+        DigitalStore? store = DigitalStore.Steam,
+        int? rating = null,
+        string? currency = "USD",
+        CompletionStatus completion = CompletionStatus.NotStarted,
+        int? hours = null,
+        string[]? tags = null) => new
+        {
+            Title = title,
+            Platform = platform,
+            Year = (int?)2020,
+            Publisher = "Supergiant Games",
+            Developer = "Supergiant Games",
+            IsDigital = isDigital,
+            DigitalStore = store,
+            Barcode = (string?)null,
+            IgdbId = (string?)null,
+            ImagePath = (string?)null,
+            Description = "Roguelike from Supergiant.",
+            Notes = (string?)null,
+            PersonalRating = rating,
+            Status = CollectionStatus.Owned,
+            Condition = (Condition?)null,
+            AcquiredOn = (DateOnly?)new DateOnly(2024, 2, 10),
+            AcquisitionPrice = (decimal?)24.99m,
+            AcquisitionCurrency = currency,
+            AcquisitionSource = "Steam Sale",
+            CompletionStatus = completion,
+            HoursPlayed = hours,
+            LastPlayedOn = (DateOnly?)new DateOnly(2024, 9, 1),
+            Tags = tags,
+        };
+}


### PR DESCRIPTION
## Summary
- Collapse `MoviesEndpointsTests`, `MusicEndpointsTests`, and `GamesEndpointsTests` onto a single abstract generic `CollectionEndpointsTestsBase<TEntity, TResponse>`, with the 3 concrete classes reduced to route/DTO/entity wiring plus their own per-type tests (formats bitmask, artist/label filters, platform filters, etc.).
- Extract the response DTOs and per-type sample-DTO factories into `tests/TestSupport/CollectionTestSupport.cs` so they're declared once instead of copy-pasted per file.
- Extend the 11 previously movie-only behaviors (currency normalization, tag replace/dedupe/empty-array-removal, owner-scoped tags, cover-URL caching, rating boundaries, title whitespace validation) to run for music and games too.
- Switch each concrete test class to a class-level shared `CollectifyApiFactory` host via `IClassFixture` instead of booting a fresh `WebApplicationFactory` per test. Every test uses a uniquely-generated username so ownership-scoping assertions still hold against the shared in-memory SQLite DB; the one previously-global tag count assertion (`Tags_AreOwnerScoped_BetweenUsers`) is rewritten to count per-owner.
- Align `CoverImageGarbageCollectorTests`, `CoverImageStoreTests`, `IgdbBackfillRunnerTests`, and `IgdbBackfillServiceTests` onto the same migration-based schema path the endpoint tests already use (`Database.Migrate()` instead of `EnsureCreated()`), closing the schema-divergence gap called out in #96. `GamePlatformBackfillTests` stays on `EnsureCreated` deliberately (documented, exercises the Postgres-only path); `LookupCacheMigrationTests` already used `MigrateAsync`.

Net result: 595 tests passing (up from the 565 baseline), full suite wall-clock ~20-23s (was ~28s baseline).

## Deviations from the runbook, flagged for driver review
- **No `StubHttpHandler` extracted.** The runbook's acceptance criteria named a shared `HttpMessageHandler` stub as one of three things to consolidate into `TestSupport`, but none of the three endpoint test files (movies/music/games) actually use an `HttpMessageHandler` stub — they don't make outbound HTTP calls; `ICoverImageStore` is faked via DI instead. Adding an unused `StubHttpHandler` would be dead code, so it was omitted. `StubHandler` classes do exist elsewhere in the test project (`CoverImageStoreTests.cs`, `TmdbMovieProviderTests.cs`, etc.) but those files are outside this slice's edit scope.
- **`Database.Migrate()` instead of `MigrateAsync()`** for the four unit-test files in increment 5. Those files build schema inside a synchronous test-class constructor; `MigrateAsync()` can't be awaited there without restructuring to `IAsyncLifetime` (a bigger structural change than "align the schema path"). The sync `Migrate()` API runs through the identical EF Core migration pipeline — the property that actually matters for closing the `EnsureCreated`-vs-migrations divergence — so this is functionally equivalent to the intent.
- **Mutation check #3** (currency normalization) as literally specified — "change the sample's currency to an already-uppercase value" — does not produce a RED test, because the assertion checks the *output* equals `"EUR"`, and an already-uppercase input trivially satisfies that regardless of whether normalization ran. Verified this doesn't discriminate, then ran a mutation that does (flipped the assertion's expected value to lowercase `"eur"` while keeping the lowercase input) — that goes RED for all three types as expected, proving the test genuinely exercises normalization. Reported both experiments below.

## Mutation checks (per runbook section 4)
| # | Mutation | Result |
|---|---|---|
| 1 | Removed `using Collectify.Tests.TestSupport;` from `MoviesEndpointsTests.cs` | RED — `CS0246: The type or namespace name 'MovieResponse' could not be found`. Restored, green. |
| 2 | Forced `GamesEndpointsTests`'s `Sample()` override to always pass `tags: ["nope"]` | RED — only `GamesEndpointsTests.Create_WithTags_CreatesTagsAndAttachesThem` failed; `MoviesEndpointsTests`/`MusicEndpointsTests` stayed green. Restored, green. |
| 3 | As literally specified (input `"EUR"` instead of `"eur"`) | **Did not go RED** (see deviation above — not discriminating). Refined: flipped the assertion to expect `"eur"` — RED for all three types (Movies/Music/Games `Create_NormalizesCurrencyToUppercase`). Restored, green. |
| 4 | Changed `StartsWith("/covers/", ...)` to `StartsWith("/nope", ...)` in the shared base | RED for all three types (Movies/Music/Games `Create_WithRemoteImageUrl_StoresLocalCoverPath`). Restored, green. |

All four restores verified with a full green `dotnet test` run afterward.

## Increments applied
All 5 increments from the runbook were applied by me (no pre-existing work found on this branch — it started at parity with `main`):
1. TestSupport extraction (response DTOs + sample factories)
2. Generic base class + 3 thin subclasses (shared scenarios parameterized)
3. Extended the 11 movie-only behaviors to music and games
4. Shared host fixture (`IClassFixture<CollectifyApiFactory>`) + unique usernames + owner-scoped tag counts
5. Unit test schema alignment (`EnsureCreated` → `Migrate`)

Increments 1–4 landed in one commit (they were designed and built together as a single coherent architecture); increment 5 is a separate commit.

## Test plan
- [x] `dotnet test Collectify.slnx` — 595 passed, 0 failed, ~20-23s wall-clock (baseline: 565 passed, ~28s)
- [x] Confirmed shared scenarios run under all three concrete classes (`--list-tests` shows `MoviesEndpointsTests`/`MusicEndpointsTests`/`GamesEndpointsTests` each carrying the full shared scenario set plus their own per-type tests)
- [x] `git diff main --stat` — only files under `src/server/tests/` touched, no production code
- [x] All 4 mutation checks run and restored to green (see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)