### PR TITLE
fix(steam): persist ReleaseDate from SteamReleaseDate on import (#156)

### DIFF
--- a/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
@@ -546,6 +546,10 @@ public sealed class SteamStoreImportService
         Developer = FirstOrNull(meta?.BasicInfo?.Developers?.FirstOrDefault()?.Name, 500),
         Publisher = FirstOrNull(meta?.BasicInfo?.Publishers?.FirstOrDefault()?.Name, 500),
         Year = ToYear(meta?.Release?.SteamReleaseDate ?? 0),
+        // SteamReleaseDate is a unix timestamp with day granularity; land its UTC
+        // calendar date on the full ReleaseDate field (#156), not just the
+        // derived Year above. Null when Steam omits a release date (0 / invalid).
+        ReleaseDate = ToDateOnly(meta?.Release?.SteamReleaseDate ?? 0),
         Description = FirstOrNull(meta?.BasicInfo?.ShortDescription, 2000),
         AcquisitionSource = "Steam Import",
     };

--- a/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
@@ -546,9 +546,6 @@ public sealed class SteamStoreImportService
         Developer = FirstOrNull(meta?.BasicInfo?.Developers?.FirstOrDefault()?.Name, 500),
         Publisher = FirstOrNull(meta?.BasicInfo?.Publishers?.FirstOrDefault()?.Name, 500),
         Year = ToYear(meta?.Release?.SteamReleaseDate ?? 0),
-        // SteamReleaseDate is a unix timestamp with day granularity; land its UTC
-        // calendar date on the full ReleaseDate field (#156), not just the
-        // derived Year above. Null when Steam omits a release date (0 / invalid).
         ReleaseDate = ToDateOnly(meta?.Release?.SteamReleaseDate ?? 0),
         Description = FirstOrNull(meta?.BasicInfo?.ShortDescription, 2000),
         AcquisitionSource = "Steam Import",

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -270,6 +270,9 @@ public class SteamEndpointsTests
         Assert.Equal("Supergiant Games", game.Developer);
         Assert.Equal("Supergiant Games", game.Publisher);
         Assert.Equal(2021, game.Year);
+        // Steam's SteamReleaseDate (unix: 1609459200 = 2021-01-01) must land on
+        // the full ReleaseDate, not just the derived Year. Regression for #156.
+        Assert.Equal(new DateOnly(2021, 1, 1), game.ReleaseDate);
         Assert.Equal("Defy the god of the dead.", game.Description);
     }
 

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -270,8 +270,6 @@ public class SteamEndpointsTests
         Assert.Equal("Supergiant Games", game.Developer);
         Assert.Equal("Supergiant Games", game.Publisher);
         Assert.Equal(2021, game.Year);
-        // Steam's SteamReleaseDate (unix: 1609459200 = 2021-01-01) must land on
-        // the full ReleaseDate, not just the derived Year. Regression for #156.
         Assert.Equal(new DateOnly(2021, 1, 1), game.ReleaseDate);
         Assert.Equal("Defy the god of the dead.", game.Description);
     }

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -302,6 +302,8 @@ public class SteamEndpointsTests
         Assert.Null(game.Developer);
         Assert.Null(game.Publisher);
         Assert.Null(game.Year);
+        // No browse metadata -> ReleaseDate stays null too, not just Year (#156).
+        Assert.Null(game.ReleaseDate);
         Assert.Null(game.Description);
     }
 


### PR DESCRIPTION
Closes #156

## What
`SteamStoreImportService.NewImportedGame` derived only the release **Year** from Steam's `meta.Release.SteamReleaseDate`; the full nullable `Game.ReleaseDate` field (added in #88) stayed `null` until manual edit or a provider backfill. This lands the UTC calendar date on `ReleaseDate`.

## Fix
```csharp
ReleaseDate = ToDateOnly(meta?.Release?.SteamReleaseDate ?? 0),
```
Reuses the existing `ToDateOnly(long)` helper (already used for `LastPlayedOn`). `Game.ReleaseDate` is `DateOnly?`; `ToDateOnly` yields `DateOnly?` and degrades to `null` when Steam omits the date (unix 0 / invalid).

> Note: the issue's suggested line `FromUnixTimeSecondsOrNull(...)?.UtcDateTime.Date` was **not** used — it yields `DateTime`, which has no implicit conversion to `DateOnly?` and would not compile. `ToDateOnly` is the correct, existing mirror.

## Test
`Import_CapturesRichMetadataFromStoreBrowse` now asserts `ReleaseDate == new DateOnly(2021, 1, 1)` from `SteamReleaseDate = 1609459200`.
- **Red** before the fix: `Assert.Equal() Failure — Expected 1/1/2021, Actual: null` (exact #156 symptom).
- **Green** after the fix.
- Metadata-unavailable path (`Import_ProceedsWhenStoreBrowseMetadataUnavailable`) stays green → ReleaseDate remains null when no metadata (positive control).

## Verification
- Release build: 0 errors (3 pre-existing warnings — 2× AD0001 analyzer NRE in Api, 1× xUnit2031 at line 725; none introduced here).
- `Collectify.Tests`: **623 passed / 0 failed**.
- Mutation M1 (remove the `ReleaseDate` line, comment-only so it compiles): named test goes red at line 275 (`Expected 1/1/2021, Actual: null`), restored, rebuild clean.
- `Collectify.PostgresTests` (9 failures) = Docker Testcontainers unavailable here (`/var/run/docker.sock`) — environment-only, pre-existing, unrelated to this server change.

Server-only change; no client/enum-parity impact.

**Phase 13: merge is the caller's ⛔ gate.**---

## Independent review (feature-driver round)

Independent reviewer on the regression test + fix, head `9138ced`: **no merge-blocking findings**. One FOLLOW-UP pinned and applied:
- `Import_ProceedsWhenStoreBrowseMetadataUnavailable` now asserts `ReleaseDate` is null (previously only Year/Developer/Publisher/Description). Mutation M2 (ReleaseDate defaulted to unix-1 in the no-metadata path) goes red at that exact assertion (`Actual: 1/1/1970`), proving the pin is live.

New head: `349ddc0`. Full suite 623/623, Release build 0 errors.