### PR TITLE
chore(client): media-registry token cleanup + structured byId noun/hint (#149)

### DIFF
--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -55,7 +55,7 @@ export default function AlbumForm({ initial, prefillLookup, prefillBarcode, subm
       fill: (draft, r) => ({ ...draft, artistName: draft.artistName || r.artistName, year: draft.year ?? r.year ?? null, label: draft.label ?? r.label ?? null }),
       shouldRun: (r) => r.provider === 'musicbrainz' && (!r.artistName || r.year == null || !r.label),
       loadingLabel: 'Loading artist & label…', successLabel: 'Populated from MusicBrainz.', notConfiguredLabel: 'MusicBrainz lookup not configured. Set the User-Agent.' },
-    byId: { label: 'MusicBrainz Release ID', lookup: lookupAlbumByMbid },
+    byId: { label: 'MusicBrainz Release ID', entityNoun: 'release', notConfiguredHint: 'MusicBrainz lookup not configured. Set the User-Agent.', lookup: lookupAlbumByMbid },
   });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => prefillEffect(prefillLookup, prefillBarcode), []);

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -78,7 +78,7 @@ export default function GameForm({ initial, prefillLookup, prefillBarcode, submi
     }),
     providerNames: ['igdb'], linkageKey: (draft) => draft.igdbId ?? null,
     setLinkageKey: (draft, value) => ({ ...draft, igdbId: value }),
-    byId: { label: 'IGDB ID', lookup: lookupGameByIgdbId },
+    byId: { label: 'IGDB ID', entityNoun: 'game', notConfiguredHint: 'IGDB lookup not configured. Set the Twitch client id and secret.', lookup: lookupGameByIgdbId },
   });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => prefillEffect(prefillLookup, prefillBarcode), []);

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -59,7 +59,7 @@ export default function MovieForm({ initial, prefillLookup, prefillBarcode, subm
       fill: (draft: Movie, r: MovieLookupResult) => ({ ...draft, director: draft.director ?? r.director ?? null, runtimeMinutes: draft.runtimeMinutes ?? r.runtimeMinutes ?? null }),
       shouldRun: (r: MovieLookupResult) => r.provider === 'tmdb' && (r.director == null || r.runtimeMinutes == null),
       loadingLabel: 'Loading director and runtime…', successLabel: 'Populated from TMDB.', notConfiguredLabel: 'TMDB lookup not configured. Set the provider key.' },
-    byId: { label, lookup },
+    byId: { label, entityNoun: 'movie', notConfiguredHint: 'TMDB lookup not configured. Set the provider key.', lookup },
   });
   const { importLookup, runById, prefillEffect, fetchState } = useLookupProtocol<'movies', Movie, MovieLookupResult>(protocolConfig(lookupMovieById, 'TMDB ID'));
   const imdbProtocol = useLookupProtocol<'movies', Movie, MovieLookupResult>(protocolConfig(lookupMovieByImdbId, 'IMDB ID'));

--- a/src/client/hooks/useLookupProtocol.test.ts
+++ b/src/client/hooks/useLookupProtocol.test.ts
@@ -26,10 +26,10 @@ describe.each(['movies', 'music', 'games'])('useLookupProtocol %s', () => {
     await act(() => s.result.current.runById('1'));
     expect(s.draft()).toMatchObject({ title: 'Found', key: '1' });
   });
