### PR TITLE
feat: bulk update of movies, music and games (#89)

### DIFF
--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -120,6 +120,26 @@ describe('CollectionList — bulk select + update', () => {
     });
   });
 
+  it('Confirm is disabled until a field is set, and enables once one is', async () => {
+    const fetchSpy = mockFetch();
+    renderList();
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]);
+    await user.click(screen.getByRole('button', { name: 'Edit selected' }));
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(confirmButton);
+    expect(fetchSpy.mock.calls.some(([u]) => String(u) === '/api/movies/bulk')).toBe(false);
+
+    await user.click(screen.getByRole('radio', { name: '7 of 10' }));
+    expect(confirmButton).not.toBeDisabled();
+  });
+
   it('Cancel closes the modal and sends nothing', async () => {
     const fetchSpy = mockFetch();
     renderList();

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CollectionList from './CollectionList';
+import type { Movie } from '../services/types';
+
+const FIXTURE_MOVIES: Movie[] = [
+  { id: 1, title: 'Inception', formats: 2, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
+  { id: 2, title: 'Heat', formats: 1, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
+];
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function mockFetch(onBulk?: () => unknown) {
+  const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (method === 'GET' && url === '/api/movies') {
+      return jsonResponse(FIXTURE_MOVIES);
+    }
+    if (method === 'PATCH' && url === '/api/movies/bulk') {
+      return jsonResponse(onBulk ? onBulk() : []);
+    }
+    throw new Error(`Unexpected fetch: ${method} ${url}`);
+  });
+  globalThis.fetch = spy as unknown as typeof fetch;
+  return spy;
+}
+
+function renderList() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <CollectionList
+          type="movies"
+          title="Movies"
+          newPath="/movies/new"
+          category="movies"
+          renderItem={(m: Movie) => ({ primary: m.title })}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('CollectionList — bulk select + update', () => {
+  it('shows the bulk bar with the correct count when a card is selected, and hides it on deselect', async () => {
+    mockFetch();
+    renderList();
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]);
+
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await user.click(checkboxes[0]);
+    expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+  });
+
+  it('"Select all on current page" toggles every rendered card', async () => {
+    mockFetch();
+    renderList();
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const selectAll = screen.getByLabelText('Select all on current page');
+
+    await user.click(selectAll);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+    await user.click(selectAll);
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+  });
+
+  it('confirming the modal issues PATCH movies/bulk with only the set fields, then refetches the list', async () => {
+    const fetchSpy = mockFetch();
+    renderList();
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    expect(fetchSpy.mock.calls.filter(([u]) => String(u) === '/api/movies')).toHaveLength(1);
+
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]);
+    await user.click(screen.getByRole('button', { name: 'Edit selected' }));
+
+    await user.click(screen.getByRole('radio', { name: '7 of 10' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      const bulkCall = fetchSpy.mock.calls.find(([u]) => String(u) === '/api/movies/bulk');
+      expect(bulkCall).toBeDefined();
+    });
+
+    const [, init] = fetchSpy.mock.calls.find(([u]) => String(u) === '/api/movies/bulk')!;
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(init!.body as string)).toEqual({ ids: [1], updates: { personalRating: 7 } });
+
+    // Modal closes and selection clears.
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument());
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+
+    // The bulk mutation invalidates the list query, triggering a refetch.
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.filter(([u]) => String(u) === '/api/movies')).toHaveLength(2);
+    });
+  });
+
+  it('Cancel closes the modal and sends nothing', async () => {
+    const fetchSpy = mockFetch();
+    renderList();
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]);
+    await user.click(screen.getByRole('button', { name: 'Edit selected' }));
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
+    expect(fetchSpy.mock.calls.some(([u]) => String(u) === '/api/movies/bulk')).toBe(false);
+    // Selection (and thus the bulk bar) survives a cancel — only the modal closes.
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -157,4 +157,65 @@ describe('CollectionList — bulk select + update', () => {
     // Selection (and thus the bulk bar) survives a cancel — only the modal closes.
     expect(screen.getByText('1 selected')).toBeInTheDocument();
   });
+
+  it('drops a selection that falls out of the result set before a bulk edit is confirmed', async () => {
+    // useList is mocked directly (network-driven query-key changes leave
+    // `data` transiently undefined, which would mask what this test checks);
+    // this gives full control over `list.data` with no loading gap.
+    let currentData: Movie[] = FIXTURE_MOVIES;
+    const bulkMutate = vi.fn((_vars: unknown, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+
+    vi.doMock('../services/collection', async () => {
+      const actual = await vi.importActual<typeof import('../services/collection')>('../services/collection');
+      return {
+        ...actual,
+        useList: () => ({ data: currentData, isLoading: false, error: null }),
+        useBulkUpdate: () => ({ mutate: bulkMutate, isPending: false, isError: false, error: null }),
+      };
+    });
+    vi.resetModules();
+    const { default: MockedCollectionList } = await import('./CollectionList');
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const buildElement = () => (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <MockedCollectionList
+            type="movies"
+            title="Movies"
+            newPath="/movies/new"
+            category="movies"
+            renderItem={(m: Movie) => ({ primary: m.title })}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(buildElement());
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]); // Inception (id 1)
+    await user.click(checkboxes[1]); // Heat (id 2)
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+    // Simulate a search/filter change narrowing the result set: Heat (id 2) drops out.
+    currentData = FIXTURE_MOVIES.filter((m) => m.title === 'Inception');
+    rerender(buildElement());
+
+    await waitFor(() => expect(screen.queryByText('Heat')).not.toBeInTheDocument());
+    // The stale selection (Heat) must have been dropped; Inception stays selected.
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit selected' }));
+    await user.click(screen.getByRole('radio', { name: '7 of 10' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(bulkMutate).toHaveBeenCalledWith({ ids: [1], updates: { personalRating: 7 } }, expect.any(Object));
+
+    vi.doUnmock('../services/collection');
+    vi.resetModules();
+  });
 });

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -266,6 +266,11 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
   };
   const closeBulkEdit = () => setBulkModalOpen(false);
 
+  const hasBulkEdit = Boolean(
+    bulkStatus || bulkRating != null || bulkTags.length > 0 || bulkAcquiredOn
+      || (category === 'movies' && bulkWatchStatus),
+  );
+
   const confirmBulkEdit = () => {
     const updates: BulkUpdates = {};
     if (bulkStatus) updates.status = bulkStatus;
@@ -413,7 +418,7 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
 
             <div className="flex justify-end gap-2">
               <Button type="button" variant="secondary" onClick={closeBulkEdit}>Cancel</Button>
-              <Button type="button" onClick={confirmBulkEdit} disabled={bulkUpdate.isPending}>Confirm</Button>
+              <Button type="button" onClick={confirmBulkEdit} disabled={bulkUpdate.isPending || !hasBulkEdit}>Confirm</Button>
             </div>
           </Card>
         </div>

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { useState, type ReactNode } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { useBulkUpdate, useList, type BulkUpdates } from '../services/collection';
 import { useFiltersState } from '../services/filters';
 import { ApiError } from '../services/client';
@@ -239,6 +239,23 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
       return next;
     });
   };
