### PR TITLE
test: consolidate identical StubHandler into shared TestSupport (#144)

### DIFF
--- a/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/MusicBrainzMusicProviderTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Lookup.MusicBrainz;
+using Collectify.Tests.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -320,27 +321,5 @@ public class MusicBrainzMusicProviderTests
         Assert.Single(barcodeHits);
         Assert.Equal("OK Computer", barcodeHits[0].Title);
         Assert.Single(barcodeHandler.RequestedUrls);
-    }
-
-    private sealed class StubHandler : HttpMessageHandler
-    {
-        private readonly string _body;
-        private readonly HttpStatusCode _status;
-        public List<string> RequestedUrls { get; } = new();
-
-        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
-        {
-            _body = body;
-            _status = status;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
-            return Task.FromResult(new HttpResponseMessage(_status)
-            {
-                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
-            });
-        }
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/SteamClientTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/SteamClientTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Store;
+using Collectify.Tests.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -135,27 +136,5 @@ public class SteamClientTests
         Assert.Equal(SteamFetchStatus.Ok, first.Status);
         Assert.Equal(SteamFetchStatus.Ok, second.Status);
         Assert.Single(handler.RequestedUrls); // second served from cache
-    }
-
-    private sealed class StubHandler : HttpMessageHandler
-    {
-        private readonly string _body;
-        private readonly HttpStatusCode _status;
-        public List<string> RequestedUrls { get; } = new();
-
-        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
-        {
-            _body = body;
-            _status = status;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
-            return Task.FromResult(new HttpResponseMessage(_status)
-            {
-                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
-            });
-        }
     }
 }

--- a/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/TmdbMovieProviderTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Lookup.Tmdb;
+using Collectify.Tests.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -572,29 +573,6 @@ public class TmdbMovieProviderTests
         Assert.All(storage.Writes, w => Assert.Equal(options.CacheTtl, w.Ttl));
     }
 
-
-    private sealed class StubHandler : HttpMessageHandler
-    {
-        private readonly string _body;
-        private readonly HttpStatusCode _status;
-        public List<string> RequestedUrls { get; } = new();
-
-        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
-        {
-            _body = body;
-            _status = status;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            // AbsoluteUri keeps percent-encoding intact; ToString unescapes %20 -> space.
-            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
-            return Task.FromResult(new HttpResponseMessage(_status)
-            {
-                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
-            });
-        }
-    }
 
     /// <summary>
     /// Stub that picks a response body by matching a substring of the

--- a/src/server/tests/Collectify.Tests/Infrastructure/UpcItemDbClientTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/UpcItemDbClientTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Collectify.Infrastructure.Lookup;
 using Collectify.Infrastructure.Lookup.Upc;
+using Collectify.Tests.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -128,27 +129,5 @@ public class UpcItemDbClientTests
         Assert.Null(await client.LookupAsync("0883929473076"));
         await client.LookupAsync("0883929473076"); // should retry, not serve cached null
         Assert.Equal(2, handler.RequestedUrls.Count);
-    }
-
-    private sealed class StubHandler : HttpMessageHandler
-    {
-        private readonly string _body;
-        private readonly HttpStatusCode _status;
-        public List<string> RequestedUrls { get; } = new();
-
-        public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
-        {
-            _body = body;
-            _status = status;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
-            return Task.FromResult(new HttpResponseMessage(_status)
-            {
-                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
-            });
-        }
     }
 }

--- a/src/server/tests/Collectify.Tests/TestSupport/StubHandler.cs
+++ b/src/server/tests/Collectify.Tests/TestSupport/StubHandler.cs
@@ -4,20 +4,9 @@ using System.Text;
 namespace Collectify.Tests.TestSupport;
 
 /// <summary>
-/// A controller-style <see cref="HttpMessageHandler"/> that returns a fixed
-/// body/status for every request and records the request URIs it served.
-/// Providers differ only by the response they return, so the four metadata
-/// client/provider test classes that each used to declare a private copy of
-/// this handler now share this one.
+/// An <see cref="HttpMessageHandler"/> that returns a fixed body/status for
+/// every request and records the request URIs it served.
 /// </summary>