-  it.each([['not-configured', 'not configured'], ['not-found', 'no ']] as const)('%s exposes outcome', async (kind, message) => {
+  it.each([['not-configured', 'provider not configured'], ['not-found', 'No widget with item 1.']] as const)('%s exposes outcome', async (kind, expected) => {
     const s = setup(vi.fn().mockResolvedValue({ kind }));
     await act(() => s.result.current.runById('1'));
-    expect(s.result.current.fetchState.message?.toLowerCase()).toContain(message);
+    expect(s.result.current.fetchState.message).toBe(expected);
     expect(s.draft().title).toBe('');
   });
   it('surfaces errors', async () => {

--- a/src/client/hooks/useLookupProtocol.test.ts
+++ b/src/client/hooks/useLookupProtocol.test.ts
@@ -14,7 +14,7 @@ function setup(lookup = vi.fn()) {
     providerNames: ['provider'],
     linkageKey: (d: Draft) => d.key,
     setLinkageKey: (d: Draft, key: string) => ({ ...d, key }),
-    byId: { label: 'item', lookup },
+    byId: { label: 'item', entityNoun: 'widget', notConfiguredHint: 'provider not configured', lookup },
   } as const;
   const hook = renderHook(() => useLookupProtocol<'movies', Draft, Result>(config));
   return { ...hook, draft: () => draft };
@@ -49,7 +49,7 @@ it('guards enrichment against a newer linkage key', async () => {
     importFields: (_d, r) => ({ title: r.title }), providerNames: ['provider'],
     linkageKey: (d) => d.key, setLinkageKey: (d, key) => ({ ...d, key }),
     enrich: { keyOf: (d) => d.key, run: (id) => id === 'old' ? pending as never : new Promise(() => undefined), fill: (d) => ({ ...d, title: 'old enriched' }), shouldRun: () => true, loadingLabel: 'loading', successLabel: 'done', notConfiguredLabel: 'no' },
-    byId: { label: 'item', lookup: vi.fn() },
+    byId: { label: 'item', entityNoun: 'widget', notConfiguredHint: 'provider not configured', lookup: vi.fn() },
   }));
   act(() => { result.current.importLookup({ title: 'old', provider: 'provider', providerKey: 'old' }); result.current.importLookup({ title: 'new', provider: 'provider', providerKey: 'new' }); });
   resolve({ kind: 'found', result: { title: 'old enriched', provider: 'provider', providerKey: 'old' } });

--- a/src/client/hooks/useLookupProtocol.ts
+++ b/src/client/hooks/useLookupProtocol.ts
@@ -18,7 +18,15 @@ export interface LookupProtocolConfig<TMedia extends MediaType, TItem, TResult> 
     successLabel: string;
     notConfiguredLabel: string;
   };
-  byId: { label: string; lookup: (id: string) => Promise<LookupByIdOutcome<TResult>> };
+  byId: {
+    /** Human prompt for the input, e.g. 'TMDB ID'. */
+    label: string;
+    /** Noun for "No <noun> with <label> …" — e.g. 'movie'. */
+    entityNoun: string;
+    /** Shown when the provider is not configured, e.g. 'TMDB lookup not configured. Set the provider key.' */
+    notConfiguredHint: string;
+    lookup: (id: string) => Promise<LookupByIdOutcome<TResult>>;
+  };
 }
 
 export function useLookupProtocol<TMedia extends MediaType, TItem, TResult>(cfg: LookupProtocolConfig<TMedia, TItem, TResult>) {
@@ -65,11 +73,9 @@ export function useLookupProtocol<TMedia extends MediaType, TItem, TResult>(cfg:
       const outcome = await cfg.byId.lookup(trimmed);
       if (outcome.kind === 'found') { importLookup(outcome.result); setFetchState({ status: 'idle', message: 'Populated.' }); }
       else if (outcome.kind === 'not-configured') {
-        const provider = cfg.byId.label.includes('MusicBrainz') ? 'MusicBrainz lookup not configured. Set the User-Agent.' : cfg.byId.label.includes('IGDB') ? 'IGDB lookup not configured. Set the Twitch client id and secret.' : 'TMDB lookup not configured. Set the provider key.';
-        setFetchState({ status: 'idle', message: provider });
+        setFetchState({ status: 'idle', message: cfg.byId.notConfiguredHint });
       } else {
-        const noun = cfg.byId.label.includes('MusicBrainz') ? 'release' : cfg.byId.label.includes('IGDB') ? 'game' : 'movie';
-        setFetchState({ status: 'idle', message: `No ${noun} with ${cfg.byId.label} ${trimmed}.` });
+        setFetchState({ status: 'idle', message: `No ${cfg.byId.entityNoun} with ${cfg.byId.label} ${trimmed}.` });
       }
     } catch (error) { setFetchState({ status: 'idle', message: (error as Error).message ?? 'Lookup failed.' }); }
   }, [importLookup]);

--- a/src/client/services/mediaRegistry.ts
+++ b/src/client/services/mediaRegistry.ts
@@ -13,13 +13,6 @@ export type MediaResultMap = {
   games: GameLookupResult;
 };
 
-/** The per-media-type collection item type. */
-export type MediaItemMap = {
-  movies: Movie;
-  music: Album;
-  games: Game;
-};
-
 export interface MediaConfig {
   /** Singular human label, e.g. 'Movie'. */
   label: string;
@@ -63,10 +56,6 @@ export interface MediaConfig {
   formComponent: ComponentType<never>;
   /** Provider canonical name used to detect the prefill provider-key, e.g. 'tmdb'. */
   providerName: string;
-  /** Lookup-result type for this media type. */
-  lookupResultType: MediaResultMap[MediaType];
-  /** Collection item type for this media type. */
-  itemType: MediaItemMap[MediaType];
 }
 
 export const MEDIA: Record<MediaType, MediaConfig> = {
@@ -82,7 +71,7 @@ export const MEDIA: Record<MediaType, MediaConfig> = {
       navActiveDesktop: 'bg-movies-light text-movies border-movies-border shadow-sm',
       navActiveMobile: 'bg-movies-light text-movies border-movies-border',
     },
-    formComponent: MovieForm, providerName: 'tmdb', lookupResultType: null!, itemType: null!,
+    formComponent: MovieForm, providerName: 'tmdb',
   },
   music: {
     label: 'Album', pluralLabel: 'Music', iconSrc: '/brand/media-music.svg', iconAlt: 'Music',
@@ -96,7 +85,7 @@ export const MEDIA: Record<MediaType, MediaConfig> = {
       navActiveDesktop: 'bg-music-light text-music border-music-border shadow-sm',
       navActiveMobile: 'bg-music-light text-music border-music-border',
     },
-    formComponent: AlbumForm, providerName: 'musicbrainz', lookupResultType: null!, itemType: null!,
+    formComponent: AlbumForm, providerName: 'musicbrainz',
   },
   games: {
     label: 'Game', pluralLabel: 'Games', iconSrc: '/brand/media-games.svg', iconAlt: 'Games',
@@ -110,6 +99,6 @@ export const MEDIA: Record<MediaType, MediaConfig> = {
       navActiveDesktop: 'bg-games-light text-games border-games-border shadow-sm',
       navActiveMobile: 'bg-games-light text-games border-games-border',
     },
-    formComponent: GameForm, providerName: 'igdb', lookupResultType: null!, itemType: null!,
+    formComponent: GameForm, providerName: 'igdb',
   },
 };


### PR DESCRIPTION
Closes #149. No behavior change.

(1) Drop the dead null! type-token fields (lookupResultType/itemType) and the unused MediaItemMap from the media registry. (2) Replace runById's human-label substring sniffing (label.includes('MusicBrainz'/'IGDB')) with structured byId entityNoun + notConfiguredHint.

Issue item 2 (collapse the three per-type hook calls on Add/Edit pages) was verified to be a net regression — TS cannot narrow a unified hook's value per branch, and the only fix is per-branch casts, the anti-pattern #99 removed. Left as-is; documented in the handout.

Verified: npm run build + npm test (16x min) green; mutation rows documented.