+  // Bulk selection / edit — drop selections that leave the current result set.
+  const shownIds = new Set(
+    items.map((item) => (item as BaseItem).id).filter((id): id is number => id != null),
+  );
+  useEffect(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      let changed = false;
+      const next = new Set<number>();
+      for (const id of prev) {
+        if (shownIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items]);
   const clearSelection = () => setSelected(new Set());
 
   const allIds = items

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -1,14 +1,22 @@
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import type { ReactNode } from 'react';
-import { useList } from '../services/collection';
+import { useState, type ReactNode } from 'react';
+import { useBulkUpdate, useList, type BulkUpdates } from '../services/collection';
 import { useFiltersState } from '../services/filters';
-import { Button, Card, Input, StatusPill, TagChip, ViewSwitcher } from './ui';
+import { ApiError } from '../services/client';
+import { Button, Card, Field, Input, RatingInput, Select, StatusPill, TagChip, TagInput, ViewSwitcher } from './ui';
 import BarcodeLookup from './BarcodeLookup';
 import PhotoLookup from './PhotoLookup';
 import FiltersPanel from './FiltersPanel';
 import MediaIcon from './MediaIcon';
 import { useViewPreference, type ViewMode } from '../hooks/useViewPreference';
-import type { CollectionItemBase, MediaType } from '../services/types';
+import {
+  COLLECTION_STATUSES,
+  WATCH_STATUSES,
+  type CollectionItemBase,
+  type CollectionStatus,
+  type MediaType,
+  type WatchStatus,
+} from '../services/types';
 import type { MediaResultMap } from '../services/mediaRegistry';
 
 interface RenderedItem {
@@ -50,6 +58,26 @@ interface BaseItem extends CollectionItemBase {
   imagePath?: string | null;
 }
 
+// A checkbox rendered as a sibling of the surrounding <Link>; stopping
+// propagation here keeps a click on the checkbox from also firing the
+// card's navigation.
+function SelectCheckbox({ id, checked, onToggle }: { id: number; checked: boolean; onToggle: (id: number) => void }) {
+  return (
+    <span
+      onClick={(e) => e.stopPropagation()}
+      className="absolute left-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-md bg-card/90 shadow-sm"
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={() => onToggle(id)}
+        aria-label="Select item"
+        className="h-4 w-4 cursor-pointer accent-brand"
+      />
+    </span>
+  );
+}
+
 function CoverBlock({ src }: { src?: string | null }) {
   if (src) {
     return (
@@ -68,10 +96,16 @@ function CoverBlock({ src }: { src?: string | null }) {
   );
 }
 
-function ListCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+interface CardSelectProps {
+  selected: boolean;
+  onToggle: (id: number) => void;
+}
+
+function ListCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   return (
-    <Card className={`!p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+    <Card className={`relative !p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+      {item.id != null && <SelectCheckbox id={item.id} checked={selected} onToggle={onToggle} />}
       <div className="flex items-center gap-3 p-2">
         <div className="w-16 shrink-0 overflow-hidden rounded-xl bg-imgPlaceholder">
           <CoverBlock src={item.imagePath} />
@@ -93,11 +127,12 @@ function ListCard({ item, r, category }: { item: BaseItem; r: RenderedItem; cate
   );
 }
 
-function MediumCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+function MediumCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   const tags = item.tags ?? [];
   return (
-    <Card className={`!p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+    <Card className={`relative !p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+      {item.id != null && <SelectCheckbox id={item.id} checked={selected} onToggle={onToggle} />}
       <div className="flex gap-3 p-3">
         <div className="w-24 shrink-0 overflow-hidden rounded-xl bg-imgPlaceholder">
           <CoverBlock src={item.imagePath} />
@@ -130,11 +165,12 @@ function MediumCard({ item, r, category }: { item: BaseItem; r: RenderedItem; ca
   );
 }
 
-function BigCard({ item, r, category }: { item: BaseItem; r: RenderedItem; category?: string }) {
+function BigCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   const tags = item.tags ?? [];
   return (
-    <Card className={`!p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+    <Card className={`relative !p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
+      {item.id != null && <SelectCheckbox id={item.id} checked={selected} onToggle={onToggle} />}
       <div className="flex flex-col gap-3 md:flex-row">
         <div className="relative w-full shrink-0 overflow-hidden bg-imgPlaceholder sm:w-24 md:w-36 lg:w-48">
           <CoverBlock src={item.imagePath} />
@@ -193,6 +229,62 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
 
   const btnClass = category ? BTN_CLASS[category] : '';
 
+  // ─── Bulk selection + edit ─────────────────────────────────────
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const toggleSelected = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const clearSelection = () => setSelected(new Set());
+
+  const allIds = items
+    .map((item) => (item as BaseItem).id)
+    .filter((id): id is number => typeof id === 'number');
+  const allSelected = allIds.length > 0 && allIds.every((id) => selected.has(id));
+  const toggleSelectAll = () => setSelected(allSelected ? new Set() : new Set(allIds));
+
+  const [bulkModalOpen, setBulkModalOpen] = useState(false);
+  const [bulkStatus, setBulkStatus] = useState<CollectionStatus | ''>('');
+  const [bulkRating, setBulkRating] = useState<number | null>(null);
+  const [bulkTags, setBulkTags] = useState<string[]>([]);
+  const [bulkAcquiredOn, setBulkAcquiredOn] = useState('');
+  const [bulkWatchStatus, setBulkWatchStatus] = useState<WatchStatus | ''>('');
+
+  const bulkUpdate = useBulkUpdate(type);
+
+  const openBulkEdit = () => {
+    setBulkStatus('');
+    setBulkRating(null);
+    setBulkTags([]);
+    setBulkAcquiredOn('');
+    setBulkWatchStatus('');
+    setBulkModalOpen(true);
+  };
+  const closeBulkEdit = () => setBulkModalOpen(false);
+
+  const confirmBulkEdit = () => {
+    const updates: BulkUpdates = {};
+    if (bulkStatus) updates.status = bulkStatus;
+    if (bulkRating != null) updates.personalRating = bulkRating;
+    if (bulkTags.length > 0) updates.tags = bulkTags;
+    if (bulkAcquiredOn) updates.acquiredOn = bulkAcquiredOn;
+    if (category === 'movies' && bulkWatchStatus) updates.watchStatus = bulkWatchStatus;
+
+    bulkUpdate.mutate(
+      { ids: [...selected], updates },
+      {
+        onSuccess: () => {
+          clearSelection();
+          setBulkModalOpen(false);
+        },
+      },
+    );
+  };
+
   // Grid classes per view mode
   const gridClass = viewMode === 'list'
     ? 'grid-cols-1 gap-2'
@@ -215,6 +307,18 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
           <p className="mt-1 text-sm text-text-secondary">Search, filter, and add to this shelf.</p>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
+          {items.length > 0 && (
+            <label className="flex items-center gap-1.5 text-xs font-semibold text-text-secondary">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={toggleSelectAll}
+                aria-label="Select all on current page"
+                className="h-4 w-4 accent-brand"
+              />
+              Select all
+            </label>
+          )}
           <ViewSwitcher value={viewMode} onChange={setViewMode} />
           <BarcodeLookup type={type} onPick={onBarcodePick} onBarcodeFallback={onBarcodeFallback} />
           <PhotoLookup type={type} onPick={onBarcodePick} />
@@ -231,6 +335,16 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
 
       <FiltersPanel type={type} value={filters} onChange={setFilters} onClear={clear} />
 
+      {selected.size > 0 && (
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-2">
+          <span className="text-sm font-semibold text-text-primary">{selected.size} selected</span>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="secondary" onClick={clearSelection}>Clear</Button>
+            <Button type="button" onClick={openBulkEdit}>Edit selected</Button>
+          </div>
+        </div>
+      )}
+
       {list.isLoading && <p className="text-text-secondary">Loading…</p>}
       {list.error && <p className="text-error">Failed to load.</p>}
       {!list.isLoading && items.length === 0 && (
@@ -241,15 +355,69 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
         {items.map((item) => {
           const base = item as BaseItem;
           const r = renderItem(item);
+          const isSelected = base.id != null && selected.has(base.id);
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="group block">
-              {viewMode === 'list' && <ListCard item={base} r={r} category={category} />}
-              {viewMode === 'medium' && <MediumCard item={base} r={r} category={category} />}
-              {viewMode === 'big' && <BigCard item={base} r={r} category={category} />}
+              {viewMode === 'list' && <ListCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
+              {viewMode === 'medium' && <MediumCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
+              {viewMode === 'big' && <BigCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
             </Link>
           );
         })}
       </div>
+
+      {bulkModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <Card className="w-full max-w-md space-y-4">
+            <h2 className="text-lg font-bold text-text-primary">
+              Edit {selected.size} item{selected.size === 1 ? '' : 's'}
+            </h2>
+
+            <Field label="Status">
+              <Select value={bulkStatus} onChange={(e) => setBulkStatus(e.target.value as CollectionStatus | '')}>
+                <option value="">— Leave unchanged —</option>
+                {COLLECTION_STATUSES.map((s) => (
+                  <option key={s.value} value={s.value}>{s.label}</option>
+                ))}
+              </Select>
+            </Field>
+
+            {category === 'movies' && (
+              <Field label="Watch status">
+                <Select value={bulkWatchStatus} onChange={(e) => setBulkWatchStatus(e.target.value as WatchStatus | '')}>
+                  <option value="">— Leave unchanged —</option>
+                  {WATCH_STATUSES.map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </Select>
+              </Field>
+            )}
+
+            <Field label="Personal rating">
+              <RatingInput value={bulkRating} onChange={setBulkRating} category={category} />
+            </Field>
+
+            <Field label="Tags">
+              <TagInput value={bulkTags} onChange={setBulkTags} category={category} />
+            </Field>
+
+            <Field label="Acquired on">
+              <Input type="date" value={bulkAcquiredOn} onChange={(e) => setBulkAcquiredOn(e.target.value)} />
+            </Field>
+
+            {bulkUpdate.isError && (
+              <p className="text-sm text-error">
+                {bulkUpdate.error instanceof ApiError ? bulkUpdate.error.message : 'Something went wrong.'}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={closeBulkEdit}>Cancel</Button>
+              <Button type="button" onClick={confirmBulkEdit} disabled={bulkUpdate.isPending}>Confirm</Button>
+            </div>
+          </Card>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -1,7 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './client';
 import { filtersToParams, type Filters } from './filters';
-import type { Album, Game, MediaType, Movie } from './types';
+import type {
+  Album,
+  CollectionStatus,
+  CompletionStatus,
+  Condition,
+  Game,
+  MediaType,
+  Movie,
+  MusicFormat,
+  WatchStatus,
+} from './types';
 
 type ItemMap = { movies: Movie; music: Album; games: Game };
 
@@ -87,6 +97,45 @@ export function useDelete<T extends MediaType>(type: T) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: number) => api(`/api/${type}/${id}`, { method: 'DELETE' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [type] }),
+  });
+}
+
+/** Fields the bulk-update endpoint accepts per media type (a partial map).
+ * Only keys present are set on every selected row; absent keys are untouched.
+ * The union reflects the shared collection fields plus the per-type extras;
+ * the server rejects any key a given type does not support. */
+export interface BulkUpdates {
+  status?: CollectionStatus;
+  condition?: Condition | null;
+  personalRating?: number | null;
+  acquiredOn?: string | null;
+  acquisitionPrice?: number | null;
+  acquisitionCurrency?: string | null;
+  acquisitionSource?: string | null;
+  description?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  // movies
+  watchStatus?: WatchStatus;
+  watchCount?: number;
+  lastWatchedOn?: string | null;
+  // music
+  format?: MusicFormat;
+  listenCount?: number;
+  // games
+  completionStatus?: CompletionStatus;
+  hoursPlayed?: number | null;
+}
+
+/** Set the SAME fields to the SAME values across many selected ids. The
+ * payload is `{ ids, updates }` where `updates` is a partial map. Invalidates
+ * the type's list query cache so the grid/table refetches. */
+export function useBulkUpdate<T extends MediaType>(type: T) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ ids, updates }: { ids: number[]; updates: BulkUpdates }) =>
+      api(`/api/${type}/bulk`, { method: 'PATCH', body: JSON.stringify({ ids, updates }) }),
     onSuccess: () => qc.invalidateQueries({ queryKey: [type] }),
   });
 }

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -126,6 +126,8 @@ export interface BulkUpdates {
   // games
   completionStatus?: CompletionStatus;
   hoursPlayed?: number | null;
+  // games + music
+  lastPlayedOn?: string | null;
 }
 
 /** Set the SAME fields to the SAME values across many selected ids. The

--- a/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
+++ b/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using System.Text.Json;
+using Collectify.Domain.Entities;
+
+namespace Collectify.Api.Endpoints;
+
+/// <summary>
+/// Builders for <see cref="BulkField{TEntity}"/> setters. Each parser validates
+/// its value and returns an error message on failure (never throwing), so the
+/// surrounding bulk handler stays atomic: a bad value anywhere in the batch
+/// returns 400 and nothing is persisted. Enum parsers mirror the repo's write
+/// boundary — only defined members are accepted, undefined values are rejected
+/// — so bulk updates cannot bypass the boundary that single writes enforce.
+/// </summary>
+public static class BulkFieldBuilder
+{
+    /// <summary>Set a nullable primitive (string, DateOnly, decimal, int, bool, enum).</summary>
+    public static BulkField<TEntity> Scalar<TEntity, T>(
+        string name, Action<TEntity, T?> set) where TEntity : class, ICollectionEntry
+        where T : struct
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                try
+                {
+                    set(e, el.ValueKind == JsonValueKind.Null
+                        ? null
+                        : JsonSerializer.Deserialize<T>(el.GetRawText()));
+                    return null;
+                }
+                catch (JsonException)
+                {
+                    return $"invalid value for {name}.";
+                }
+            },
+        };
+    }
+
+    /// <summary>Set a string field (null clears it).</summary>
+    public static BulkField<TEntity> Text<TEntity>(
+        string name, Action<TEntity, string?> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null) { set(e, null); return null; }
+                if (el.ValueKind != JsonValueKind.String) return $"invalid value for {name}.";
+                set(e, el.GetString());
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set an enum field, accepting only defined member values (write-boundary parity).</summary>
+    public static BulkField<TEntity> Enum<TEntity, TEnum>(
+        string name, Action<TEntity, TEnum> set) where TEntity : class, ICollectionEntry
+        where TEnum : struct, System.Enum
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                TEnum value;
+                try
+                {
+                    value = JsonSerializer.Deserialize<TEnum>(el.GetRawText());
+                }
+                catch (JsonException)
+                {
+                    return $"invalid value for {name}.";
+                }
+                if (!System.Enum.IsDefined(value))
+                    return $"'{value}' is not a defined {typeof(TEnum).Name}.";
+                set(e, value);
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set a decimal in [0, 999999.99]: 2 decimal places, never negative.</summary>
+    public static BulkField<TEntity> Price<TEntity>(
+        string name, Action<TEntity, decimal?> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null) { set(e, null); return null; }
+                if (el.ValueKind != JsonValueKind.Number) return $"invalid value for {name}.";
+                var raw = el.GetRawText();
+                if (!decimal.TryParse(raw, NumberStyles.Number, CultureInfo.InvariantCulture, out var d))
+                    return $"invalid value for {name}.";
+                if (d < 0) return $"{name} must not be negative.";
+                if (decimal.Round(d, 2) != d) return $"{name} must have at most 2 decimal places.";
+                set(e, d);
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set a personal rating in [1, 10] (matches the single-write boundary).</summary>
+    public static BulkField<TEntity> Rating<TEntity>(
+        string name, Action<TEntity, int?> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null) { set(e, null); return null; }
+                if (el.ValueKind != JsonValueKind.Number) return $"invalid value for {name}.";
+                var raw = el.GetRawText();
+                if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var r))
+                    return $"invalid value for {name}.";
+                if (r < 1 || r > 10) return $"{name} must be between 1 and 10.";
+                set(e, r);
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set a required (non-null) int field, e.g. a count.</summary>
+    public static BulkField<TEntity> Count<TEntity>(
+        string name, Action<TEntity, int> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind != JsonValueKind.Number) return $"invalid value for {name}.";
+                var raw = el.GetRawText();
+                if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var c))
+                    return $"invalid value for {name}.";
+                if (c < 0) return $"{name} must not be negative.";
+                set(e, c);
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set a 3-letter ISO 4217 currency code (null clears it), upper-cased.</summary>
+    public static BulkField<TEntity> Currency<TEntity>(
+        string name, Action<TEntity, string?> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null) { set(e, null); return null; }
+                if (el.ValueKind != JsonValueKind.String) return $"invalid value for {name}.";
+                var s = el.GetString();
+                if (string.IsNullOrWhiteSpace(s)) { set(e, null); return null; }
+                if (s.Trim().Length != 3) return $"{name} must be a 3-letter ISO 4217 code.";
+                set(e, s.Trim().ToUpperInvariant());
+                return null;
+            },
+        };
+    }
+}

--- a/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
+++ b/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
@@ -206,6 +206,31 @@ public static class BulkFieldBuilder
         };
     }
 
+    /// <summary>Set a non-negative nullable integer counter (null clears it), rejecting negatives.</summary>
+    public static BulkField<TEntity> NonNegativeInt<TEntity>(
+        string name, Action<TEntity, int?> set) where TEntity : class, ICollectionEntry
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null)
+                {
+                    set(e, null);
+                    return null;
+                }
+                if (el.ValueKind != JsonValueKind.Number) return $"invalid value for {name}.";
+                var raw = el.GetRawText();
+                if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var c))
+                    return $"invalid value for {name}.";
+                if (c < 0) return $"{name} must not be negative.";
+                set(e, c);
+                return null;
+            },
+        };
+    }
+
     /// <summary>Set a 3-letter ISO 4217 currency code (null clears it), upper-cased.</summary>
     public static BulkField<TEntity> Currency<TEntity>(
         string name, Action<TEntity, string?> set) where TEntity : class, ICollectionEntry

--- a/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
+++ b/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
@@ -69,9 +69,21 @@ public static class BulkFieldBuilder
                 TEnum value;
                 try
                 {
-                    value = JsonSerializer.Deserialize<TEnum>(el.GetRawText());
+                    // JsonSerializer.Deserialize<TEnum> with no options only
+                    // accepts numeric JSON tokens (the default converter has
+                    // no string-name support); a JSON string like "Sold"
+                    // needs Enum.Parse instead, matching how every other
+                    // enum-typed field in the app (bound via the configured
+                    // JsonStringEnumConverter) actually accepts values.
+                    value = el.ValueKind == JsonValueKind.String
+                        ? System.Enum.Parse<TEnum>(el.GetString()!)
+                        : JsonSerializer.Deserialize<TEnum>(el.GetRawText());
                 }
                 catch (JsonException)
+                {
+                    return $"invalid value for {name}.";
+                }
+                catch (ArgumentException)
                 {
                     return $"invalid value for {name}.";
                 }

--- a/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
+++ b/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
@@ -76,7 +76,47 @@ public static class BulkFieldBuilder
                     // enum-typed field in the app (bound via the configured
                     // JsonStringEnumConverter) actually accepts values.
                     value = el.ValueKind == JsonValueKind.String
-                        ? System.Enum.Parse<TEnum>(el.GetString()!)
+                        ? System.Enum.Parse<TEnum>(el.GetString()!, ignoreCase: true)
+                        : JsonSerializer.Deserialize<TEnum>(el.GetRawText());
+                }
+                catch (JsonException)
+                {
+                    return $"invalid value for {name}.";
+                }
+                catch (ArgumentException)
+                {
+                    return $"invalid value for {name}.";
+                }
+                if (!System.Enum.IsDefined(value))
+                    return $"'{value}' is not a defined {typeof(TEnum).Name}.";
+                set(e, value);
+                return null;
+            },
+        };
+    }
+
+    /// <summary>Set a nullable enum field: accepts a defined member name
+    /// (case-insensitive, matching the single-write boundary) or JSON null to
+    /// clear the value. Rejects undefined member values.</summary>
+    public static BulkField<TEntity> NullableEnum<TEntity, TEnum>(
+        string name, Action<TEntity, TEnum?> set) where TEntity : class, ICollectionEntry
+        where TEnum : struct, System.Enum
+    {
+        return new BulkField<TEntity>
+        {
+            Name = name,
+            Apply = (e, el) =>
+            {
+                if (el.ValueKind == JsonValueKind.Null)
+                {
+                    set(e, null);
+                    return null;
+                }
+                TEnum value;
+                try
+                {
+                    value = el.ValueKind == JsonValueKind.String
+                        ? System.Enum.Parse<TEnum>(el.GetString()!, ignoreCase: true)
                         : JsonSerializer.Deserialize<TEnum>(el.GetRawText());
                 }
                 catch (JsonException)
@@ -107,7 +147,7 @@ public static class BulkFieldBuilder
                 if (el.ValueKind == JsonValueKind.Null) { set(e, null); return null; }
                 if (el.ValueKind != JsonValueKind.Number) return $"invalid value for {name}.";
                 var raw = el.GetRawText();
-                if (!decimal.TryParse(raw, NumberStyles.Number, CultureInfo.InvariantCulture, out var d))
+                if (!decimal.TryParse(raw, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out var d))
                     return $"invalid value for {name}.";
                 if (d < 0) return $"{name} must not be negative.";
                 if (decimal.Round(d, 2) != d) return $"{name} must have at most 2 decimal places.";
@@ -171,7 +211,7 @@ public static class BulkFieldBuilder
                 if (el.ValueKind != JsonValueKind.String) return $"invalid value for {name}.";
                 var s = el.GetString();
                 if (string.IsNullOrWhiteSpace(s)) { set(e, null); return null; }
-                if (s.Trim().Length != 3) return $"{name} must be a 3-letter ISO 4217 code.";
+                if (s.Length != 3) return $"{name} must be 3 characters.";
                 set(e, s.Trim().ToUpperInvariant());
                 return null;
             },

--- a/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
+++ b/src/server/Collectify.Api/Endpoints/BulkFieldBuilder.cs
@@ -87,6 +87,10 @@ public static class BulkFieldBuilder
                 {
                     return $"invalid value for {name}.";
                 }
+                catch (OverflowException)
+                {
+                    return $"invalid value for {name}.";
+                }
                 if (!System.Enum.IsDefined(value))
                     return $"'{value}' is not a defined {typeof(TEnum).Name}.";
                 set(e, value);
@@ -124,6 +128,10 @@ public static class BulkFieldBuilder
                     return $"invalid value for {name}.";
                 }
                 catch (ArgumentException)
+                {
+                    return $"invalid value for {name}.";
+                }
+                catch (OverflowException)
                 {
                     return $"invalid value for {name}.";
                 }

--- a/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
@@ -169,7 +169,7 @@ public static class CollectionEndpoints
                     return Results.BadRequest(new { error = "updates must not be empty." });
 
                 foreach (var key in req.Updates.Keys)
-                    if (!bulk.ContainsKey(key))
+                    if (key != "tags" && !bulk.ContainsKey(key))
                         return Results.BadRequest(new { error = $"Unknown bulk-update field '{key}'." });
 
                 var ownerId = users.GetUserId(ctx.User)!;

--- a/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
@@ -6,6 +6,7 @@ using Collectify.Infrastructure.Lookup.Images;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
 
 namespace Collectify.Api.Endpoints;
 
@@ -17,6 +18,24 @@ public interface ICollectionEntryDto
 {
     string[]? Tags { get; }
 }
+
+/// <summary>A bulk-updatable field. Authoring the value to a strongly-typed
+/// JsonElement keeps the write boundary explicit per field: each setter
+/// validates its value and returns a human error message on failure, or null
+/// and applies it. Returns do not persist until the surrounding handler's
+/// single SaveChangesAsync commits, so a failure anywhere in a batch keeps the
+/// whole request atomic (nothing is written).</summary>
+public sealed class BulkField<TEntity> where TEntity : class, ICollectionEntry
+{
+    /// <summary>JSON key the client sends (matches the DTO property name).</summary>
+    public required string Name { get; init; }
+    /// <summary>Returns null on success (value applied) or an error message.</summary>
+    public required Func<TEntity, JsonElement, string?> Apply { get; init; }
+}
+
+/// <summary>Request body for a bulk PATCH. <see cref="Updates"/> is a partial
+/// map — only named fields are set on each row; absent fields are untouched.</summary>
+public sealed record BulkUpdateRequest(int[] Ids, Dictionary<string, JsonElement> Updates);
 
 public sealed class CollectionEndpointConfig<TEntity, TDto>
     where TEntity : class, ICollectionEntry, new()
@@ -34,6 +53,9 @@ public sealed class CollectionEndpointConfig<TEntity, TDto>
     // error result that, when non-null, short-circuits the list response.
     public Func<IQueryable<TEntity>, HttpRequest, (IQueryable<TEntity> Query, IResult? Error)>? ExtraFilters { get; init; }
     public Action<CollectifyDbContext, int, string>? OnDelete { get; init; }
+    // Bulk-updatable fields keyed by their JSON name (see BulkField<TEntity>).
+    // Absent (or empty) => the resource has no bulk PATCH surface.
+    public IReadOnlyDictionary<string, BulkField<TEntity>>? BulkFields { get; init; }
 }
 
 public static class CollectionEndpoints
@@ -132,6 +154,64 @@ public static class CollectionEndpoints
             await db.SaveChangesAsync();
             return Results.NoContent();
         });
+
+        // ---- PATCH /bulk — set the SAME field(s) to the same value(s) across many ids ----
+        if (cfg.BulkFields is { Count: > 0 } bulk)
+        {
+            group.MapMethods("/bulk", new[] { "PATCH" },
+                async (BulkUpdateRequest req, CollectifyDbContext db, UserManager<AppUser> users, HttpContext ctx, CancellationToken ct) =>
+            {
+                if (req.Ids is not { Length: > 0 })
+                    return Results.BadRequest(new { error = "ids must be a non-empty array." });
+                if (req.Ids.Distinct().Count() != req.Ids.Length)
+                    return Results.BadRequest(new { error = "ids must not contain duplicates." });
+                if (req.Updates is not { Count: > 0 })
+                    return Results.BadRequest(new { error = "updates must not be empty." });
+
+                foreach (var key in req.Updates.Keys)
+                    if (!bulk.ContainsKey(key))
+                        return Results.BadRequest(new { error = $"Unknown bulk-update field '{key}'." });
+
+                var ownerId = users.GetUserId(ctx.User)!;
+                var rows = await cfg.Set(db)
+                    .Include(e => e.Tags)
+                    .Where(e => req.Ids.Contains(e.Id) && e.OwnerId == ownerId)
+                    .ToListAsync(ct);
+
+                // Atomic ownership/isolation: every requested id must exist and
+                // belong to the caller, or the whole request is rejected (no
+                // partial application).
+                if (rows.Count != req.Ids.Length)
+                    return Results.NotFound();
+
+                // Tag resolution first (establishes any missing Tag rows for
+                // the owner); everything else applies in-memory and persists in
+                // the single SaveChangesAsync below.
+                if (req.Updates.TryGetValue("tags", out var tagsEl))
+                {
+                    var names = tagsEl.ValueKind == JsonValueKind.Null
+                        ? null
+                        : JsonSerializer.Deserialize<string[]?>(tagsEl.GetRawText());
+                    var resolved = await TagResolver.ResolveAsync(db, ownerId, names);
+                    foreach (var row in rows) row.Tags = resolved;
+                }
+
+                foreach (var (key, value) in req.Updates)
+                {
+                    if (key == "tags") continue;
+                    var field = bulk[key];
+                    foreach (var row in rows)
+                    {
+                        if (field.Apply(row, value) is { } error)
+                            return Results.BadRequest(new { error = $"{key}: {error}" });
+                    }
+                }
+
+                foreach (var row in rows) row.UpdatedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync(ct);
+                return Results.Ok(rows.Select(cfg.ToDto));
+            });
+        }
 
         return app;
     }

--- a/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
@@ -189,9 +189,17 @@ public static class CollectionEndpoints
                 // the single SaveChangesAsync below.
                 if (req.Updates.TryGetValue("tags", out var tagsEl))
                 {
-                    var names = tagsEl.ValueKind == JsonValueKind.Null
-                        ? null
-                        : JsonSerializer.Deserialize<string[]?>(tagsEl.GetRawText());
+                    string[]? names;
+                    try
+                    {
+                        names = tagsEl.ValueKind == JsonValueKind.Null
+                            ? null
+                            : JsonSerializer.Deserialize<string[]?>(tagsEl.GetRawText());
+                    }
+                    catch (JsonException)
+                    {
+                        return Results.BadRequest(new { error = "tags: invalid value for tags." });
+                    }
                     var resolved = await TagResolver.ResolveAsync(db, ownerId, names);
                     foreach (var row in rows) row.Tags = resolved;
                 }

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -153,6 +153,21 @@ public static class GamesEndpoints
                 child.UpdatedAt = DateTime.UtcNow;
             }
         },
+        BulkFields = new Dictionary<string, BulkField<Game>>
+        {
+            ["status"] = BulkFieldBuilder.Enum<Game, CollectionStatus>("status", (e, v) => e.Status = v),
+            ["condition"] = BulkFieldBuilder.Enum<Game, Condition>("condition", (e, v) => e.Condition = v),
+            ["personalRating"] = BulkFieldBuilder.Rating<Game>("personalRating", (e, v) => e.PersonalRating = v),
+            ["acquiredOn"] = BulkFieldBuilder.Scalar<Game, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
+            ["acquisitionPrice"] = BulkFieldBuilder.Price<Game>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),
+            ["acquisitionCurrency"] = BulkFieldBuilder.Currency<Game>("acquisitionCurrency", (e, v) => e.AcquisitionCurrency = v),
+            ["acquisitionSource"] = BulkFieldBuilder.Text<Game>("acquisitionSource", (e, v) => e.AcquisitionSource = v),
+            ["description"] = BulkFieldBuilder.Text<Game>("description", (e, v) => e.Description = v),
+            ["notes"] = BulkFieldBuilder.Text<Game>("notes", (e, v) => e.Notes = v),
+            ["completionStatus"] = BulkFieldBuilder.Enum<Game, CompletionStatus>("completionStatus", (e, v) => e.CompletionStatus = v),
+            ["hoursPlayed"] = BulkFieldBuilder.Scalar<Game, int>("hoursPlayed", (e, v) => e.HoursPlayed = v),
+            ["lastPlayedOn"] = BulkFieldBuilder.Scalar<Game, DateOnly>("lastPlayedOn", (e, v) => e.LastPlayedOn = v),
+        },
     };
 
     // Bound as a raw string (not the enum) so a stale/legacy value

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -165,7 +165,7 @@ public static class GamesEndpoints
             ["description"] = BulkFieldBuilder.Text<Game>("description", (e, v) => e.Description = v),
             ["notes"] = BulkFieldBuilder.Text<Game>("notes", (e, v) => e.Notes = v),
             ["completionStatus"] = BulkFieldBuilder.Enum<Game, CompletionStatus>("completionStatus", (e, v) => e.CompletionStatus = v),
-            ["hoursPlayed"] = BulkFieldBuilder.Scalar<Game, int>("hoursPlayed", (e, v) => e.HoursPlayed = v),
+            ["hoursPlayed"] = BulkFieldBuilder.NonNegativeInt<Game>("hoursPlayed", (e, v) => e.HoursPlayed = v),
             ["lastPlayedOn"] = BulkFieldBuilder.Scalar<Game, DateOnly>("lastPlayedOn", (e, v) => e.LastPlayedOn = v),
         },
     };

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -156,7 +156,7 @@ public static class GamesEndpoints
         BulkFields = new Dictionary<string, BulkField<Game>>
         {
             ["status"] = BulkFieldBuilder.Enum<Game, CollectionStatus>("status", (e, v) => e.Status = v),
-            ["condition"] = BulkFieldBuilder.Enum<Game, Condition>("condition", (e, v) => e.Condition = v),
+            ["condition"] = BulkFieldBuilder.NullableEnum<Game, Condition>("condition", (e, v) => e.Condition = v),
             ["personalRating"] = BulkFieldBuilder.Rating<Game>("personalRating", (e, v) => e.PersonalRating = v),
             ["acquiredOn"] = BulkFieldBuilder.Scalar<Game, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
             ["acquisitionPrice"] = BulkFieldBuilder.Price<Game>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -125,6 +125,21 @@ public static class MoviesEndpoints
             return (q, null);
         },
         OnDelete = null,
+        BulkFields = new Dictionary<string, BulkField<Movie>>
+        {
+            ["status"] = BulkFieldBuilder.Enum<Movie, CollectionStatus>("status", (e, v) => e.Status = v),
+            ["condition"] = BulkFieldBuilder.Enum<Movie, Condition>("condition", (e, v) => e.Condition = v),
+            ["personalRating"] = BulkFieldBuilder.Rating<Movie>("personalRating", (e, v) => e.PersonalRating = v),
+            ["acquiredOn"] = BulkFieldBuilder.Scalar<Movie, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
+            ["acquisitionPrice"] = BulkFieldBuilder.Price<Movie>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),
+            ["acquisitionCurrency"] = BulkFieldBuilder.Currency<Movie>("acquisitionCurrency", (e, v) => e.AcquisitionCurrency = v),
+            ["acquisitionSource"] = BulkFieldBuilder.Text<Movie>("acquisitionSource", (e, v) => e.AcquisitionSource = v),
+            ["description"] = BulkFieldBuilder.Text<Movie>("description", (e, v) => e.Description = v),
+            ["notes"] = BulkFieldBuilder.Text<Movie>("notes", (e, v) => e.Notes = v),
+            ["watchStatus"] = BulkFieldBuilder.Enum<Movie, WatchStatus>("watchStatus", (e, v) => e.WatchStatus = v),
+            ["watchCount"] = BulkFieldBuilder.Count<Movie>("watchCount", (e, v) => e.WatchCount = v),
+            ["lastWatchedOn"] = BulkFieldBuilder.Scalar<Movie, DateOnly>("lastWatchedOn", (e, v) => e.LastWatchedOn = v),
+        },
     };
 
     // Bound as a raw string (not the enum) so the filter mirrors the

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -128,7 +128,7 @@ public static class MoviesEndpoints
         BulkFields = new Dictionary<string, BulkField<Movie>>
         {
             ["status"] = BulkFieldBuilder.Enum<Movie, CollectionStatus>("status", (e, v) => e.Status = v),
-            ["condition"] = BulkFieldBuilder.Enum<Movie, Condition>("condition", (e, v) => e.Condition = v),
+            ["condition"] = BulkFieldBuilder.NullableEnum<Movie, Condition>("condition", (e, v) => e.Condition = v),
             ["personalRating"] = BulkFieldBuilder.Rating<Movie>("personalRating", (e, v) => e.PersonalRating = v),
             ["acquiredOn"] = BulkFieldBuilder.Scalar<Movie, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
             ["acquisitionPrice"] = BulkFieldBuilder.Price<Movie>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -101,6 +101,21 @@ public static class MusicEndpoints
             return (q, null);
         },
         OnDelete = null,
+        BulkFields = new Dictionary<string, BulkField<MusicAlbum>>
+        {
+            ["status"] = BulkFieldBuilder.Enum<MusicAlbum, CollectionStatus>("status", (e, v) => e.Status = v),
+            ["condition"] = BulkFieldBuilder.Enum<MusicAlbum, Condition>("condition", (e, v) => e.Condition = v),
+            ["personalRating"] = BulkFieldBuilder.Rating<MusicAlbum>("personalRating", (e, v) => e.PersonalRating = v),
+            ["acquiredOn"] = BulkFieldBuilder.Scalar<MusicAlbum, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
+            ["acquisitionPrice"] = BulkFieldBuilder.Price<MusicAlbum>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),
+            ["acquisitionCurrency"] = BulkFieldBuilder.Currency<MusicAlbum>("acquisitionCurrency", (e, v) => e.AcquisitionCurrency = v),
+            ["acquisitionSource"] = BulkFieldBuilder.Text<MusicAlbum>("acquisitionSource", (e, v) => e.AcquisitionSource = v),
+            ["description"] = BulkFieldBuilder.Text<MusicAlbum>("description", (e, v) => e.Description = v),
+            ["notes"] = BulkFieldBuilder.Text<MusicAlbum>("notes", (e, v) => e.Notes = v),
+            ["format"] = BulkFieldBuilder.Enum<MusicAlbum, MusicFormat>("format", (e, v) => e.Format = v),
+            ["listenCount"] = BulkFieldBuilder.Count<MusicAlbum>("listenCount", (e, v) => e.ListenCount = v),
+            ["lastPlayedOn"] = BulkFieldBuilder.Scalar<MusicAlbum, DateOnly>("lastPlayedOn", (e, v) => e.LastPlayedOn = v),
+        },
     };
 
     public static IEndpointRouteBuilder MapMusicEndpoints(this IEndpointRouteBuilder app) =>

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -104,7 +104,7 @@ public static class MusicEndpoints
         BulkFields = new Dictionary<string, BulkField<MusicAlbum>>
         {
             ["status"] = BulkFieldBuilder.Enum<MusicAlbum, CollectionStatus>("status", (e, v) => e.Status = v),
-            ["condition"] = BulkFieldBuilder.Enum<MusicAlbum, Condition>("condition", (e, v) => e.Condition = v),
+            ["condition"] = BulkFieldBuilder.NullableEnum<MusicAlbum, Condition>("condition", (e, v) => e.Condition = v),
             ["personalRating"] = BulkFieldBuilder.Rating<MusicAlbum>("personalRating", (e, v) => e.PersonalRating = v),
             ["acquiredOn"] = BulkFieldBuilder.Scalar<MusicAlbum, DateOnly>("acquiredOn", (e, v) => e.AcquiredOn = v),
             ["acquisitionPrice"] = BulkFieldBuilder.Price<MusicAlbum>("acquisitionPrice", (e, v) => e.AcquisitionPrice = v),

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -539,6 +539,32 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
     }
 
     [Fact]
+    public async Task BulkUpdate_Tags_MalformedValue_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { tags = "not-an-array" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_UnknownFieldWithTags_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { tags = new[] { "x" }, bogusField = 1 } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("bogusField", body.GetProperty("error").GetString());
+    }
+
+    [Fact]
     public async Task BulkUpdate_EmptyIds_Returns400()
     {
         var alice = await NewAliceAsync();

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Collectify.Domain.Entities;
 using Collectify.Tests.Infrastructure;
 using Collectify.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -534,6 +535,40 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
             new { ids = new[] { id }, updates = new { status = "999999999999999999999999" } });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_HoursPlayed_Negative_Returns400()
+    {
+        // hoursPlayed is games-only; kept here (not a games-specific test
+        // class) per the allow-listed file for this fix.
+        if (RoutePrefix != "/api/games/") return;
+
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { hoursPlayed = -1 } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var entity = await FindByIdAsync(id);
+        if (entity is Game game) Assert.Null(game.HoursPlayed);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_HoursPlayed_NonNegative_Returns200()
+    {
+        if (RoutePrefix != "/api/games/") return;
+
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { hoursPlayed = 3 } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entity = await FindByIdAsync(id);
+        if (entity is Game game) Assert.Equal(3, game.HoursPlayed);
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -428,9 +428,9 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
 
     // -------- Bulk update --------
 
-    private async Task<int> CreateAndGetIdAsync(HttpClient client, string? title = null)
+    private async Task<int> CreateAndGetIdAsync(HttpClient client, string? title = null, int? rating = null)
     {
-        var response = await client.PostAsJsonAsync(RoutePrefix, Sample(title: title));
+        var response = await client.PostAsJsonAsync(RoutePrefix, Sample(title: title, rating: rating));
         var body = await response.ReadJsonAsync<TResponse>();
         return body!.Id;
     }
@@ -439,9 +439,9 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
     public async Task BulkUpdate_AsOwner_SetsOnlyNamedFields()
     {
         var alice = await NewAliceAsync();
-        var id1 = await CreateAndGetIdAsync(alice.Client, "Alpha");
-        var id2 = await CreateAndGetIdAsync(alice.Client, "Beta");
-        var id3 = await CreateAndGetIdAsync(alice.Client, "Gamma");
+        var id1 = await CreateAndGetIdAsync(alice.Client, "Alpha", rating: 7);
+        var id2 = await CreateAndGetIdAsync(alice.Client, "Beta", rating: 7);
+        var id3 = await CreateAndGetIdAsync(alice.Client, "Gamma", rating: 7);
 
         var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
             new { ids = new[] { id1, id2, id3 }, updates = new { status = "Sold" } });
@@ -450,11 +450,36 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal(3, body.GetArrayLength());
         foreach (var item in body.EnumerateArray())
+        {
             Assert.Equal("Sold", item.GetProperty("status").GetString());
+            // Pins the partial-update guarantee: a status-only update must
+            // not disturb an unrelated field already set on the row.
+            Assert.Equal(7, item.GetProperty("personalRating").GetInt32());
+        }
 
         Assert.Equal("Alpha", TitleOf(await FindByIdAsync(id1)));
         Assert.Equal("Beta", TitleOf(await FindByIdAsync(id2)));
         Assert.Equal("Gamma", TitleOf(await FindByIdAsync(id3)));
+    }
+
+    [Fact]
+    public async Task BulkUpdate_Tags_ViaBulkEndpoint()
+    {
+        var alice = await NewAliceAsync();
+        var id1 = await CreateAndGetIdAsync(alice.Client, "Alpha");
+        var id2 = await CreateAndGetIdAsync(alice.Client, "Beta");
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id1, id2 }, updates = new { tags = new[] { "classic" } } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(2, body.GetArrayLength());
+        foreach (var item in body.EnumerateArray())
+        {
+            var tags = item.GetProperty("tags").EnumerateArray().Select(t => t.GetString()).ToArray();
+            Assert.Contains("classic", tags);
+        }
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -525,6 +525,18 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
     }
 
     [Fact]
+    public async Task BulkUpdate_EnumValue_Overflows_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { status = "999999999999999999999999" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task BulkUpdate_UnknownField_Returns400()
     {
         var alice = await NewAliceAsync();

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Collectify.Tests.Infrastructure;
 using Collectify.Tests.TestSupport;
 using Microsoft.EntityFrameworkCore;
@@ -423,5 +424,138 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
             db.Tags.CountAsync(t => t.OwnerId == bob.Id));
         Assert.Equal(1, aliceTags);
         Assert.Equal(1, bobTags);
+    }
+
+    // -------- Bulk update --------
+
+    private async Task<int> CreateAndGetIdAsync(HttpClient client, string? title = null)
+    {
+        var response = await client.PostAsJsonAsync(RoutePrefix, Sample(title: title));
+        var body = await response.ReadJsonAsync<TResponse>();
+        return body!.Id;
+    }
+
+    [Fact]
+    public async Task BulkUpdate_AsOwner_SetsOnlyNamedFields()
+    {
+        var alice = await NewAliceAsync();
+        var id1 = await CreateAndGetIdAsync(alice.Client, "Alpha");
+        var id2 = await CreateAndGetIdAsync(alice.Client, "Beta");
+        var id3 = await CreateAndGetIdAsync(alice.Client, "Gamma");
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id1, id2, id3 }, updates = new { status = "Sold" } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(3, body.GetArrayLength());
+        foreach (var item in body.EnumerateArray())
+            Assert.Equal("Sold", item.GetProperty("status").GetString());
+
+        Assert.Equal("Alpha", TitleOf(await FindByIdAsync(id1)));
+        Assert.Equal("Beta", TitleOf(await FindByIdAsync(id2)));
+        Assert.Equal("Gamma", TitleOf(await FindByIdAsync(id3)));
+    }
+
+    [Fact]
+    public async Task BulkUpdate_IncludesForeignOrUnknownId_Returns404()
+    {
+        var alice = await NewAliceAsync();
+        var bob = await NewBobAsync();
+        var aliceId1 = await CreateAndGetIdAsync(alice.Client, "Alice One");
+        var aliceId2 = await CreateAndGetIdAsync(alice.Client, "Alice Two");
+        var bobId = await CreateAndGetIdAsync(bob.Client, "Bob One");
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { aliceId1, aliceId2, bobId }, updates = new { status = "Sold" } });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("Alice One", TitleOf(await FindByIdAsync(aliceId1)));
+        Assert.Equal("Alice Two", TitleOf(await FindByIdAsync(aliceId2)));
+        Assert.Equal("Bob One", TitleOf(await FindByIdAsync(bobId)));
+    }
+
+    [Fact]
+    public async Task BulkUpdate_UndefinedEnumValue_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { status = "NotARealStatus" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_UndefinedEnumNumeric_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { status = 99 } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_UnknownField_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { nonexistentField = 1 } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("nonexistentField", body.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task BulkUpdate_EmptyIds_Returns400()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = Array.Empty<int>(), updates = new { status = "Sold" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_DuplicateIds_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id, id }, updates = new { status = "Sold" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_EmptyUpdates_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var id = await CreateAndGetIdAsync(alice.Client);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { id }, updates = new { } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_Unauthenticated_ReturnsUnauthorized()
+    {
+        var client = Factory.CreateClient();
+
+        var response = await client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { 1 }, updates = new { status = "Sold" } });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 }

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -324,4 +324,36 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         Assert.Contains("Tenet", titles);
         Assert.DoesNotContain("Goodfellas", titles);
     }
+
+    // -------- Bulk update (movie-specific whitelist) --------
+
+    [Fact]
+    public async Task BulkUpdate_MovieWatchStatus_SetsValue()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<MovieResponse>();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created!.Id }, updates = new { watchStatus = "Watched" } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
+        Assert.Equal(WatchStatus.Watched, fetched!.WatchStatus);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_MovieFormatsNotBulkUpdatable_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<MovieResponse>();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created!.Id }, updates = new { formats = 3 } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Unknown bulk-update field 'formats'.", body.GetProperty("error").GetString());
+    }
 }

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -388,4 +388,19 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
         Assert.Null(fetched!.Condition);
     }
+
+    [Fact]
+    public async Task BulkUpdate_NullableCondition_CaseInsensitive()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<MovieResponse>();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created!.Id }, updates = new { condition = "poor" } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
+        Assert.Equal(Condition.Poor, fetched!.Condition);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -356,4 +356,36 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("Unknown bulk-update field 'formats'.", body.GetProperty("error").GetString());
     }
+
+    [Fact]
+    public async Task BulkUpdate_EnumValue_CaseInsensitive()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<MovieResponse>();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created!.Id }, updates = new { status = "sold" } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
+        Assert.Equal(CollectionStatus.Sold, fetched!.Status);
+    }
+
+    [Fact]
+    public async Task BulkUpdate_NullableCondition_Clears()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix,
+            MovieTestSupport.Sample(condition: Condition.LikeNew)))
+            .ReadJsonAsync<MovieResponse>();
+        Assert.Equal(Condition.LikeNew, created!.Condition);
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created.Id }, updates = new { condition = (Condition?)null } });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
+        Assert.Null(fetched!.Condition);
+    }
 }

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -403,4 +403,17 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         var fetched = await alice.Client.GetJsonAsync<MovieResponse>($"{RoutePrefix}{created.Id}");
         Assert.Equal(Condition.Poor, fetched!.Condition);
     }
+
+    [Fact]
+    public async Task BulkUpdate_NullableCondition_Overflows_Returns400()
+    {
+        var alice = await NewAliceAsync();
+        var created = await (await alice.Client.PostAsJsonAsync(RoutePrefix, Sample()))
+            .ReadJsonAsync<MovieResponse>();
+
+        var response = await alice.Client.PatchAsJsonAsync($"{RoutePrefix}bulk",
+            new { ids = new[] { created!.Id }, updates = new { condition = "999999999999999999999999" } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }


### PR DESCRIPTION
Bulk update movies/music/games from the collection lists: select rows, set shared/per-type
fields in one PATCH /api/:type/bulk. One generic endpoint reused across all three media types (#97
generic module). Partial-update semantics; atomic ownership isolation; write-boundary enum validation.

Closes #89