### PR TITLE
feat(ui): add format/platform style icons (#90)

### DIFF
--- a/src/client/components/AlbumForm.tsx
+++ b/src/client/components/AlbumForm.tsx
@@ -7,6 +7,7 @@ import OnlineSearch from './OnlineSearch';
 import BarcodeLookup from './BarcodeLookup';
 import PhotoLookup from './PhotoLookup';
 import { MUSIC_FORMATS, type Album } from '../services/types';
+import { MusicFormatIcon } from './FormatIcons';
 import { lookupAlbumByMbid, type MusicLookupResult } from '../services/lookup';
 import { useLookupProtocol } from '../hooks/useLookupProtocol';
 
@@ -116,11 +117,16 @@ export default function AlbumForm({ initial, prefillLookup, prefillBarcode, subm
               <Input type="number" value={a.year ?? ''} onChange={(e) => set('year', e.target.value ? Number(e.target.value) : null)} />
             </Field>
             <Field label="Format">
-              <Select value={a.format} onChange={(e) => set('format', e.target.value as Album['format'])}>
-                {MUSIC_FORMATS.map((f) => (
-                  <option key={f.value} value={f.value}>{f.label}</option>
-                ))}
-              </Select>
+              <div className="relative">
+                <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">
+                  <MusicFormatIcon format={a.format} className="h-4 w-4" />
+                </span>
+                <Select value={a.format} onChange={(e) => set('format', e.target.value as Album['format'])} className="pl-10">
+                  {MUSIC_FORMATS.map((f) => (
+                    <option key={f.value} value={f.value}>{f.label}</option>
+                  ))}
+                </Select>
+              </div>
             </Field>
             <Field label="Label">
               <Input value={a.label ?? ''} onChange={(e) => set('label', e.target.value || null)} />

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -13,7 +13,7 @@ import type { MediaResultMap } from '../services/mediaRegistry';
 
 interface RenderedItem {
   primary: string;
-  secondary?: string;
+  secondary?: ReactNode;
   tertiary?: ReactNode;
 }
 

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import type { ReactNode } from 'react';
 import { useList } from '../services/collection';
 import { useFiltersState } from '../services/filters';
 import { Button, Card, Input, StatusPill, TagChip, ViewSwitcher } from './ui';
@@ -13,7 +14,7 @@ import type { MediaResultMap } from '../services/mediaRegistry';
 interface RenderedItem {
   primary: string;
   secondary?: string;
-  tertiary?: string;
+  tertiary?: ReactNode;
 }
 
 interface Props<T extends MediaType> {

--- a/src/client/components/DetailView.tsx
+++ b/src/client/components/DetailView.tsx
@@ -12,6 +12,7 @@ import {
 } from '../services/types';
 import MediaIcon from './MediaIcon';
 import { MEDIA } from '../services/mediaRegistry';
+import { MovieFormatIcon, MusicFormatIcon, PlatformIcon } from './FormatIcons';
 
 interface Props<T> {
   item: T;
@@ -108,7 +109,8 @@ function MovieDetail({ item }: { item: Movie }) {
           {formats.length > 0 && (
             <div className="flex flex-wrap gap-1.5">
               {formats.map((f) => (
-                <span key={f.key} className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('movies').accent}`}>
+                <span key={f.key} className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('movies').accent}`}>
+                  <MovieFormatIcon format={f.key} className="h-3.5 w-3.5" />
                   {f.label}
                 </span>
               ))}
@@ -220,7 +222,8 @@ function MusicDetail({ item }: { item: Album }) {
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
             {item.year && <span className="shrink-0">{item.year}</span>}
             {item.format && (
-              <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('music').accent}`}>
+              <span className={`inline-flex items-center gap-1 shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('music').accent}`}>
+                <MusicFormatIcon format={item.format} className="h-3.5 w-3.5" />
                 {musicFormatLabel(item.format) ?? item.format}
               </span>
             )}
@@ -325,6 +328,10 @@ function GameDetail({ item }: { item: Game }) {
           {/* Year / Platform row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
             {item.year && <span className="shrink-0">{item.year}</span>}
+            <span className="inline-flex items-center gap-1 shrink-0">
+              <PlatformIcon platform={item.platform} className="h-4 w-4" />
+              {gamePlatformLabel(item.platform)}
+            </span>
             {item.digitalStores ? (
               <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('games').accent}`}>
                 Digital <span className="min-w-0 truncate"> · {digitalStoresLabel(item.digitalStores)}</span>

--- a/src/client/components/DetailView.tsx
+++ b/src/client/components/DetailView.tsx
@@ -56,7 +56,7 @@ function ThemedCard({ type, children, className = '' }: { type: MediaType; child
   return <Card className={className}>{children}</Card>;
 }
 
-function HeroTitle({ type, title, subtitle }: { type: MediaType; title: string; subtitle?: string | null }) {
+function HeroTitle({ type, title, subtitle }: { type: MediaType; title: string; subtitle?: ReactNode }) {
   return (
     <div className="flex items-start gap-3 min-w-0">
       <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-card shadow-sm">
@@ -322,16 +322,21 @@ function GameDetail({ item }: { item: Game }) {
         </div>
         <div className="min-w-0 flex-1 space-y-3">
           <div>
-            <HeroTitle type="games" title={item.title} subtitle={gamePlatformLabel(item.platform)} />
+            <HeroTitle
+              type="games"
+              title={item.title}
+              subtitle={
+                <span className="inline-flex items-center gap-1.5">
+                  <PlatformIcon platform={item.platform} className="h-4 w-4" />
+                  {gamePlatformLabel(item.platform)}
+                </span>
+              }
+            />
           </div>
 
           {/* Year / Platform row */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-text-secondary">
             {item.year && <span className="shrink-0">{item.year}</span>}
-            <span className="inline-flex items-center gap-1 shrink-0">
-              <PlatformIcon platform={item.platform} className="h-4 w-4" />
-              {gamePlatformLabel(item.platform)}
-            </span>
             {item.digitalStores ? (
               <span className={`inline-flex items-center shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${detailTheme('games').accent}`}>
                 Digital <span className="min-w-0 truncate"> · {digitalStoresLabel(item.digitalStores)}</span>

--- a/src/client/components/FormatIcons.test.tsx
+++ b/src/client/components/FormatIcons.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { MovieFormatIcon, MusicFormatIcon, PlatformIcon } from './FormatIcons';
+
+describe('FormatIcons', () => {
+  it('renders an svg for each movie format', () => {
+    for (const format of ['Dvd', 'BluRay', 'UhdBluRay', 'Vhs', 'Digital'] as const) {
+      const { container } = render(<MovieFormatIcon format={format} />);
+      expect(container.querySelector('svg'), format).not.toBeNull();
+    }
+  });
+
+  it('renders nothing for movie format None (graceful, no blank box)', () => {
+    const { container } = render(<MovieFormatIcon format="None" />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders an svg for each music format', () => {
+    for (const format of ['Cd', 'Vinyl', 'Other'] as const) {
+      const { container } = render(<MusicFormatIcon format={format} />);
+      expect(container.querySelector('svg'), format).not.toBeNull();
+    }
+  });
+
+  it('renders a platform icon for every GamePlatform value and falls back to a generic console for uncurated ones', () => {
+    const platforms = [
+      'Other', 'Pc', 'Mac', 'Mobile',
+      'XboxOriginal', 'Xbox360', 'XboxOne', 'XboxSeriesXS',
+      'Ps1', 'Ps2', 'Ps3', 'Ps4', 'Ps5', 'Psp', 'PsVita',
+      'Nes', 'Snes', 'N64', 'GameCube', 'Wii', 'WiiU', 'Switch', 'Switch2',
+      'GameBoy', 'GameBoyColor', 'GameBoyAdvance', 'NintendoDs', 'Nintendo3Ds',
+      'SegaGenesis', 'SegaSaturn', 'SegaDreamcast',
+    ] as const;
+    for (const p of platforms) {
+      const { container, unmount } = render(<PlatformIcon platform={p} />);
+      expect(container.querySelector('svg'), p).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('honors a custom className on the svg (size override)', () => {
+    const { container } = render(<PlatformIcon platform="Ps5" className="h-4 w-4" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toBe('h-4 w-4');
+  });
+
+  it('uses a distinct generic console silhouette for uncurated platforms (fallback is exercised)', () => {
+    // Ps5 maps to the curated 'tower' silhouette; Other has no entry and must
+    // fall through to the generic console. If a platform were ever dropped from
+    // PLATFORM_SHAPE, its icon would silently collapse to the generic fallback —
+    // this assertion pins that these two do NOT share a path.
+    const curated = render(<PlatformIcon platform="Ps5" />);
+    const fallback = render(<PlatformIcon platform="Other" />);
+    const curatedPath = curated.container.querySelector('path')?.getAttribute('d');
+    const fallbackPath = fallback.container.querySelector('path')?.getAttribute('d');
+    expect(curatedPath).not.toBeNull();
+    expect(curatedPath).not.toBe(fallbackPath);
+  });
+});

--- a/src/client/components/FormatIcons.tsx
+++ b/src/client/components/FormatIcons.tsx
@@ -1,0 +1,188 @@
+import type { MovieFormat, MusicFormat, GamePlatform } from '../services/types';
+
+/**
+ * Small inline-SVG format/platform icons for Collectify.
+ *
+ * Every icon is monochrome (inherits `currentColor`), decorative
+ * (aria-hidden), and sized by a `className` prop — default ~20px. No external
+ * icon library: everything is hand-drawn here so the set stays licensing-safe
+ * (silhouettes, not brand logos).
+ *
+ * Graceful fallback rule: a member with no designed variant renders `null`
+ * (the caller keeps showing its text label, no broken image / blank box) for
+ * formats; platforms fall back to a generic console silhouette.
+ */
+
+type IconProps = { className?: string };
+
+function Disc({ className, children }: IconProps & { children?: React.ReactNode }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      aria-hidden
+      className={className ?? 'h-5 w-5'}
+    >
+      <circle cx="10" cy="10" r="8" />
+      <circle cx="10" cy="10" r="4.2" opacity="0.65" />
+      {children}
+    </svg>
+  );
+}
+
+// ─── Movie formats ────────────────────────────────────────────────
+const MOVIE_FMT: Record<Exclude<MovieFormat, 'None'>, (p: IconProps) => React.ReactElement> = {
+  Dvd: ({ className }) => (
+    <Disc className={className}>
+      <circle cx="10" cy="10" r="1.4" fill="currentColor" stroke="none" />
+      <text x="10" y="12.2" textAnchor="middle" fontSize="3.6" fontWeight="700" fill="currentColor" stroke="none">
+        DVD
+      </text>
+    </Disc>
+  ),
+  BluRay: ({ className }) => (
+    <Disc className={className}>
+      <circle cx="10" cy="10" r="5.6" opacity="0.4" />
+      <text x="10" y="12.2" textAnchor="middle" fontSize="3.6" fontWeight="700" fill="currentColor" stroke="none">
+        BD
+      </text>
+    </Disc>
+  ),
+  UhdBluRay: ({ className }) => (
+    <Disc className={className}>
+      <text x="10" y="12.4" textAnchor="middle" fontSize="4.4" fontWeight="800" fill="currentColor" stroke="none">
+        4K
+      </text>
+    </Disc>
+  ),
+  Vhs: ({ className }) => (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden className={className ?? 'h-5 w-5'}>
+      {/* Cassette outline */}
+      <rect x="2.5" y="5.5" width="15" height="9" rx="1.4" />
+      {/* Label window */}
+      <rect x="5.5" y="8" width="9" height="2.6" rx="0.6" opacity="0.6" />
+      {/* Two reels */}
+      <circle cx="6.8" cy="12" r="1" fill="currentColor" stroke="none" opacity="0.7" />
+      <circle cx="13.2" cy="12" r="1" fill="currentColor" stroke="none" opacity="0.7" />
+    </svg>
+  ),
+  Digital: ({ className }) => (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden className={className ?? 'h-5 w-5'}>
+      {/* Cloud outline */}
+      <path d="M6 15.5a3.6 3.6 0 0 1-.4-7.18 4.6 4.6 0 0 1 8.8 1.34A3.1 3.1 0 0 1 14 15.5H6Z" />
+      {/* Download arrow */}
+      <path d="M10 12.4V6.8M8 10.6l2 2 2-2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ),
+};
+
+export function MovieFormatIcon({ format, className }: { format: MovieFormat } & IconProps) {
+  if (format === 'None') return null;
+  const render = MOVIE_FMT[format];
+  if (!render) return null;
+  return render({ className });
+}
+
+// ─── Music formats ────────────────────────────────────────────────
+const MUSIC_FMT: Record<MusicFormat, (p: IconProps) => React.ReactElement> = {
+  Cd: ({ className }) => (
+    <Disc className={className}>
+      <circle cx="10" cy="10" r="2.6" opacity="0.55" />
+      <circle cx="10" cy="10" r="1.1" fill="currentColor" stroke="none" />
+    </Disc>
+  ),
+  Vinyl: ({ className }) => (
+    <Disc className={className}>
+      {/* Grooves */}
+      <circle cx="10" cy="10" r="6" opacity="0.4" />
+      <circle cx="10" cy="10" r="4.6" opacity="0.3" />
+      {/* Center label */}
+      <circle cx="10" cy="10" r="2.4" fill="currentColor" stroke="none" opacity="0.55" />
+      <circle cx="10" cy="10" r="0.9" fill="none" stroke="currentColor" />
+    </Disc>
+  ),
+  Other: ({ className }) => (
+    <Disc className={className}>
+      <circle cx="10" cy="10" r="2" opacity="0.5" />
+      <text x="10" y="12.1" textAnchor="middle" fontSize="3.2" fontWeight="700" fill="currentColor" stroke="none">
+        ?
+      </text>
+    </Disc>
+  ),
+};
+
+export function MusicFormatIcon({ format, className }: { format: MusicFormat } & IconProps) {
+  return MUSIC_FMT[format]?.({ className }) ?? null;
+}
+
+// ─── Game platforms ───────────────────────────────────────────────
+// Curated family silhouettes + generic fallback (issue approach 1).
+function ConsoleSilhouette({ className, shape }: IconProps & { shape: 'tower' | 'slab' | 'handheld' | 'arcade' | 'monitor' | 'phone' }) {
+  const body: React.ReactNode =
+    shape === 'tower' ? (
+      <path d="M5 3.5h10l1.2 3.6v9.4a2 2 0 0 1-2 2H5.8a2 2 0 0 1-2-2V7.1L5 3.5Z" />
+    ) : shape === 'slab' ? (
+      <rect x="3" y="6" width="14" height="8.5" rx="1.6" />
+    ) : shape === 'handheld' ? (
+      <path d="M3.4 8.2C3.4 6.5 5 5.2 6.9 5.2h6.2c1.9 0 3.5 1.3 3.5 3v2.6c0 1.7-1.6 3-3.5 3H6.9c-1.9 0-3.5-1.3-3.5-3V8.2Z" />
+    ) : shape === 'arcade' ? (
+      <path d="M4.5 8.2 6.2 5h7.6l1.7 3.2 1.5 3.3v2.6a1.6 1.6 0 0 1-1.6 1.6H4.6a1.6 1.6 0 0 1-1.6-1.6v-2.6l1.5-3.3Z" />
+    ) : shape === 'monitor' ? (
+      <path d="M2.8 4.6h14.4v9H2.8v-9Z M6.5 15.6h7M10 13.6v2" />
+    ) : (
+      <path d="M5.5 7.2c-1.4 0-2.5 1.1-2.5 2.5v1.4c0 1.4 1.1 2.5 2.5 2.5h9c1.4 0 2.5-1.1 2.5-2.5V9.7c0-1.4-1.1-2.5-2.5-2.5h-9Z M6 9.6v1M14 9.6v1" />
+    );
+
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.3" aria-hidden className={className ?? 'h-5 w-5'}>
+      {body}
+    </svg>
+  );
+}
+
+type ConsoleShape = 'tower' | 'slab' | 'handheld' | 'arcade' | 'monitor' | 'phone';
+
+const PLATFORM_SHAPE: Record<string, ConsoleShape> = {
+  // Computer / mobile
+  Pc: 'monitor',
+  Mac: 'monitor',
+  Mobile: 'phone',
+  // Xbox — rounded slab console
+  XboxOriginal: 'slab',
+  Xbox360: 'slab',
+  XboxOne: 'slab',
+  XboxSeriesXS: 'slab',
+  // PlayStation — tower-ish console
+  Ps1: 'tower',
+  Ps2: 'tower',
+  Ps3: 'tower',
+  Ps4: 'tower',
+  Ps5: 'tower',
+  Psp: 'handheld',
+  PsVita: 'handheld',
+  // Nintendo
+  Nes: 'arcade',
+  Snes: 'arcade',
+  N64: 'arcade',
+  GameCube: 'slab',
+  Wii: 'slab',
+  WiiU: 'handheld',
+  Switch: 'handheld',
+  Switch2: 'handheld',
+  GameBoy: 'handheld',
+  GameBoyColor: 'handheld',
+  GameBoyAdvance: 'handheld',
+  NintendoDs: 'handheld',
+  Nintendo3Ds: 'handheld',
+  // Sega
+  SegaGenesis: 'slab',
+  SegaSaturn: 'slab',
+  SegaDreamcast: 'slab',
+};
+
+export function PlatformIcon({ platform, className }: { platform: GamePlatform } & IconProps) {
+  const shape = PLATFORM_SHAPE[platform] ?? 'arcade'; // generic console fallback
+  return <ConsoleSilhouette shape={shape} className={className} />;
+}

--- a/src/client/components/GameForm.tsx
+++ b/src/client/components/GameForm.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Button, CoverPreview, ExternalIdField, Field, Input, SearchableSelect, SectionHeading, Select, Textarea } from './ui';
+import {
+  Button,
+  CoverPreview,
+  ExternalIdField,
+  Field,
+  Input,
+  SearchableSelect,
+  SectionHeading,
+  Select,
+  Textarea,
+} from './ui';
+import { PlatformIcon } from './FormatIcons';
 import CoverEditor from './CoverEditor';
 import CoverFormLayout from './CoverFormLayout';
 import PersonalAcquisitionSection from './PersonalAcquisitionSection';
@@ -150,12 +161,19 @@ export default function GameForm({ initial, prefillLookup, prefillBarcode, submi
               <Input value={g.title} onChange={(e) => set('title', e.target.value)} required />
             </Field>
             <Field label="Platform">
-              <SearchableSelect
-                value={g.platform}
-                onChange={(v) => set('platform', v as GamePlatform)}
-                options={GAME_PLATFORMS}
-                placeholder="Type to search platforms…"
-              />
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 text-text-secondary">
+                  <PlatformIcon platform={g.platform} className="h-4 w-4" />
+                </span>
+                <div className="flex-1">
+                  <SearchableSelect
+                    value={g.platform}
+                    onChange={(v) => set('platform', v as GamePlatform)}
+                    options={GAME_PLATFORMS}
+                    placeholder="Type to search platforms…"
+                  />
+                </div>
+              </div>
               {g.platformLegacy && (
                 // Stickier than a generic placeholder -- surfaces the
                 // original free-text so the user can see what they had

--- a/src/client/components/MovieForm.tsx
+++ b/src/client/components/MovieForm.tsx
@@ -7,6 +7,7 @@ import OnlineSearch from './OnlineSearch';
 import BarcodeLookup from './BarcodeLookup';
 import PhotoLookup from './PhotoLookup';
 import { MOVIE_FORMAT_FLAGS, WATCH_STATUSES, type Movie, type WatchStatus } from '../services/types';
+import { MovieFormatIcon } from './FormatIcons';
 import { lookupMovieById, lookupMovieByImdbId, type MovieLookupResult } from '../services/lookup';
 import { useLookupProtocol } from '../hooks/useLookupProtocol';
 
@@ -161,8 +162,9 @@ export default function MovieForm({ initial, prefillLookup, prefillBarcode, subm
                 type="button"
                 key={f.key}
                 onClick={() => toggleFormat(f.value)}
-                className={`inline-flex min-h-[44px] items-center rounded-xl border px-3 text-sm font-semibold transition-colors ${checked ? 'category-active' : 'border-border bg-input-bg text-text-primary category-hover-soft'}`}
+                className={`inline-flex min-h-[44px] items-center gap-1.5 rounded-xl border px-3 text-sm font-semibold transition-colors ${checked ? 'category-active' : 'border-border bg-input-bg text-text-primary category-hover-soft'}`}
               >
+                <MovieFormatIcon format={f.key} className="h-4 w-4" />
                 {f.label}
               </button>
             );

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -33,19 +33,20 @@ export default function GamesList() {
             g.platform && g.platform !== 'Other'
               ? gamePlatformLabel(g.platform)
               : g.platformLegacy ?? null;
+          const year = g.year ? String(g.year) : null;
           return {
             primary: g.title,
-            secondary: [platform, g.year].filter(Boolean).join(' · '),
-            tertiary: (
+            secondary: (
               <>
-                {g.platform && (
+                {g.platform && g.platform !== 'Other' && (
                   <PlatformIcon platform={g.platform} className="mr-1 inline h-3.5 w-3.5 align-[-2px] text-text-secondary" />
                 )}
-                {g.digitalStores
-                  ? `Digital · ${digitalStoresLabel(g.digitalStores)}`
-                  : 'Physical'}
+                {[platform, year].filter(Boolean).join(' · ')}
               </>
             ),
+            tertiary: g.digitalStores
+              ? `Digital · ${digitalStoresLabel(g.digitalStores)}`
+              : 'Physical',
           };
         }}
       />

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -34,16 +34,24 @@ export default function GamesList() {
               ? gamePlatformLabel(g.platform)
               : g.platformLegacy ?? null;
           const year = g.year ? String(g.year) : null;
+          const meta = [platform, year].filter(Boolean).join(' · ');
+          const showIcon = Boolean(g.platform && g.platform !== 'Other');
           return {
             primary: g.title,
-            secondary: (
-              <>
-                {g.platform && g.platform !== 'Other' && (
-                  <PlatformIcon platform={g.platform} className="mr-1 inline h-3.5 w-3.5 align-[-2px] text-text-secondary" />
-                )}
-                {[platform, year].filter(Boolean).join(' · ')}
-              </>
-            ),
+            // Only emit a secondary row when there's metadata to show; an empty
+            // React fragment is truthy and would render a blank row in every
+            // card variant (regression guard: previous code returned the falsy
+            // empty string '' for unclassified games).
+            secondary: meta
+              ? (
+                <>
+                  {showIcon && (
+                    <PlatformIcon platform={g.platform} className="mr-1 inline h-3.5 w-3.5 align-[-2px] text-text-secondary" />
+                  )}
+                  {meta}
+                </>
+              )
+              : undefined,
             tertiary: g.digitalStores
               ? `Digital · ${digitalStoresLabel(g.digitalStores)}`
               : 'Physical',

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import CollectionList from '../components/CollectionList';
+import { PlatformIcon } from '../components/FormatIcons';
 import { digitalStoresLabel, gamePlatformLabel, type Game } from '../services/types';
 
 export default function GamesList() {
@@ -35,9 +36,16 @@ export default function GamesList() {
           return {
             primary: g.title,
             secondary: [platform, g.year].filter(Boolean).join(' · '),
-            tertiary: g.digitalStores
-              ? `Digital · ${digitalStoresLabel(g.digitalStores)}`
-              : 'Physical',
+            tertiary: (
+              <>
+                {g.platform && (
+                  <PlatformIcon platform={g.platform} className="mr-1 inline h-3.5 w-3.5 align-[-2px] text-text-secondary" />
+                )}
+                {g.digitalStores
+                  ? `Digital · ${digitalStoresLabel(g.digitalStores)}`
+                  : 'Physical'}
+              </>
+            ),
           };
         }}
       />

--- a/src/client/pages/MoviesList.tsx
+++ b/src/client/pages/MoviesList.tsx
@@ -1,4 +1,5 @@
 import CollectionList from '../components/CollectionList';
+import { MovieFormatIcon } from '../components/FormatIcons';
 import { MOVIE_FORMAT_FLAGS, type Movie } from '../services/types';
 
 export default function MoviesList() {
@@ -9,11 +10,21 @@ export default function MoviesList() {
       newPath="/movies/new"
       category="movies"
       renderItem={(m: Movie) => {
-        const fmts = MOVIE_FORMAT_FLAGS.filter((f) => ((m.formats ?? 0) & f.value) !== 0).map((f) => f.label).join(', ');
+        const fmts = MOVIE_FORMAT_FLAGS.filter((f) => ((m.formats ?? 0) & f.value) !== 0);
         return {
           primary: m.title,
           secondary: [m.year, m.director].filter(Boolean).join(' · '),
-          tertiary: fmts || undefined,
+          tertiary:
+            fmts.length > 0 ? (
+              <span className="inline-flex items-center gap-1">
+                {fmts.map((f) => (
+                  <span key={f.key} className="inline-flex items-center gap-0.5" title={f.label}>
+                    <MovieFormatIcon format={f.key} className="h-3.5 w-3.5" />
+                    <span>{f.label}</span>
+                  </span>
+                ))}
+              </span>
+            ) : undefined,
         };
       }}
     />

--- a/src/client/pages/MusicList.tsx
+++ b/src/client/pages/MusicList.tsx
@@ -1,4 +1,5 @@
 import CollectionList from '../components/CollectionList';
+import { MusicFormatIcon } from '../components/FormatIcons';
 import { musicFormatLabel, type Album } from '../services/types';
 
 export default function MusicList() {
@@ -8,11 +9,20 @@ export default function MusicList() {
       title="Music"
       newPath="/music/new"
       category="music"
-      renderItem={(a: Album) => ({
-        primary: a.title,
-        secondary: [a.artistName, a.year].filter(Boolean).join(' · '),
-        tertiary: musicFormatLabel(a.format),
-      })}
+      renderItem={(a: Album) => {
+        const label = musicFormatLabel(a.format);
+        return {
+          primary: a.title,
+          secondary: [a.artistName, a.year].filter(Boolean).join(' · '),
+          tertiary:
+            label ? (
+              <span className="inline-flex items-center gap-1">
+                <MusicFormatIcon format={a.format} className="h-3.5 w-3.5" />
+                {label}
+              </span>
+            ) : undefined,
+        };
+      }}
     />
   );
 }


### PR DESCRIPTION
Closes #90

## What
Add small inline-SVG style icons for movie formats, music formats and game
platforms, shown alongside their text labels across the detail view, edit forms
and list cards — so formats/platforms read at a glance instead of text-only.

- **New `src/client/components/FormatIcons.tsx`** — `MovieFormatIcon`,
  `MusicFormatIcon`, `PlatformIcon`. All monochrome (`currentColor`), ~20px
  default (callers size down to ~14-16px in lists/forms), **no external icon
  library** (hand-drawn licensing-safe silhouettes).
  - Movie: Dvd / BluRay / UhdBluRay / Vhs / Digital
  - Music: Cd / Vinyl / Other
  - Game platforms: curated *family* silhouettes (console/PC/mobile/handheld)
    + generic console fallback internally for uncurated members (issue approach 1).
  - Graceful: `None`/unknown format renders nothing; `platform` always falls
    back to a generic console (no blank boxes).
- **Detail view** (`DetailView.tsx`): icon prepended to movie format pills,
  music format pill, and game platform row.
- **Edit forms**: `MovieForm` format-toggles, `AlbumForm` format select (inline
  overlay icon), `GameForm` platform icon beside the searchable select (shared
  `SearchableSelect` primitive left untouched).
- **List cards**: `MoviesList`/`MusicList`/`GamesList` tertiary line shows an
  icon alongside the label — `CollectionList.RenderedItem.tertiary` widened
  `string` → `React.ReactNode` (non-breaking; only 3 consumers).

Explicitly **out of scope** per issue: DigitalStore icons, filter-panel icons.

## Verification (all driver-run)
- `tsc -b` clean; `vite build` clean.
- Client tests: **168 → 174** (6 new FormatIcons tests: per-value render, `None`
  → null, per-platform render incl. fallback, className override, curated-vs-fallback
  distinct silhouette). Ledger delta +6 = added.
- Mutation M1: dropped `Ps5` from the platform shape map → the new
  "curated-vs-fallback distinct" test goes RED; restored → green. Proves that
  guard is live.
- Note: an M2 attempt on the `None` short-circuit compiled as a **no-op/substituted**
  mutant (explicit `None` check is redundant with the `!render` fallback since
  `None` isn't a key). The `None → null` behavior is correct and tested, just via
  the `!render` path — recorded, not a defect.

Client-only: no server files touched.