-/// <remarks>
-/// Deliberately the minimal identical shape only. Handlers with richer capture
-/// (Igdb's <c>CapturedRequest</c>), per-URL routing (Tmdb's
-/// <c>RoutingStubHandler</c>), a response sequence (<c>SequenceHandler</c>), a
-/// login/response-building body (<c>SteamOpenIdVerifierTests</c>) or a binary
-/// payload (<c>CoverImageStoreTests</c>) each kept their own implementation —
-/// they are not this shape.
-/// </remarks>
 public sealed class StubHandler : HttpMessageHandler
 {
     private readonly string _body;

--- a/src/server/tests/Collectify.Tests/TestSupport/StubHandler.cs
+++ b/src/server/tests/Collectify.Tests/TestSupport/StubHandler.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Text;
+
+namespace Collectify.Tests.TestSupport;
+
+/// <summary>
+/// A controller-style <see cref="HttpMessageHandler"/> that returns a fixed
+/// body/status for every request and records the request URIs it served.
+/// Providers differ only by the response they return, so the four metadata
+/// client/provider test classes that each used to declare a private copy of
+/// this handler now share this one.
+/// </summary>
+/// <remarks>
+/// Deliberately the minimal identical shape only. Handlers with richer capture
+/// (Igdb's <c>CapturedRequest</c>), per-URL routing (Tmdb's
+/// <c>RoutingStubHandler</c>), a response sequence (<c>SequenceHandler</c>), a
+/// login/response-building body (<c>SteamOpenIdVerifierTests</c>) or a binary
+/// payload (<c>CoverImageStoreTests</c>) each kept their own implementation —
+/// they are not this shape.
+/// </remarks>
+public sealed class StubHandler : HttpMessageHandler
+{
+    private readonly string _body;
+    private readonly HttpStatusCode _status;
+
+    public List<string> RequestedUrls { get; } = new();
+
+    public StubHandler(string body, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        _body = body;
+        _status = status;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // AbsoluteUri keeps percent-encoding intact; ToString unescapes %20 -> space.
+        RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+        return Task.FromResult(new HttpResponseMessage(_status)
+        {
+            Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+        });
+    }
+}


### PR DESCRIPTION
Consolidates the copy-pasted `StubHandler` in the Infrastructure provider tests into one shared handler in `TestSupport/`, as called for by #96 acceptance criterion #3 / this follow-up issue.

## Scope (verbatim, minimal)
Only the **genuinely identical** shape is consolidated. Four files each declared an identical `StubHandler(string body, HttpStatusCode status = OK)` that captures `RequestedUrls` and returns `StringContent(body, "application/json")`:

- `MusicBrainzMusicProviderTests` (was :325)
- `SteamClientTests` (was :140)
- `TmdbMovieProviderTests` (was :576)
- `UpcItemDbClientTests` (was :133)

These 4 private declarations are deleted; they now resolve to the shared `TestSupport/StubHandler.cs` (namespace `Collectify.Tests.TestSupport`) via a `using` added to each file.

## Intentionally NOT consolidated (structurally different — issue says "keep per-provider response shaping where the current handlers differ")
- `IgdbGameProviderTests` — captures richer `CapturedRequest` (URL/body/ClientId/auth) + its `SequenceHandler`
- `TmdbMovieProviderTests` `RoutingStubHandler` — response selected by URL substring
- `SteamOpenIdVerifierTests` — builds an OpenID response from the request content; no URL capture
- `CoverImageStoreTests` — binary `byte[]` payload + media-type handling

## Verification
- `dotnet build` — 0 errors (3 pre-existing warnings: 2× AD0001 analyzer NRE in Collectify.Api, 1× xUnit2031 in SteamEndpointsTests)
- `dotnet test` full suite: **599 passed / 0 failed**
- Affected classes: 104 tests passed

No behavior or coverage change — the shared handler is a byte-identical transcription; behaviour preservation is by construction.