### PR TITLE
Steam import: hide-imported toggle + pagination (#180, #181)

### DIFF
--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -8,14 +8,11 @@ import ImportSteam from './ImportSteam';
 const mockUseConnection = vi.fn();
 const mockUseConnect = vi.fn();
 const mockUseGames = vi.fn();
-const mockFetchSteamOwnedGames = vi.fn();
 const mockUseImport = vi.fn();
 const mockUseDisconnect = vi.fn();
 const mockConnectMutate = vi.fn();
 
 vi.mock('../services/steam', () => ({
-  fetchSteamOwnedGames: (search: string, offset: number, limit: number) =>
-    mockFetchSteamOwnedGames(search, offset, limit),
   useSteamConnection: () => mockUseConnection(),
   useSteamConnect: () => mockUseConnect(),
   useSteamGames: (enabled: boolean, search: string, offset: number, limit: number) =>
@@ -308,56 +305,6 @@ describe('ImportSteam', () => {
 
     expect(importMutate).toHaveBeenCalledWith(['1', '2']);
     expect(onSuccess).toBeTypeOf('function');
-  });
-
-  it('Repair covers refreshes imported games across pages, not just the current page', async () => {
-    const user = userEvent.setup();
-    const importMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 2, items: [] });
-    mockUseImport.mockReturnValue({ mutateAsync: importMutate, isPending: false });
-    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
-    mockUseGames.mockReturnValue({
-      data: {
-        status: 'ok',
-        truncated: true,
-        total: 1002,
-        titles: [
-          { externalGameId: 'imported-page-1', title: 'Imported One', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
-          { externalGameId: 'importable-page-1', title: 'Importable One', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
-        ],
-      },
-      isLoading: false,
-      error: null,
-    });
-    mockFetchSteamOwnedGames.mockImplementation((_search: string, offset: number) =>
-      Promise.resolve(offset === 0
-        ? {
-            status: 'ok',
-            truncated: true,
-            total: 1002,
-            titles: [
-              { externalGameId: 'imported-page-1', title: 'Imported One', playtimeMinutes: 0, state: 'imported' },
-              { externalGameId: 'importable-page-1', title: 'Importable One', playtimeMinutes: 0, state: 'importable' },
-            ],
-          }
-        : {
-            status: 'ok',
-            truncated: false,
-            total: 1002,
-            titles: [
-              { externalGameId: 'imported-page-2', title: 'Imported Two', playtimeMinutes: 0, state: 'imported' },
-              { externalGameId: 'importable-page-2', title: 'Importable Two', playtimeMinutes: 0, state: 'importable' },
-            ],
-          }),
-    );
-
-    renderPage();
-
-    await user.click(screen.getByRole('button', { name: /repair covers/i }));
-    await waitFor(() => expect(importMutate).toHaveBeenCalledWith([
-      'imported-page-1',
-      'imported-page-2',
-    ]));
-    expect(mockFetchSteamOwnedGames).toHaveBeenNthCalledWith(2, '', 1000, 1000);
   });
 
   it('merges select-all on a later page with selections made on earlier pages', async () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -8,11 +8,14 @@ import ImportSteam from './ImportSteam';
 const mockUseConnection = vi.fn();
 const mockUseConnect = vi.fn();
 const mockUseGames = vi.fn();
+const mockFetchSteamOwnedGames = vi.fn();
 const mockUseImport = vi.fn();
 const mockUseDisconnect = vi.fn();
 const mockConnectMutate = vi.fn();
 
 vi.mock('../services/steam', () => ({
+  fetchSteamOwnedGames: (search: string, offset: number, limit: number) =>
+    mockFetchSteamOwnedGames(search, offset, limit),
   useSteamConnection: () => mockUseConnection(),
   useSteamConnect: () => mockUseConnect(),
   useSteamGames: (enabled: boolean, search: string, offset: number, limit: number) =>
@@ -305,6 +308,56 @@ describe('ImportSteam', () => {
 
     expect(importMutate).toHaveBeenCalledWith(['1', '2']);
     expect(onSuccess).toBeTypeOf('function');
+  });
+
+  it('Repair covers refreshes imported games across pages, not just the current page', async () => {
+    const user = userEvent.setup();
+    const importMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 2, items: [] });
+    mockUseImport.mockReturnValue({ mutateAsync: importMutate, isPending: false });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: true,
+        total: 1002,
+        titles: [
+          { externalGameId: 'imported-page-1', title: 'Imported One', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: 'importable-page-1', title: 'Importable One', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockFetchSteamOwnedGames.mockImplementation((_search: string, offset: number) =>
+      Promise.resolve(offset === 0
+        ? {
+            status: 'ok',
+            truncated: true,
+            total: 1002,
+            titles: [
+              { externalGameId: 'imported-page-1', title: 'Imported One', playtimeMinutes: 0, state: 'imported' },
+              { externalGameId: 'importable-page-1', title: 'Importable One', playtimeMinutes: 0, state: 'importable' },
+            ],
+          }
+        : {
+            status: 'ok',
+            truncated: false,
+            total: 1002,
+            titles: [
+              { externalGameId: 'imported-page-2', title: 'Imported Two', playtimeMinutes: 0, state: 'imported' },
+              { externalGameId: 'importable-page-2', title: 'Importable Two', playtimeMinutes: 0, state: 'importable' },
+            ],
+          }),
+    );
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /repair covers/i }));
+    await waitFor(() => expect(importMutate).toHaveBeenCalledWith([
+      'imported-page-1',
+      'imported-page-2',
+    ]));
+    expect(mockFetchSteamOwnedGames).toHaveBeenNthCalledWith(2, '', 1000, 1000);
   });
 
   it('merges select-all on a later page with selections made on earlier pages', async () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import ImportSteam from './ImportSteam';
@@ -269,9 +269,11 @@ describe('ImportSteam', () => {
   it('imports the selected games when the user clicks Import selected', async () => {
     const user = userEvent.setup();
     let onSuccess: (() => void) | null = null;
+    let hookCall = 0;
     const importMutate = vi.fn().mockResolvedValue({ imported: 1, alreadyImported: 0, items: [] });
     mockUseImport.mockImplementation((cb: () => void) => {
-      onSuccess = cb;
+      if (hookCall % 2 === 0) onSuccess = cb;
+      hookCall += 1;
       return { mutateAsync: importMutate, isPending: false };
     });
     mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
@@ -296,6 +298,51 @@ describe('ImportSteam', () => {
 
     expect(importMutate).toHaveBeenCalledWith(['1', '2']);
     expect(onSuccess).toBeTypeOf('function');
+    act(() => onSuccess?.());
+    expect(screen.getByRole('button', { name: /^import selected$/i })).toBeDisabled();
+  });
+
+  it('repair covers preserves the pending cross-page import selection', async () => {
+    const user = userEvent.setup();
+    const successCallbacks: Array<() => void> = [];
+    let hookCall = 0;
+    const importSelectedMutate = vi.fn().mockResolvedValue({ imported: 1, alreadyImported: 0, items: [] });
+    const repairCoversMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 1, items: [] });
+    mockUseImport.mockImplementation((onSuccess: () => void) => {
+      const instance = hookCall % 2;
+      hookCall += 1;
+      successCallbacks[instance] = onSuccess;
+      return {
+        mutateAsync: instance === 0 ? importSelectedMutate : repairCoversMutate,
+        isPending: false,
+      };
+    });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: true,
+        total: 200,
+        titles: [
+          { externalGameId: '101', title: 'Importable 101', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '102', title: 'Imported 102', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    await user.click(screen.getByRole('checkbox', { name: /Importable 101/ }));
+    expect(screen.getByRole('button', { name: /import selected \(1\)/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /repair covers/i }));
+    expect(repairCoversMutate).toHaveBeenCalledWith(['102']);
+    act(() => successCallbacks[1]?.());
+
+    await user.click(screen.getByRole('button', { name: /import selected \(1\)/i }));
+    expect(importSelectedMutate).toHaveBeenLastCalledWith(['101']);
   });
 
   it('repairs only imported ids from the currently fetched page', async () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -115,6 +115,35 @@ describe('ImportSteam', () => {
     expect(screen.getByText('Hades')).toBeInTheDocument();
   });
 
+  it('shows the fetched page range even when Hide imported filters the visible list', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: false,
+        total: 3,
+        titles: [
+          { externalGameId: '1', title: 'ImportedA', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: '2', title: 'ImportableB', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '3', title: 'ImportableC', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+    // Full page visible first: range reflects 3 fetched titles.
+    expect(screen.getByText(/1–3 of 3/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('checkbox', { name: /hide imported/i }));
+    // Hide removes the imported row from the LIST but the RANGE still reflects
+    // the fetched page (3), and the select-all count still derives from the
+    // UN-HIDDEN page (2 importable).
+    expect(screen.queryByText('ImportedA')).not.toBeInTheDocument();
+    expect(screen.getByText(/1–3 of 3/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/select all not-imported \(2\)/i)).toBeInTheDocument();
+  });
+
   it('keeps the Select all not-imported count derived from the full page, not the hidden subset', async () => {
     const user = userEvent.setup();
     mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -201,6 +201,17 @@ describe('ImportSteam', () => {
 
     await user.click(next);
     expect(callOffset).toBe(100);
+    // Changing the search term must reset the page offset back to 0 even while
+    // paged forward (the filter effect fires immediately, not gated on the
+    // 300ms debounce). This must be an IMMEDIATE assertion, not waitFor: a
+    // waitFor would allow the delayed [debouncedFilter] reset (300ms) to also
+    // satisfy it, so the mutant (regressing to [debouncedFilter]) would stay
+    // green and the test proves nothing about immediacy.
+    const filterInput = screen.getByLabelText(/filter owned games/i);
+    await user.clear(filterInput);
+    await user.type(filterInput, 'aha');
+    expect(callOffset).toBe(0);
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
   });
 
   it('shows a qualified public-profile hint when Steam is unavailable', () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -11,6 +11,15 @@ const mockUseGames = vi.fn();
 const mockUseImport = vi.fn();
 const mockUseDisconnect = vi.fn();
 const mockConnectMutate = vi.fn();
+const { mockToastInfo } = vi.hoisted(() => ({ mockToastInfo: vi.fn() }));
+
+vi.mock('../components/toaster', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: mockToastInfo,
+  },
+}));
 
 vi.mock('../services/steam', () => ({
   useSteamConnection: () => mockUseConnection(),
@@ -389,5 +398,60 @@ describe('ImportSteam', () => {
     await user.click(screen.getByLabelText(/select all not-imported \(2\)/i));
 
     expect(screen.getByRole('button', { name: /import selected \(2\)/i })).toBeInTheDocument();
+  });
+
+  it('caps cross-page selections at 500 while allowing deselection and replacement', async () => {
+    const user = userEvent.setup();
+    const importMutate = vi.fn().mockImplementation((ids: string[]) =>
+      Promise.resolve({ imported: ids.length, alreadyImported: 0, items: [] }));
+    mockUseImport.mockReturnValue({ mutateAsync: importMutate, isPending: false });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockImplementation((_enabled, _search, offset: number) => ({
+      data: {
+        status: 'ok',
+        truncated: offset < 500,
+        total: 600,
+        titles: Array.from({ length: 100 }, (_, index) => {
+          const id = offset + index + 1;
+          return {
+            externalGameId: String(id),
+            title: `Game ${id}`,
+            playtimeMinutes: 0,
+            iconUrl: null,
+            state: 'importable' as const,
+          };
+        }),
+      },
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage();
+
+    for (let page = 1; page <= 5; page += 1) {
+      await user.click(screen.getByLabelText(/select all not-imported \(100\)/i));
+      if (page < 5) await user.click(screen.getByRole('button', { name: /next/i }));
+    }
+    expect(screen.getByRole('button', { name: /import selected \(500\)/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByLabelText(/select all not-imported \(100\)/i));
+    expect(screen.getByRole('button', { name: /import selected \(500\)/i })).toBeInTheDocument();
+    expect(mockToastInfo).toHaveBeenCalledWith('You can select up to 500 games at a time.');
+
+    await user.click(screen.getByRole('checkbox', { name: /Game 501/ }));
+    expect(screen.getByRole('button', { name: /import selected \(500\)/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /import selected \(500\)/i }));
+    const submitted = importMutate.mock.calls.at(-1)?.[0] as string[];
+    expect(submitted).toHaveLength(500);
+    expect(new Set(submitted).size).toBe(500);
+
+    await user.click(screen.getByRole('button', { name: /prev/i }));
+    await user.click(screen.getByRole('checkbox', { name: /Game 401/ }));
+    expect(screen.getByRole('button', { name: /import selected \(499\)/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('checkbox', { name: /Game 501/ }));
+    expect(screen.getByRole('button', { name: /import selected \(500\)/i })).toBeInTheDocument();
   });
 });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -544,6 +544,7 @@ describe('ImportSteam', () => {
     mockUseGames.mockImplementation((_enabled, _search, offset: number) => ({
       data: {
         status: 'ok',
+        importCap: 500,
         truncated: offset < 500,
         total: 600,
         titles: Array.from({ length: 100 }, (_, index) => {
@@ -588,5 +589,40 @@ describe('ImportSteam', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
     await user.click(screen.getByRole('checkbox', { name: /Game 501/ }));
     expect(screen.getByRole('button', { name: /import selected \(500\)/i })).toBeInTheDocument();
+  });
+
+  it('uses the configured import cap for select-all, its toast, and submission', async () => {
+    const user = userEvent.setup();
+    const importMutate = vi.fn().mockImplementation((ids: string[]) =>
+      Promise.resolve({ imported: ids.length, alreadyImported: 0, items: [] }));
+    mockUseImport.mockReturnValue({ mutateAsync: importMutate, isPending: false });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        importCap: 2,
+        truncated: false,
+        total: 3,
+        titles: [
+          { externalGameId: '1', title: 'One', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '2', title: 'Two', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '3', title: 'Three', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByLabelText(/select all not-imported \(3\)/i));
+
+    const submit = screen.getByRole('button', { name: /import selected \(2\)/i });
+    expect(submit).toBeInTheDocument();
+    expect(mockToastInfo).toHaveBeenCalledWith('You can select up to 2 games at a time.');
+
+    await user.click(submit);
+    const submitted = importMutate.mock.calls.at(-1)?.[0] as string[];
+    expect(submitted).toHaveLength(2);
+    expect(new Set(submitted).size).toBe(2);
   });
 });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -295,4 +295,45 @@ describe('ImportSteam', () => {
     expect(importMutate).toHaveBeenCalledWith(['1', '2']);
     expect(onSuccess).toBeTypeOf('function');
   });
+
+  it('merges select-all on a later page with selections made on earlier pages', async () => {
+    const user = userEvent.setup();
+    let importArg: string[] | null = null;
+    const importMutate = vi.fn().mockImplementation((ids: string[]) => {
+      importArg = ids;
+      return Promise.resolve({ imported: ids.length, alreadyImported: 0, items: [] });
+    });
+    mockUseImport.mockImplementation((cb: () => void) => ({ mutateAsync: importMutate, isPending: false }));
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockImplementation((_e, _s, offset: number) => ({
+      data: {
+        status: 'ok',
+        truncated: true,
+        total: 4,
+        titles: [
+          { externalGameId: String(offset + 1), title: `Game ${offset + 1}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: String(offset + 2), title: `Game ${offset + 2}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage();
+
+    // Page 1: select Game 1 individually (the row checkbox's accessible label
+    // is the title plus the formatted playtime, so match with a regex role).
+    await user.click(screen.getByRole('checkbox', { name: /Game 1/ }));
+    // Advance to page 2.
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    // Select all on page 2 (games 101 and 102). This must MERGE, not replace.
+    await user.click(screen.getByLabelText(/select all not-imported \(2\)/i));
+
+    // Cumulative count: Game 1 (page 1) + Games 101/102 (page 2) = 3.
+    expect(screen.getByRole('button', { name: /import selected \(3\)/i })).toBeInTheDocument();
+
+    // The submit must include the page-1 pick, proving it was not dropped.
+    await user.click(screen.getByRole('button', { name: /import selected \(3\)/i }));
+    expect(importArg ? [...importArg].sort() : []).toEqual(['1', '101', '102'].sort());
+  });
 });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -15,7 +15,8 @@ const mockConnectMutate = vi.fn();
 vi.mock('../services/steam', () => ({
   useSteamConnection: () => mockUseConnection(),
   useSteamConnect: () => mockUseConnect(),
-  useSteamGames: (enabled: boolean, search: string) => mockUseGames(enabled, search),
+  useSteamGames: (enabled: boolean, search: string, offset: number, limit: number) =>
+    mockUseGames(enabled, search, offset, limit),
   useSteamImport: (onSuccess: () => void) => mockUseImport(onSuccess),
   useSteamDisconnect: (onSuccess: () => void) => mockUseDisconnect(onSuccess),
 }));
@@ -50,7 +51,7 @@ describe('ImportSteam', () => {
 
   it('does not fetch games until connected', () => {
     renderPage();
-    expect(mockUseGames).toHaveBeenCalledWith(false, '');
+    expect(mockUseGames).toHaveBeenCalledWith(false, '', 0, 100);
   });
 
   it('disconnects and keeps a message that games stay', async () => {
@@ -85,6 +86,92 @@ describe('ImportSteam', () => {
     expect(screen.getByText('Hades')).toBeInTheDocument();
     expect(screen.getByText('Celeste')).toBeInTheDocument();
     expect(screen.getAllByText(/in collection/i).length).toBe(1);
+  });
+
+  it('hides already-imported titles when the Hide imported toggle is on', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: false,
+        total: 2,
+        titles: [
+          { externalGameId: '1', title: 'Hades', playtimeMinutes: 300, iconUrl: null, state: 'importable' },
+          { externalGameId: '2', title: 'Celeste', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Hades')).toBeInTheDocument();
+    expect(screen.getByText('Celeste')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/hide imported/i));
+    expect(screen.queryByText('Celeste')).not.toBeInTheDocument();
+    expect(screen.getByText('Hades')).toBeInTheDocument();
+  });
+
+  it('keeps the Select all not-imported count derived from the full page, not the hidden subset', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: false,
+        total: 2,
+        titles: [
+          { externalGameId: '1', title: 'Hades', playtimeMinutes: 300, iconUrl: null, state: 'importable' },
+          { externalGameId: '2', title: 'Celeste', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    // Before hiding, count shows the importable subset of the full page.
+    expect(screen.getByLabelText(/select all not-imported \(1\)/i)).toBeInTheDocument();
+    await user.click(screen.getByLabelText(/hide imported/i));
+    // Count is unchanged by the hide toggle (still 1 importable on this page).
+    expect(screen.getByLabelText(/select all not-imported \(1\)/i)).toBeInTheDocument();
+  });
+
+  it('pages with Next and shows Prev only after the first page', async () => {
+    const user = userEvent.setup();
+    let callOffset = 0;
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockImplementation((_e, _s, offset: number) => {
+      callOffset = offset;
+      return {
+        data: {
+          status: 'ok',
+          truncated: true, // more pages after this one
+          total: 3,
+          titles: [
+            { externalGameId: String(offset + 1), title: `Game ${offset + 1}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+            { externalGameId: String(offset + 2), title: `Game ${offset + 2}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      };
+    });
+
+    renderPage();
+
+    // Next is enabled (truncated), Prev disabled (offset 0).
+    const next = screen.getByRole('button', { name: /next/i });
+    const prev = screen.getByRole('button', { name: /prev/i });
+    expect(next).toBeEnabled();
+    expect(prev).toBeDisabled();
+
+    await user.click(next);
+    expect(callOffset).toBe(100);
   });
 
   it('shows a qualified public-profile hint when Steam is unavailable', () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -345,6 +345,61 @@ describe('ImportSteam', () => {
     expect(importSelectedMutate).toHaveBeenLastCalledWith(['101']);
   });
 
+  it('disables Repair covers while the import-selected mutation is pending', () => {
+    let hookCall = 0;
+    mockUseImport.mockImplementation(() => {
+      const instance = hookCall % 2;
+      hookCall += 1;
+      return { mutateAsync: vi.fn(), isPending: instance === 0 };
+    });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: false,
+        total: 1,
+        titles: [
+          { externalGameId: '1', title: 'Imported 1', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.getByRole('button', { name: /repair covers/i })).toBeDisabled();
+  });
+
+  it('disables Import selected while the repair mutation is pending', async () => {
+    const user = userEvent.setup();
+    let hookCall = 0;
+    mockUseImport.mockImplementation(() => {
+      const instance = hookCall % 2;
+      hookCall += 1;
+      return { mutateAsync: vi.fn(), isPending: instance === 1 };
+    });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: false,
+        total: 2,
+        titles: [
+          { externalGameId: '1', title: 'Importable 1', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '2', title: 'Imported 2', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByRole('checkbox', { name: /Importable 1/ }));
+
+    expect(screen.getByRole('button', { name: /import selected \(1\)/i })).toBeDisabled();
+  });
+
   it('repairs only imported ids from the currently fetched page', async () => {
     const user = userEvent.setup();
     const importMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 2, items: [] });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -15,8 +15,8 @@ const mockConnectMutate = vi.fn();
 vi.mock('../services/steam', () => ({
   useSteamConnection: () => mockUseConnection(),
   useSteamConnect: () => mockUseConnect(),
-  useSteamGames: (enabled: boolean, search: string, offset: number, limit: number) =>
-    mockUseGames(enabled, search, offset, limit),
+  useSteamGames: (enabled: boolean, search: string, offset: number, limit: number, hideImported: boolean) =>
+    mockUseGames(enabled, search, offset, limit, hideImported),
   useSteamImport: (onSuccess: () => void) => mockUseImport(onSuccess),
   useSteamDisconnect: (onSuccess: () => void) => mockUseDisconnect(onSuccess),
 }));
@@ -51,7 +51,7 @@ describe('ImportSteam', () => {
 
   it('does not fetch games until connected', () => {
     renderPage();
-    expect(mockUseGames).toHaveBeenCalledWith(false, '', 0, 100);
+    expect(mockUseGames).toHaveBeenCalledWith(false, '', 0, 100, false);
   });
 
   it('disconnects and keeps a message that games stay', async () => {
@@ -88,86 +88,68 @@ describe('ImportSteam', () => {
     expect(screen.getAllByText(/in collection/i).length).toBe(1);
   });
 
-  it('hides already-imported titles when the Hide imported toggle is on', async () => {
+  it('requests and renders the server-provided hide-imported page', async () => {
     const user = userEvent.setup();
     mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
-    mockUseGames.mockReturnValue({
+    mockUseGames.mockImplementation((_enabled, _search, _offset, _limit, hideImported) => ({
       data: {
         status: 'ok',
         truncated: false,
-        total: 2,
-        titles: [
-          { externalGameId: '1', title: 'Hades', playtimeMinutes: 300, iconUrl: null, state: 'importable' },
-          { externalGameId: '2', title: 'Celeste', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
-        ],
+        total: hideImported ? 100 : 120,
+        titles: hideImported
+          ? Array.from({ length: 100 }, (_, index) => ({
+              externalGameId: String(index + 21),
+              title: `Importable ${index + 21}`,
+              playtimeMinutes: 0,
+              iconUrl: null,
+              state: 'importable' as const,
+            }))
+          : [{ externalGameId: '1', title: 'Imported 1', playtimeMinutes: 0, iconUrl: null, state: 'imported' as const }],
       },
       isLoading: false,
       error: null,
-    });
+    }));
 
     renderPage();
-
-    expect(screen.getByText('Hades')).toBeInTheDocument();
-    expect(screen.getByText('Celeste')).toBeInTheDocument();
-
     await user.click(screen.getByLabelText(/hide imported/i));
-    expect(screen.queryByText('Celeste')).not.toBeInTheDocument();
-    expect(screen.getByText('Hades')).toBeInTheDocument();
+    expect(mockUseGames).toHaveBeenLastCalledWith(true, '', 0, 100, true);
+    expect(screen.getAllByText(/Importable \d+/)).toHaveLength(100);
+    expect(screen.getByText('1–100 of 100')).toBeInTheDocument();
   });
 
-  it('shows the fetched page range even when Hide imported filters the visible list', async () => {
+  it('offers page sizes 25, 50, and 100 and resets to page one when changed', async () => {
     const user = userEvent.setup();
     mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
     mockUseGames.mockReturnValue({
-      data: {
-        status: 'ok',
-        truncated: false,
-        total: 3,
-        titles: [
-          { externalGameId: '1', title: 'ImportedA', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
-          { externalGameId: '2', title: 'ImportableB', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
-          { externalGameId: '3', title: 'ImportableC', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
-        ],
-      },
+      data: { status: 'ok', truncated: true, total: 300, titles: [] },
       isLoading: false,
       error: null,
     });
     renderPage();
-    // Full page visible first: range reflects 3 fetched titles.
-    expect(screen.getByText(/1–3 of 3/i)).toBeInTheDocument();
-    await user.click(screen.getByRole('checkbox', { name: /hide imported/i }));
-    // Hide removes the imported row from the LIST but the RANGE still reflects
-    // the fetched page (3), and the select-all count still derives from the
-    // UN-HIDDEN page (2 importable).
-    expect(screen.queryByText('ImportedA')).not.toBeInTheDocument();
-    expect(screen.getByText(/1–3 of 3/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/select all not-imported \(2\)/i)).toBeInTheDocument();
+
+    const pageSize = screen.getByRole('combobox', { name: /games per page/i });
+    expect(pageSize).toHaveValue('100');
+    expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual(['25', '50', '100']);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(mockUseGames).toHaveBeenLastCalledWith(true, '', 100, 100, false);
+    await user.selectOptions(pageSize, '25');
+    expect(mockUseGames).toHaveBeenLastCalledWith(true, '', 0, 25, false);
   });
 
-  it('keeps the Select all not-imported count derived from the full page, not the hidden subset', async () => {
+  it('resets to page one immediately when hide-imported changes', async () => {
     const user = userEvent.setup();
     mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
     mockUseGames.mockReturnValue({
-      data: {
-        status: 'ok',
-        truncated: false,
-        total: 2,
-        titles: [
-          { externalGameId: '1', title: 'Hades', playtimeMinutes: 300, iconUrl: null, state: 'importable' },
-          { externalGameId: '2', title: 'Celeste', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
-        ],
-      },
+      data: { status: 'ok', truncated: true, total: 300, titles: [] },
       isLoading: false,
       error: null,
     });
-
     renderPage();
 
-    // Before hiding, count shows the importable subset of the full page.
-    expect(screen.getByLabelText(/select all not-imported \(1\)/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(mockUseGames).toHaveBeenLastCalledWith(true, '', 100, 100, false);
     await user.click(screen.getByLabelText(/hide imported/i));
-    // Count is unchanged by the hide toggle (still 1 importable on this page).
-    expect(screen.getByLabelText(/select all not-imported \(1\)/i)).toBeInTheDocument();
+    expect(mockUseGames).toHaveBeenLastCalledWith(true, '', 0, 100, true);
   });
 
   it('pages with Next and shows Prev only after the first page', async () => {
@@ -305,6 +287,33 @@ describe('ImportSteam', () => {
 
     expect(importMutate).toHaveBeenCalledWith(['1', '2']);
     expect(onSuccess).toBeTypeOf('function');
+  });
+
+  it('repairs only imported ids from the currently fetched page', async () => {
+    const user = userEvent.setup();
+    const importMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 2, items: [] });
+    mockUseImport.mockReturnValue({ mutateAsync: importMutate, isPending: false });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        truncated: true,
+        total: 300,
+        titles: [
+          { externalGameId: '101', title: 'Imported 101', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: '102', title: 'Importable 102', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: '103', title: 'Imported 103', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /repair covers/i }));
+
+    expect(importMutate).toHaveBeenCalledTimes(1);
+    expect(importMutate).toHaveBeenCalledWith(['101', '103']);
   });
 
   it('merges select-all on a later page with selections made on earlier pages', async () => {

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -233,6 +233,39 @@ describe('ImportSteam', () => {
     expect(screen.getByText(/no owned games returned/i)).toBeInTheDocument();
   });
 
+  it('explains when hiding imported games leaves no owned games', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: { status: 'ok', titles: [], truncated: false, total: 0 },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByLabelText(/hide imported/i));
+
+    expect(screen.getByText('All owned games are already in your collection.')).toBeInTheDocument();
+    expect(screen.queryByText(/privacy settings/i)).not.toBeInTheDocument();
+  });
+
+  it('explains when no unimported games match the filter', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: { status: 'ok', titles: [], truncated: false, total: 0 },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByLabelText(/hide imported/i));
+    await user.type(screen.getByLabelText(/filter owned games/i), 'Hades');
+
+    expect(screen.getByText('No unimported games match “Hades”.')).toBeInTheDocument();
+    expect(screen.queryByText(/no matches for/i)).not.toBeInTheDocument();
+  });
+
   it('filters the owned-games list by title (server-side search)', async () => {
     const user = userEvent.setup();
     const allTitles = [

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -336,4 +336,38 @@ describe('ImportSteam', () => {
     await user.click(screen.getByRole('button', { name: /import selected \(3\)/i }));
     expect(importArg ? [...importArg].sort() : []).toEqual(['1', '101', '102'].sort());
   });
+
+  it('deselecting all on a later page keeps earlier-page selections', async () => {
+    const user = userEvent.setup();
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockImplementation((_e, _s, offset: number) => ({
+      data: {
+        status: 'ok',
+        truncated: true,
+        total: 4,
+        titles: [
+          { externalGameId: String(offset + 1), title: `Game ${offset + 1}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+          { externalGameId: String(offset + 2), title: `Game ${offset + 2}`, playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage();
+
+    // Page 1: select-all (selects Games 1 and 2), then advance to page 2.
+    await user.click(screen.getByLabelText(/select all not-imported \(2\)/i));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    // Page 2 shows Games 101/102. First select-all click SELECTS them (else
+    // branch: adds {101,102} to the existing {1,2}, because allImportableSelected
+    // is false on page 2 on this click).
+    await user.click(screen.getByLabelText(/select all not-imported \(2\)/i));
+    // Now all importable on page 2 are selected, so the same button is a
+    // DISMISS. A second click removes ONLY this page's ids (101,102), keeping
+    // the earlier-page picks (1,2). Result: {1,2} -> "Import selected (2)".
+    await user.click(screen.getByLabelText(/select all not-imported \(2\)/i));
+
+    expect(screen.getByRole('button', { name: /import selected \(2\)/i })).toBeInTheDocument();
+  });
 });

--- a/src/client/pages/ImportSteam.test.tsx
+++ b/src/client/pages/ImportSteam.test.tsx
@@ -11,11 +11,14 @@ const mockUseGames = vi.fn();
 const mockUseImport = vi.fn();
 const mockUseDisconnect = vi.fn();
 const mockConnectMutate = vi.fn();
-const { mockToastInfo } = vi.hoisted(() => ({ mockToastInfo: vi.fn() }));
+const { mockToastInfo, mockToastSuccess } = vi.hoisted(() => ({
+  mockToastInfo: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}));
 
 vi.mock('../components/toaster', () => ({
   toast: {
-    success: vi.fn(),
+    success: mockToastSuccess,
     error: vi.fn(),
     info: mockToastInfo,
   },
@@ -458,6 +461,52 @@ describe('ImportSteam', () => {
 
     expect(importMutate).toHaveBeenCalledTimes(1);
     expect(importMutate).toHaveBeenCalledWith(['101', '103']);
+  });
+
+  it('batches only current-page repair ids by the configured import cap', async () => {
+    const user = userEvent.setup();
+    let hookCall = 0;
+    const importSelectedMutate = vi.fn().mockResolvedValue({ imported: 0, alreadyImported: 0, items: [] });
+    const repairCoversMutate = vi.fn()
+      .mockResolvedValueOnce({ imported: 1, alreadyImported: 1, items: [] })
+      .mockResolvedValueOnce({ imported: 0, alreadyImported: 1, items: [] });
+    mockUseImport.mockImplementation(() => {
+      const instance = hookCall % 2;
+      hookCall += 1;
+      return {
+        mutateAsync: instance === 0 ? importSelectedMutate : repairCoversMutate,
+        isPending: false,
+      };
+    });
+    mockUseConnection.mockReturnValue({ data: connected, isLoading: false, error: null });
+    mockUseGames.mockReturnValue({
+      data: {
+        status: 'ok',
+        importCap: 2,
+        truncated: true,
+        total: 300,
+        titles: [
+          { externalGameId: '1', title: 'Imported 1', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: '2', title: 'Imported 2', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: '3', title: 'Imported 3', playtimeMinutes: 0, iconUrl: null, state: 'imported' },
+          { externalGameId: '4', title: 'Importable 4', playtimeMinutes: 0, iconUrl: null, state: 'importable' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    await user.click(screen.getByRole('checkbox', { name: /Importable 4/ }));
+    await user.click(screen.getByRole('button', { name: /repair covers/i }));
+
+    expect(repairCoversMutate.mock.calls).toEqual([[['1', '2']], [['3']]]);
+    expect(mockUseGames.mock.calls.every(([, , offset]) => offset === 0)).toBe(true);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledWith('Re-imported 1 game and refreshed covers');
+
+    await user.click(screen.getByRole('button', { name: /import selected \(1\)/i }));
+    expect(importSelectedMutate).toHaveBeenCalledWith(['4']);
   });
 
   it('merges select-all on a later page with selections made on earlier pages', async () => {

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -93,12 +93,8 @@ export default function ImportSteam() {
       const next = new Set(prev);
       const pageIds = importable.map((g) => g.externalGameId);
       if (allImportableSelected) {
-        // All importable on the current page are already selected: drop only
-        // THIS page's ids, preserving selections made on other pages.
         pageIds.forEach((id) => next.delete(id));
       } else {
-        // Add this page's importable ids to the existing selection, preserving
-        // selections from other pages (matches per-row toggle semantics).
         pageIds.forEach((id) => next.add(id));
       }
       return next;

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -32,7 +32,7 @@ export default function ImportSteam() {
     const t = setTimeout(() => setDebouncedFilter(filter), 300);
     return () => clearTimeout(t);
   }, [filter]);
-  useEffect(() => setOffset(0), [debouncedFilter]);
+  useEffect(() => setOffset(0), [filter]);
   // Search is sent to the server so it filters across the FULL owned library,
   // not just the capped preview slice — reaching lower-playtime titles a user
   // might search for (Codex: paginate/search large libraries).

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -45,7 +45,8 @@ export default function ImportSteam() {
     pageSize,
     hideImported,
   );
-  const doImport = useSteamImport(() => setSelected(new Set()));
+  const importSelected = useSteamImport(() => setSelected(new Set()));
+  const repairCovers = useSteamImport(() => {});
   const disconnect = useSteamDisconnect(() => setSelected(new Set()));
 
   // Surface the OpenID callback outcome once, then clear it from the URL so
@@ -133,7 +134,7 @@ export default function ImportSteam() {
 
   const handleImport = async () => {
     try {
-      const res = await doImport.mutateAsync([...selected]);
+      const res = await importSelected.mutateAsync([...selected]);
       if (res.imported > 0) toast.success(`Imported ${res.imported} game${res.imported === 1 ? '' : 's'}`);
       if (res.alreadyImported > 0) toast.info(`${res.alreadyImported} were already in your collection`);
       // Show the imported games in the collection (spec: import → toast → /games).
@@ -150,7 +151,7 @@ export default function ImportSteam() {
   // cover (the preview doesn't report that, so it's always available; the server
   // simply no-ops on titles that need no healing).
   const handleRepairCovers = async () => {
-    if (doImport.isPending) return;
+    if (repairCovers.isPending) return;
     const importedIds = (games.data?.titles ?? [])
       .filter((g) => g.state === 'imported')
       .map((g) => g.externalGameId);
@@ -159,7 +160,7 @@ export default function ImportSteam() {
       return;
     }
     try {
-      const res = await doImport.mutateAsync(importedIds);
+      const res = await repairCovers.mutateAsync(importedIds);
       toast.success(
         res.imported > 0
           ? `Re-imported ${res.imported} game${res.imported === 1 ? '' : 's'} and refreshed covers`
@@ -304,9 +305,9 @@ export default function ImportSteam() {
                 <Button
                   variant="primary"
                   onClick={handleImport}
-                  disabled={selected.size === 0 || doImport.isPending}
+                  disabled={selected.size === 0 || importSelected.isPending}
                 >
-                  {doImport.isPending
+                  {importSelected.isPending
                     ? 'Importing…'
                     : `Import selected${selected.size ? ` (${selected.size})` : ''}`}
                 </Button>
@@ -314,7 +315,7 @@ export default function ImportSteam() {
                   <Button
                     variant="secondary"
                     onClick={handleRepairCovers}
-                    disabled={doImport.isPending}
+                    disabled={repairCovers.isPending}
                     title="Re-derive missing or stale covers for games imported before the cover fix"
                   >
                     Repair covers

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Button, Card, SectionHeading } from '../components/ui';
 import { toast } from '../components/toaster';
 import {
+  fetchSteamOwnedGames,
   useSteamConnect,
   useSteamConnection,
   useSteamDisconnect,
@@ -142,11 +143,28 @@ export default function ImportSteam() {
   // duplicates the game. Disabled when every imported title already has a local
   // cover (the preview doesn't report that, so it's always available; the server
   // simply no-ops on titles that need no healing).
+  // Enumerate every imported external game id across the whole library (paging
+  // /games by the server's 1000 MaxPageSize until offset >= total) so "Repair
+  // covers" heals all imported titles, not only the current 100-page.
+  const getAllImportedIds = async (): Promise<string[]> => {
+    const PAGE = 1000;
+    const ids: string[] = [];
+    let offset = 0;
+    for (;;) {
+      const page = await fetchSteamOwnedGames('', offset, PAGE);
+      if ((page.titles ?? []).length === 0) break;
+      for (const g of page.titles) {
+        if (g.state === 'imported') ids.push(g.externalGameId);
+      }
+      if (page.total <= offset + page.titles.length) break;
+      offset += PAGE;
+    }
+    return ids;
+  };
+
   const handleRepairCovers = async () => {
     if (doImport.isPending) return;
-    const importedIds = (games.data?.titles ?? [])
-      .filter((g) => g.state === 'imported')
-      .map((g) => g.externalGameId);
+    const importedIds = await getAllImportedIds();
     if (importedIds.length === 0) {
       toast.info('Nothing to repair — no games imported yet.');
       return;

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -47,6 +47,7 @@ export default function ImportSteam() {
   );
   const importSelected = useSteamImport(() => setSelected(new Set()));
   const repairCovers = useSteamImport(() => {});
+  const steamMutationPending = importSelected.isPending || repairCovers.isPending;
   const disconnect = useSteamDisconnect(() => setSelected(new Set()));
 
   // Surface the OpenID callback outcome once, then clear it from the URL so
@@ -133,6 +134,7 @@ export default function ImportSteam() {
   };
 
   const handleImport = async () => {
+    if (steamMutationPending) return;
     try {
       const res = await importSelected.mutateAsync([...selected]);
       if (res.imported > 0) toast.success(`Imported ${res.imported} game${res.imported === 1 ? '' : 's'}`);
@@ -151,7 +153,7 @@ export default function ImportSteam() {
   // cover (the preview doesn't report that, so it's always available; the server
   // simply no-ops on titles that need no healing).
   const handleRepairCovers = async () => {
-    if (repairCovers.isPending) return;
+    if (steamMutationPending) return;
     const importedIds = (games.data?.titles ?? [])
       .filter((g) => g.state === 'imported')
       .map((g) => g.externalGameId);
@@ -305,7 +307,7 @@ export default function ImportSteam() {
                 <Button
                   variant="primary"
                   onClick={handleImport}
-                  disabled={selected.size === 0 || importSelected.isPending}
+                  disabled={selected.size === 0 || steamMutationPending}
                 >
                   {importSelected.isPending
                     ? 'Importing…'
@@ -315,7 +317,7 @@ export default function ImportSteam() {
                   <Button
                     variant="secondary"
                     onClick={handleRepairCovers}
-                    disabled={repairCovers.isPending}
+                    disabled={steamMutationPending}
                     title="Re-derive missing or stale covers for games imported before the cover fix"
                   >
                     Repair covers

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -24,6 +24,7 @@ export default function ImportSteam() {
   const [pageSize, setPageSize] = useState(100);
   const [offset, setOffset] = useState(0);
   const [hideImported, setHideImported] = useState(false);
+  const [repairBatchPending, setRepairBatchPending] = useState(false);
 
   const connection = useSteamConnection();
   const connect = useSteamConnect();
@@ -44,7 +45,7 @@ export default function ImportSteam() {
   );
   const importSelected = useSteamImport(() => setSelected(new Set()));
   const repairCovers = useSteamImport(() => {});
-  const steamMutationPending = importSelected.isPending || repairCovers.isPending;
+  const steamMutationPending = importSelected.isPending || repairCovers.isPending || repairBatchPending;
   const disconnect = useSteamDisconnect(() => setSelected(new Set()));
 
   // Surface the OpenID callback outcome once, then clear it from the URL so
@@ -159,15 +160,24 @@ export default function ImportSteam() {
       toast.info('Nothing to repair — no games imported yet.');
       return;
     }
+    setRepairBatchPending(true);
     try {
-      const res = await repairCovers.mutateAsync(importedIds);
+      let imported = 0;
+      let alreadyImported = 0;
+      for (let index = 0; index < importedIds.length; index += importCap) {
+        const res = await repairCovers.mutateAsync(importedIds.slice(index, index + importCap));
+        imported += res.imported;
+        alreadyImported += res.alreadyImported;
+      }
       toast.success(
-        res.imported > 0
-          ? `Re-imported ${res.imported} game${res.imported === 1 ? '' : 's'} and refreshed covers`
-          : `Refreshed covers for ${res.alreadyImported} imported game${res.alreadyImported === 1 ? '' : 's'}`,
+        imported > 0
+          ? `Re-imported ${imported} game${imported === 1 ? '' : 's'} and refreshed covers`
+          : `Refreshed covers for ${alreadyImported} imported game${alreadyImported === 1 ? '' : 's'}`,
       );
     } catch {
       toast.error('Could not refresh covers. Please try again.');
+    } finally {
+      setRepairBatchPending(false);
     }
   };
 

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -33,9 +33,8 @@ export default function ImportSteam() {
     return () => clearTimeout(t);
   }, [filter]);
   useEffect(() => setOffset(0), [filter]);
-  // Search is sent to the server so it filters across the FULL owned library,
-  // not just the capped preview slice — reaching lower-playtime titles a user
-  // might search for (Codex: paginate/search large libraries).
+  // Search is sent to the server so it filters across the full owned library,
+  // not just the current page, reaching lower-playtime titles a user might search for.
   const games = useSteamGames(
     connection.data?.connected === true,
     filter.trim() ? debouncedFilter : '',

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -256,8 +256,8 @@ export default function ImportSteam() {
                 className="w-full rounded-md border border-border px-3 py-2 text-sm"
                 aria-label="Filter owned games"
               />
-              <div className="flex items-center gap-4 pt-2">
-                <label className="flex items-center gap-2 text-sm font-semibold text-text-secondary">
+              <div className="flex flex-col items-stretch gap-3 pt-2 sm:flex-row sm:items-center sm:gap-4">
+                <label className="flex shrink-0 items-center gap-2 text-sm font-semibold text-text-secondary">
                   <input
                     type="checkbox"
                     checked={hideImported}
@@ -268,7 +268,7 @@ export default function ImportSteam() {
                   />
                   Hide imported
                 </label>
-                <div className="ml-auto flex items-center gap-2">
+                <div className="flex w-full flex-wrap items-center justify-between gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap sm:justify-end">
                   <label className="flex items-center gap-2 text-xs text-text-tertiary">
                     Games per page
                     <select
@@ -328,7 +328,11 @@ export default function ImportSteam() {
               <Card className="divide-y divide-border">
                 {rendered.length === 0 ? (
                   <p className="px-3 py-2.5 text-sm text-text-tertiary">
-                    {filter.trim()
+                    {hideImported
+                      ? filter.trim()
+                        ? `No unimported games match “${filter}”.`
+                        : 'All owned games are already in your collection.'
+                      : filter.trim()
                         ? `No matches for “${filter}”.`
                         : <>No owned games returned. Make sure your Steam profile's game details are set to <strong className="text-text-secondary">Public</strong> in Privacy Settings, then try again.</>}
                   </p>

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -21,7 +21,7 @@ export default function ImportSteam() {
   const navigate = useNavigate();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [filter, setFilter] = useState('');
-  const PAGE_SIZE = 100;
+  const [pageSize, setPageSize] = useState(100);
   const [offset, setOffset] = useState(0);
   const [hideImported, setHideImported] = useState(false);
 
@@ -40,7 +40,8 @@ export default function ImportSteam() {
     connection.data?.connected === true,
     filter.trim() ? debouncedFilter : '',
     offset,
-    PAGE_SIZE,
+    pageSize,
+    hideImported,
   );
   const doImport = useSteamImport(() => setSelected(new Set()));
   const disconnect = useSteamDisconnect(() => setSelected(new Set()));
@@ -67,15 +68,7 @@ export default function ImportSteam() {
     [games.data],
   );
 
-  // The server already applies the search filter across the full library, so
-  // what we render is exactly the filtered page (no client-side re-filter).
-  // "Hide imported" additionally drops imported rows from the RENDERED list so
-  // the remaining importable set is immediately visible; it never changes the
-  // selectable count (which stays derived from the un-hidden page via
-  // `importable` above).
-  const rendered = hideImported
-    ? (games.data?.titles ?? []).filter((g) => g.state === 'importable')
-    : (games.data?.titles ?? []);
+  const rendered = games.data?.titles ?? [];
 
   const toggle = (id: string) =>
     setSelected((prev) => {
@@ -251,12 +244,30 @@ export default function ImportSteam() {
                   <input
                     type="checkbox"
                     checked={hideImported}
-                    onChange={(e) => setHideImported(e.target.checked)}
+                    onChange={(e) => {
+                      setHideImported(e.target.checked);
+                      setOffset(0);
+                    }}
                   />
                   Hide imported
                 </label>
                 <div className="ml-auto flex items-center gap-2">
-                  <Button variant="secondary" onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))} disabled={offset === 0}>
+                  <label className="flex items-center gap-2 text-xs text-text-tertiary">
+                    Games per page
+                    <select
+                      value={pageSize}
+                      onChange={(e) => {
+                        setPageSize(Number(e.target.value));
+                        setOffset(0);
+                      }}
+                      className="rounded-md border border-border bg-card px-2 py-1 text-sm text-text-primary"
+                    >
+                      <option value={25}>25</option>
+                      <option value={50}>50</option>
+                      <option value={100}>100</option>
+                    </select>
+                  </label>
+                  <Button variant="secondary" onClick={() => setOffset((o) => Math.max(0, o - pageSize))} disabled={offset === 0}>
                     Prev
                   </Button>
                   <span className="text-xs text-text-tertiary">
@@ -264,7 +275,7 @@ export default function ImportSteam() {
                   </span>
                   <Button
                     variant="secondary"
-                    onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                    onClick={() => setOffset((o) => o + pageSize)}
                     disabled={!games.data.truncated}
                   >
                     Next
@@ -275,11 +286,6 @@ export default function ImportSteam() {
                 <label className="flex items-center gap-2 text-sm font-semibold text-text-secondary">
                   <input type="checkbox" checked={allImportableSelected} onChange={toggleAll} disabled={games.data.titles.length === 0} />
                   Select all not-imported ({importable.length})
-                  {games.data.truncated && (
-                    <span className="font-normal text-xs text-text-tertiary">
-                      (showing first {games.data.titles.length})
-                    </span>
-                  )}
                 </label>
                 <Button
                   variant="primary"
@@ -305,9 +311,7 @@ export default function ImportSteam() {
               <Card className="divide-y divide-border">
                 {rendered.length === 0 ? (
                   <p className="px-3 py-2.5 text-sm text-text-tertiary">
-                    {hideImported && (games.data?.titles ?? []).length > 0
-                      ? 'All titles on this page are already in your collection.'
-                      : filter.trim()
+                    {filter.trim()
                         ? `No matches for “${filter}”.`
                         : <>No owned games returned. Make sure your Steam profile's game details are set to <strong className="text-text-secondary">Public</strong> in Privacy Settings, then try again.</>}
                   </p>

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -264,7 +264,7 @@ export default function ImportSteam() {
                     Prev
                   </Button>
                   <span className="text-xs text-text-tertiary">
-                    {games.data.total > 0 ? `${offset + 1}–${Math.min(offset + rendered.length, games.data.total)} of ${games.data.total}` : ''}
+                    {games.data.total > 0 ? `${offset + 1}–${Math.min(offset + games.data.titles.length, games.data.total)} of ${games.data.total}` : ''}
                   </span>
                   <Button
                     variant="secondary"

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -21,6 +21,9 @@ export default function ImportSteam() {
   const navigate = useNavigate();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [filter, setFilter] = useState('');
+  const PAGE_SIZE = 100;
+  const [offset, setOffset] = useState(0);
+  const [hideImported, setHideImported] = useState(false);
 
   const connection = useSteamConnection();
   const connect = useSteamConnect();
@@ -29,12 +32,15 @@ export default function ImportSteam() {
     const t = setTimeout(() => setDebouncedFilter(filter), 300);
     return () => clearTimeout(t);
   }, [filter]);
+  useEffect(() => setOffset(0), [debouncedFilter]);
   // Search is sent to the server so it filters across the FULL owned library,
   // not just the capped preview slice — reaching lower-playtime titles a user
   // might search for (Codex: paginate/search large libraries).
   const games = useSteamGames(
     connection.data?.connected === true,
     filter.trim() ? debouncedFilter : '',
+    offset,
+    PAGE_SIZE,
   );
   const doImport = useSteamImport(() => setSelected(new Set()));
   const disconnect = useSteamDisconnect(() => setSelected(new Set()));
@@ -62,8 +68,14 @@ export default function ImportSteam() {
   );
 
   // The server already applies the search filter across the full library, so
-  // what we render is exactly the filtered result (no client-side re-filter).
-  const filtered = games.data?.titles ?? [];
+  // what we render is exactly the filtered page (no client-side re-filter).
+  // "Hide imported" additionally drops imported rows from the RENDERED list so
+  // the remaining importable set is immediately visible; it never changes the
+  // selectable count (which stays derived from the un-hidden page via
+  // `importable` above).
+  const rendered = hideImported
+    ? (games.data?.titles ?? []).filter((g) => g.state === 'importable')
+    : (games.data?.titles ?? []);
 
   const toggle = (id: string) =>
     setSelected((prev) => {
@@ -225,6 +237,31 @@ export default function ImportSteam() {
                 className="w-full rounded-md border border-border px-3 py-2 text-sm"
                 aria-label="Filter owned games"
               />
+              <div className="flex items-center gap-4 pt-2">
+                <label className="flex items-center gap-2 text-sm font-semibold text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={hideImported}
+                    onChange={(e) => setHideImported(e.target.checked)}
+                  />
+                  Hide imported
+                </label>
+                <div className="ml-auto flex items-center gap-2">
+                  <Button variant="secondary" onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))} disabled={offset === 0}>
+                    Prev
+                  </Button>
+                  <span className="text-xs text-text-tertiary">
+                    {games.data.total > 0 ? `${offset + 1}–${Math.min(offset + rendered.length, games.data.total)} of ${games.data.total}` : ''}
+                  </span>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                    disabled={!games.data.truncated}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
               <div className="flex items-center justify-between gap-4">
                 <label className="flex items-center gap-2 text-sm font-semibold text-text-secondary">
                   <input type="checkbox" checked={allImportableSelected} onChange={toggleAll} disabled={games.data.titles.length === 0} />
@@ -257,14 +294,16 @@ export default function ImportSteam() {
               </div>
 
               <Card className="divide-y divide-border">
-                {filtered.length === 0 ? (
+                {rendered.length === 0 ? (
                   <p className="px-3 py-2.5 text-sm text-text-tertiary">
-                    {filter.trim()
-                      ? `No matches for “${filter}”.`
-                      : <>No owned games returned. Make sure your Steam profile's game details are set to <strong className="text-text-secondary">Public</strong> in Privacy Settings, then try again.</>}
+                    {hideImported && (games.data?.titles ?? []).length > 0
+                      ? 'All titles on this page are already in your collection.'
+                      : filter.trim()
+                        ? `No matches for “${filter}”.`
+                        : <>No owned games returned. Make sure your Steam profile's game details are set to <strong className="text-text-secondary">Public</strong> in Privacy Settings, then try again.</>}
                   </p>
                 ) : (
-                  filtered.map((g) => {
+                  rendered.map((g) => {
                     const isImported = g.state === 'imported';
                     const checked = selected.has(g.externalGameId);
                     return (

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -3,7 +3,6 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Button, Card, SectionHeading } from '../components/ui';
 import { toast } from '../components/toaster';
 import {
-  fetchSteamOwnedGames,
   useSteamConnect,
   useSteamConnection,
   useSteamDisconnect,
@@ -143,28 +142,11 @@ export default function ImportSteam() {
   // duplicates the game. Disabled when every imported title already has a local
   // cover (the preview doesn't report that, so it's always available; the server
   // simply no-ops on titles that need no healing).
-  // Enumerate every imported external game id across the whole library (paging
-  // /games by the server's 1000 MaxPageSize until offset >= total) so "Repair
-  // covers" heals all imported titles, not only the current 100-page.
-  const getAllImportedIds = async (): Promise<string[]> => {
-    const PAGE = 1000;
-    const ids: string[] = [];
-    let offset = 0;
-    for (;;) {
-      const page = await fetchSteamOwnedGames('', offset, PAGE);
-      if ((page.titles ?? []).length === 0) break;
-      for (const g of page.titles) {
-        if (g.state === 'imported') ids.push(g.externalGameId);
-      }
-      if (page.total <= offset + page.titles.length) break;
-      offset += PAGE;
-    }
-    return ids;
-  };
-
   const handleRepairCovers = async () => {
     if (doImport.isPending) return;
-    const importedIds = await getAllImportedIds();
+    const importedIds = (games.data?.titles ?? [])
+      .filter((g) => g.state === 'imported')
+      .map((g) => g.externalGameId);
     if (importedIds.length === 0) {
       toast.info('Nothing to repair — no games imported yet.');
       return;

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -10,8 +10,6 @@ import {
   useSteamImport,
 } from '../services/steam';
 
-const MAX_SELECTIONS = 500;
-
 function formatPlaytime(minutes: number): string {
   if (!minutes) return '';
   const h = Math.floor(minutes / 60);
@@ -73,6 +71,7 @@ export default function ImportSteam() {
   );
 
   const rendered = games.data?.titles ?? [];
+  const importCap = games.data?.importCap ?? 500;
 
   const toggle = (id: string) => {
     const next = new Set(selected);
@@ -81,8 +80,8 @@ export default function ImportSteam() {
       setSelected(next);
       return;
     }
-    if (next.size >= MAX_SELECTIONS) {
-      toast.info('You can select up to 500 games at a time.');
+    if (next.size >= importCap) {
+      toast.info(`You can select up to ${importCap} games at a time.`);
       return;
     }
     next.add(id);
@@ -102,11 +101,11 @@ export default function ImportSteam() {
     }
 
     const additions = pageIds.filter((id) => !next.has(id));
-    const remaining = MAX_SELECTIONS - next.size;
+    const remaining = importCap - next.size;
     additions.slice(0, remaining).forEach((id) => next.add(id));
     setSelected(next);
     if (additions.length > remaining)
-      toast.info('You can select up to 500 games at a time.');
+      toast.info(`You can select up to ${importCap} games at a time.`);
   };
 
   const handleConnect = async () => {

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -10,6 +10,8 @@ import {
   useSteamImport,
 } from '../services/steam';
 
+const MAX_SELECTIONS = 500;
+
 function formatPlaytime(minutes: number): string {
   if (!minutes) return '';
   const h = Math.floor(minutes / 60);
@@ -70,28 +72,40 @@ export default function ImportSteam() {
 
   const rendered = games.data?.titles ?? [];
 
-  const toggle = (id: string) =>
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) {
+      next.delete(id);
+      setSelected(next);
+      return;
+    }
+    if (next.size >= MAX_SELECTIONS) {
+      toast.info('You can select up to 500 games at a time.');
+      return;
+    }
+    next.add(id);
+    setSelected(next);
+  };
 
   const allImportableSelected =
     importable.length > 0 && importable.every((g) => selected.has(g.externalGameId));
 
-  const toggleAll = () =>
-    setSelected((prev) => {
-      const next = new Set(prev);
-      const pageIds = importable.map((g) => g.externalGameId);
-      if (allImportableSelected) {
-        pageIds.forEach((id) => next.delete(id));
-      } else {
-        pageIds.forEach((id) => next.add(id));
-      }
-      return next;
-    });
+  const toggleAll = () => {
+    const next = new Set(selected);
+    const pageIds = importable.map((g) => g.externalGameId);
+    if (allImportableSelected) {
+      pageIds.forEach((id) => next.delete(id));
+      setSelected(next);
+      return;
+    }
+
+    const additions = pageIds.filter((id) => !next.has(id));
+    const remaining = MAX_SELECTIONS - next.size;
+    additions.slice(0, remaining).forEach((id) => next.add(id));
+    setSelected(next);
+    if (additions.length > remaining)
+      toast.info('You can select up to 500 games at a time.');
+  };
 
   const handleConnect = async () => {
     try {

--- a/src/client/pages/ImportSteam.tsx
+++ b/src/client/pages/ImportSteam.tsx
@@ -89,7 +89,20 @@ export default function ImportSteam() {
     importable.length > 0 && importable.every((g) => selected.has(g.externalGameId));
 
   const toggleAll = () =>
-    setSelected(allImportableSelected ? new Set() : new Set(importable.map((g) => g.externalGameId)));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const pageIds = importable.map((g) => g.externalGameId);
+      if (allImportableSelected) {
+        // All importable on the current page are already selected: drop only
+        // THIS page's ids, preserving selections made on other pages.
+        pageIds.forEach((id) => next.delete(id));
+      } else {
+        // Add this page's importable ids to the existing selection, preserving
+        // selections from other pages (matches per-row toggle semantics).
+        pageIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
 
   const handleConnect = async () => {
     try {

--- a/src/client/services/steam.ts
+++ b/src/client/services/steam.ts
@@ -52,15 +52,16 @@ export function useSteamConnect() {
   });
 }
 
-export function useSteamGames(enabled: boolean, search = '', offset = 0, limit = 100) {
+export function useSteamGames(enabled: boolean, search = '', offset = 0, limit = 100, hideImported = false) {
   return useQuery<SteamPreview>({
-    queryKey: ['steam', 'games', search.trim().toLowerCase(), offset, limit],
+    queryKey: ['steam', 'games', search.trim().toLowerCase(), offset, limit, hideImported],
     queryFn: () => {
       const params = new URLSearchParams();
       const q = search.trim();
       if (q) params.set('q', q);
       if (offset > 0) params.set('offset', String(offset));
       params.set('limit', String(limit));
+      if (hideImported) params.set('hideImported', 'true');
       const qs = params.toString();
       return api<SteamPreview>(`/api/accounts/steam/games${qs ? `?${qs}` : ''}`);
     },

--- a/src/client/services/steam.ts
+++ b/src/client/services/steam.ts
@@ -68,6 +68,22 @@ export function useSteamGames(enabled: boolean, search = '', offset = 0, limit =
   });
 }
 
+/** Imperative counterpart to useSteamGames for one /games page. Used by
+ *  "Repair covers" to enumerate imported ids across the whole library. */
+export async function fetchSteamOwnedGames(
+  search: string,
+  offset: number,
+  limit: number,
+): Promise<SteamPreview> {
+  const params = new URLSearchParams();
+  const q = search.trim();
+  if (q) params.set('q', q);
+  if (offset > 0) params.set('offset', String(offset));
+  params.set('limit', String(limit));
+  const qs = params.toString();
+  return api<SteamPreview>(`/api/accounts/steam/games${qs ? `?${qs}` : ''}`);
+}
+
 export function useSteamImport(onSuccess: () => void) {
   const qc = useQueryClient();
   return useMutation({

--- a/src/client/services/steam.ts
+++ b/src/client/services/steam.ts
@@ -29,6 +29,8 @@ export interface SteamPreview {
   status: string;
   titles: SteamOwnedTitle[];
   truncated: boolean;
+  /** Total searched-library titles (before paging) — enables paging controls. */
+  total: number;
 }
 
 export interface SteamImportResult {
@@ -50,12 +52,17 @@ export function useSteamConnect() {
   });
 }
 
-export function useSteamGames(enabled: boolean, search = '') {
+export function useSteamGames(enabled: boolean, search = '', offset = 0, limit = 100) {
   return useQuery<SteamPreview>({
-    queryKey: ['steam', 'games', search.trim().toLowerCase()],
+    queryKey: ['steam', 'games', search.trim().toLowerCase(), offset, limit],
     queryFn: () => {
+      const params = new URLSearchParams();
       const q = search.trim();
-      return api<SteamPreview>(`/api/accounts/steam/games${q ? `?q=${encodeURIComponent(q)}` : ''}`);
+      if (q) params.set('q', q);
+      if (offset > 0) params.set('offset', String(offset));
+      params.set('limit', String(limit));
+      const qs = params.toString();
+      return api<SteamPreview>(`/api/accounts/steam/games${qs ? `?${qs}` : ''}`);
     },
     enabled,
   });

--- a/src/client/services/steam.ts
+++ b/src/client/services/steam.ts
@@ -68,22 +68,6 @@ export function useSteamGames(enabled: boolean, search = '', offset = 0, limit =
   });
 }
 
-/** Imperative counterpart to useSteamGames for one /games page. Used by
- *  "Repair covers" to enumerate imported ids across the whole library. */
-export async function fetchSteamOwnedGames(
-  search: string,
-  offset: number,
-  limit: number,
-): Promise<SteamPreview> {
-  const params = new URLSearchParams();
-  const q = search.trim();
-  if (q) params.set('q', q);
-  if (offset > 0) params.set('offset', String(offset));
-  params.set('limit', String(limit));
-  const qs = params.toString();
-  return api<SteamPreview>(`/api/accounts/steam/games${qs ? `?${qs}` : ''}`);
-}
-
 export function useSteamImport(onSuccess: () => void) {
   const qc = useQueryClient();
   return useMutation({

--- a/src/client/services/steam.ts
+++ b/src/client/services/steam.ts
@@ -31,6 +31,8 @@ export interface SteamPreview {
   truncated: boolean;
   /** Total searched-library titles (before paging) — enables paging controls. */
   total: number;
+  /** Server-configured maximum number of distinct games accepted per import. */
+  importCap: number;
 }
 
 export interface SteamImportResult {

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Collections.Specialized;
-using Collectify.Domain.Entities;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup.Igdb;
 using Collectify.Infrastructure.Store;
@@ -184,35 +183,26 @@ public static class SteamStoreEndpoints
             if (!schemaGuard.IsSchemaReady)
                 return Results.Ok(new SteamImportResultDto(0, 0, []));
 
-            // Accept selections larger than the single-request cap. Pagination
-            // (#181) lets a user select across pages, so tens of hundreds is a
-            // legitimate total, not an error. The import runs in ImportCap-sized
-            // server-side chunks (ImportAsync is idempotent and self-bounds each
-            // call at ImportCap), and results are aggregated across chunks.
-            // A hard ceiling still guards against runaway/bot-sized requests.
-            var distinct = req?.ExternalGameIds
-                ?.Where(id => !string.IsNullOrWhiteSpace(id))
-                .Distinct().ToList() ?? [];
-            if (distinct.Count == 0)
+            // Reject oversized selections up front (400) rather than quietly
+            // processing a capped prefix — "you picked too many to import".
+            var distinct = req?.ExternalGameIds?
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct().Count() ?? 0;
+            if (distinct == 0)
                 return Results.BadRequest(new { error = "No games selected to import." });
-            if (distinct.Count > options.Value.Steam.MaxImportBatch)
+            if (distinct > options.Value.Steam.ImportCap)
                 return Results.BadRequest(new
                 {
                     error = "Too many games selected.",
-                    cap = options.Value.Steam.MaxImportBatch,
-                    submitted = distinct.Count,
+                    cap = options.Value.Steam.ImportCap,
+                    submitted = distinct,
                 });
 
             var ownerId = users.GetUserId(ctx.User)!;
-            // req guaranteed non-null past the guards above.
-            var results = new List<SteamImportResultItem>();
-            var createdGames = new List<Game>();
-            foreach (var chunk in distinct.Chunk(options.Value.Steam.ImportCap))
-            {
-                var (cr, cg) = await service.ImportAsync(ownerId, chunk, ct);
-                results.AddRange(cr);
-                createdGames.AddRange(cg);
-            }
+            // req is guaranteed non-null here: the guards above returned a 400
+            // unless ExternalGameIds had at least one non-whitespace item.
+            var gameIds = req?.ExternalGameIds ?? [];
+            var (results, createdGames) = await service.ImportAsync(ownerId, gameIds, ct);
 
             // Imported games show up empty until the backfill sweep runs (which,
             // even with the startup sweep, is only on the NEXT boot or a timer

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -140,7 +140,6 @@ public static class SteamStoreEndpoints
             UserManager<AppUser> users,
             SteamSchemaGuard schemaGuard,
             SteamStoreImportService service,
-            Microsoft.Extensions.Configuration.IConfiguration config,
             IOptions<SteamOptions> options,
             CancellationToken ct) =>
         {

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -12,7 +12,7 @@ public static class SteamStoreEndpoints
 {
     private const string SpaImportPath = "/import/steam";
     private const string SteamAuthCookie = "collectify.steam.state";
-    private const int MaxPageSize = 1000;
+    private const int MaxPageSize = 100;
     private static readonly TimeSpan AuthRequestLifetime = TimeSpan.FromMinutes(10);
 
     public record SteamConnectDto(bool Configured, string? RedirectUrl);
@@ -137,6 +137,7 @@ public static class SteamStoreEndpoints
             string? q,
             int? offset,
             int? limit,
+            bool? hideImported,
             UserManager<AppUser> users,
             SteamSchemaGuard schemaGuard,
             SteamStoreImportService service,
@@ -146,7 +147,7 @@ public static class SteamStoreEndpoints
             if (!schemaGuard.IsSchemaReady)
                 return Results.Ok(new SteamPreviewDto("notconnected", [], false, 0));
             var effOffset = offset ?? 0;
-            var effLimit = limit ?? options.Value.Steam.PreviewCap;
+            var effLimit = limit ?? MaxPageSize;
             if (effOffset < 0 || effLimit < 1 || effLimit > MaxPageSize)
                 return Results.BadRequest(new
                 {
@@ -156,7 +157,13 @@ public static class SteamStoreEndpoints
                     maxLimit = MaxPageSize,
                 });
             var ownerId = users.GetUserId(ctx.User)!;
-            var preview = await service.GetOwnedTitlesAsync(ownerId, q, effOffset, effLimit, ct);
+            var preview = await service.GetOwnedTitlesAsync(
+                ownerId,
+                search: q,
+                offset: effOffset,
+                limit: effLimit,
+                hideImported: hideImported ?? false,
+                ct: ct);
             return Results.Ok(new SteamPreviewDto(
                 preview.Status.ToString().ToLowerInvariant(),
                 preview.Titles

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -4,6 +4,7 @@ using Collectify.Infrastructure.Lookup.Igdb;
 using Collectify.Infrastructure.Store;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Collectify.Api.Endpoints;
 
@@ -11,12 +12,13 @@ public static class SteamStoreEndpoints
 {
     private const string SpaImportPath = "/import/steam";
     private const string SteamAuthCookie = "collectify.steam.state";
+    private const int MaxPageSize = 1000;
     private static readonly TimeSpan AuthRequestLifetime = TimeSpan.FromMinutes(10);
 
     public record SteamConnectDto(bool Configured, string? RedirectUrl);
     public record SteamConnectionDto(bool Connected, string? SteamId, string? PersonaName);
     public record SteamOwnedTitleDto(string ExternalGameId, string Title, long PlaytimeMinutes, string? IconUrl, string? LogoUrl, string State);
-    public record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated);
+    public record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total);
     public record SteamImportRequest(string[]? ExternalGameIds);
     public record SteamImportItemDto(string ExternalGameId, bool Imported, bool AlreadyImported);
     public record SteamImportResultDto(int Imported, int AlreadyImported, SteamImportItemDto[] Items);
@@ -133,15 +135,29 @@ public static class SteamStoreEndpoints
         group.MapGet("/games", async (
             HttpContext ctx,
             string? q,
+            int? offset,
+            int? limit,
             UserManager<AppUser> users,
             SteamSchemaGuard schemaGuard,
             SteamStoreImportService service,
+            Microsoft.Extensions.Configuration.IConfiguration config,
+            IOptions<SteamOptions> options,
             CancellationToken ct) =>
         {
             if (!schemaGuard.IsSchemaReady)
-                return Results.Ok(new SteamPreviewDto("notconnected", [], false));
+                return Results.Ok(new SteamPreviewDto("notconnected", [], false, 0));
+            var effOffset = offset ?? 0;
+            var effLimit = limit ?? options.Value.Steam.PreviewCap;
+            if (effOffset < 0 || effLimit < 1 || effLimit > MaxPageSize)
+                return Results.BadRequest(new
+                {
+                    error = "Invalid pagination.",
+                    offset = effOffset,
+                    limit = effLimit,
+                    maxLimit = MaxPageSize,
+                });
             var ownerId = users.GetUserId(ctx.User)!;
-            var preview = await service.GetOwnedTitlesAsync(ownerId, q, ct);
+            var preview = await service.GetOwnedTitlesAsync(ownerId, q, effOffset, effLimit, ct);
             return Results.Ok(new SteamPreviewDto(
                 preview.Status.ToString().ToLowerInvariant(),
                 preview.Titles
@@ -149,7 +165,8 @@ public static class SteamStoreEndpoints
                         t.ExternalGameId, t.Title, t.PlaytimeMinutes, t.IconUrl, t.LogoUrl,
                         t.State == SteamTitleImportState.Imported ? "imported" : "importable"))
                     .ToArray(),
-                preview.Truncated));
+                preview.Truncated,
+                preview.Total));
         });
 
         group.MapPost("/import", async (

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -18,7 +18,7 @@ public static class SteamStoreEndpoints
     public record SteamConnectDto(bool Configured, string? RedirectUrl);
     public record SteamConnectionDto(bool Connected, string? SteamId, string? PersonaName);
     public record SteamOwnedTitleDto(string ExternalGameId, string Title, long PlaytimeMinutes, string? IconUrl, string? LogoUrl, string State);
-    public record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total);
+    public record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total, int ImportCap);
     public record SteamImportRequest(string[]? ExternalGameIds);
     public record SteamImportItemDto(string ExternalGameId, bool Imported, bool AlreadyImported);
     public record SteamImportResultDto(int Imported, int AlreadyImported, SteamImportItemDto[] Items);
@@ -145,7 +145,7 @@ public static class SteamStoreEndpoints
             CancellationToken ct) =>
         {
             if (!schemaGuard.IsSchemaReady)
-                return Results.Ok(new SteamPreviewDto("notconnected", [], false, 0));
+                return Results.Ok(new SteamPreviewDto("notconnected", [], false, 0, options.Value.Steam.ImportCap));
             var effOffset = offset ?? 0;
             var effLimit = limit ?? MaxPageSize;
             if (effOffset < 0 || effLimit < 1 || effLimit > MaxPageSize)
@@ -172,7 +172,8 @@ public static class SteamStoreEndpoints
                         t.State == SteamTitleImportState.Imported ? "imported" : "importable"))
                     .ToArray(),
                 preview.Truncated,
-                preview.Total));
+                preview.Total,
+                options.Value.Steam.ImportCap));
         });
 
         group.MapPost("/import", async (

--- a/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/SteamStoreEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Collections.Specialized;
+using Collectify.Domain.Entities;
 using Collectify.Infrastructure.Identity;
 using Collectify.Infrastructure.Lookup.Igdb;
 using Collectify.Infrastructure.Store;
@@ -183,26 +184,35 @@ public static class SteamStoreEndpoints
             if (!schemaGuard.IsSchemaReady)
                 return Results.Ok(new SteamImportResultDto(0, 0, []));
 
-            // Reject oversized selections up front (400) rather than quietly
-            // processing a capped prefix — "you picked too many to import".
-            var distinct = req?.ExternalGameIds?
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Distinct().Count() ?? 0;
-            if (distinct == 0)
+            // Accept selections larger than the single-request cap. Pagination
+            // (#181) lets a user select across pages, so tens of hundreds is a
+            // legitimate total, not an error. The import runs in ImportCap-sized
+            // server-side chunks (ImportAsync is idempotent and self-bounds each
+            // call at ImportCap), and results are aggregated across chunks.
+            // A hard ceiling still guards against runaway/bot-sized requests.
+            var distinct = req?.ExternalGameIds
+                ?.Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct().ToList() ?? [];
+            if (distinct.Count == 0)
                 return Results.BadRequest(new { error = "No games selected to import." });
-            if (distinct > options.Value.Steam.ImportCap)
+            if (distinct.Count > options.Value.Steam.MaxImportBatch)
                 return Results.BadRequest(new
                 {
                     error = "Too many games selected.",
-                    cap = options.Value.Steam.ImportCap,
-                    submitted = distinct,
+                    cap = options.Value.Steam.MaxImportBatch,
+                    submitted = distinct.Count,
                 });
 
             var ownerId = users.GetUserId(ctx.User)!;
-            // req is guaranteed non-null here: the guards above returned a 400
-            // unless ExternalGameIds had at least one non-whitespace item.
-            var gameIds = req?.ExternalGameIds ?? [];
-            var (results, createdGames) = await service.ImportAsync(ownerId, gameIds, ct);
+            // req guaranteed non-null past the guards above.
+            var results = new List<SteamImportResultItem>();
+            var createdGames = new List<Game>();
+            foreach (var chunk in distinct.Chunk(options.Value.Steam.ImportCap))
+            {
+                var (cr, cg) = await service.ImportAsync(ownerId, chunk, ct);
+                results.AddRange(cr);
+                createdGames.AddRange(cg);
+            }
 
             // Imported games show up empty until the backfill sweep runs (which,
             // even with the startup sweep, is only on the NEXT boot or a timer

--- a/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
@@ -25,10 +25,6 @@ public sealed class SteamOptions
         public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(5);
         /// <summary>Max titles a single import may create/select (payload bound).</summary>
         public int ImportCap { get; set; } = 500;
-        /// <summary>Hard ceiling on one /import request's distinct ids, above
-        /// which the endpoint rejects rather than processing tens of thousands of
-        /// ids in server-side chunks. Guard against runaway/bot requests.</summary>
-        public int MaxImportBatch { get; set; } = 5000;
         /// <summary>Max selections a preview may return.</summary>
         public int PreviewCap { get; set; } = 500;
 

--- a/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
@@ -25,8 +25,6 @@ public sealed class SteamOptions
         public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(5);
         /// <summary>Max titles a single import may create/select (payload bound).</summary>
         public int ImportCap { get; set; } = 500;
-        /// <summary>Max selections a preview may return.</summary>
-        public int PreviewCap { get; set; } = 500;
 
         public bool IsConfigured => !string.IsNullOrWhiteSpace(ApiKey);
     }

--- a/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamOptions.cs
@@ -25,6 +25,10 @@ public sealed class SteamOptions
         public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(5);
         /// <summary>Max titles a single import may create/select (payload bound).</summary>
         public int ImportCap { get; set; } = 500;
+        /// <summary>Hard ceiling on one /import request's distinct ids, above
+        /// which the endpoint rejects rather than processing tens of thousands of
+        /// ids in server-side chunks. Guard against runaway/bot requests.</summary>
+        public int MaxImportBatch { get; set; } = 5000;
         /// <summary>Max selections a preview may return.</summary>
         public int PreviewCap { get; set; } = 500;
 

--- a/src/server/Collectify.Infrastructure/Store/SteamPreviewResult.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamPreviewResult.cs
@@ -16,4 +16,5 @@ public enum SteamPreviewStatus
 public sealed record SteamPreviewResult(
     SteamPreviewStatus Status,
     IReadOnlyList<SteamOwnedTitle> Titles,
-    bool Truncated);
+    bool Truncated,
+    int Total);

--- a/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
@@ -187,7 +187,13 @@ public sealed class SteamStoreImportService
     /// users with more than <see cref="SteamOptions.SteamSubOptions.PreviewCap"/>
     /// games can still find, import, or repair lower-playtime titles.
     /// </summary>
-    public async Task<SteamPreviewResult> GetOwnedTitlesAsync(string ownerId, string? search = null, int offset = 0, int? limit = null, CancellationToken ct = default)
+    public async Task<SteamPreviewResult> GetOwnedTitlesAsync(
+        string ownerId,
+        string? search = null,
+        int offset = 0,
+        int? limit = null,
+        bool hideImported = false,
+        CancellationToken ct = default)
     {
         var connection = await GetConnectionAsync(ownerId, ct);
         if (connection is null)
@@ -230,6 +236,9 @@ public sealed class SteamStoreImportService
         // matching lower-playtime title outside the capped preview is reachable.
         if (!string.IsNullOrEmpty(searchTerm))
             all = all.Where(t => t.Title.ToLowerInvariant().Contains(searchTerm)).ToList();
+
+        if (hideImported)
+            all = all.Where(t => t.State != SteamTitleImportState.Imported).ToList();
 
         // Paginate within the searched set. Total is the searched-library count
         // (before paging); Truncated means "more results after this page".

--- a/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
@@ -187,15 +187,15 @@ public sealed class SteamStoreImportService
     /// users with more than <see cref="SteamOptions.SteamSubOptions.PreviewCap"/>
     /// games can still find, import, or repair lower-playtime titles.
     /// </summary>
-    public async Task<SteamPreviewResult> GetOwnedTitlesAsync(string ownerId, string? search = null, CancellationToken ct = default)
+    public async Task<SteamPreviewResult> GetOwnedTitlesAsync(string ownerId, string? search = null, int offset = 0, int? limit = null, CancellationToken ct = default)
     {
         var connection = await GetConnectionAsync(ownerId, ct);
         if (connection is null)
-            return new SteamPreviewResult(SteamPreviewStatus.NotConnected, [], false);
+            return new SteamPreviewResult(SteamPreviewStatus.NotConnected, [], false, 0);
 
         var fetch = await _steam.GetOwnedGamesAsync(connection.ExternalAccountId, ct);
         if (fetch.Status == SteamFetchStatus.Unavailable)
-            return new SteamPreviewResult(SteamPreviewStatus.Unavailable, [], false);
+            return new SteamPreviewResult(SteamPreviewStatus.Unavailable, [], false, 0);
 
         // Successful fetch: bump LastSyncedAt so we don't keep re-pulling a
         // private/empty library as though nothing had synced.
@@ -231,12 +231,14 @@ public sealed class SteamStoreImportService
         if (!string.IsNullOrEmpty(searchTerm))
             all = all.Where(t => t.Title.ToLowerInvariant().Contains(searchTerm)).ToList();
 
-        // Bound the preview so a huge library stays navigable server-side; the
-        // client gets a "truncated" flag to show "show more"/search, and can
-        // request the rest later. PreviewCap covers the common self-hosted case.
-        var truncated = all.Count > _options.PreviewCap;
-        var titles = truncated ? all.Take(_options.PreviewCap).ToList() : all;
-        return new SteamPreviewResult(SteamPreviewStatus.Ok, titles, truncated);
+        // Paginate within the searched set. Total is the searched-library count
+        // (before paging); Truncated means "more results after this page".
+        var total = all.Count;
+        var effOffset = Math.Max(0, offset);
+        var effLimit = limit ?? _options.PreviewCap;
+        var page = all.Skip(effOffset).Take(effLimit).ToList();
+        var truncated = effOffset + page.Count < total;
+        return new SteamPreviewResult(SteamPreviewStatus.Ok, page, truncated, total);
     }
 
     private static string? IconUrl(uint appId, string? iconHash)

--- a/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreImportService.cs
@@ -182,18 +182,17 @@ public sealed class SteamStoreImportService
     /// <summary>
     /// Owned titles for the preview: trusted Steam fetch joined against the
     /// owner's ledger to tag import state. Ordered by playtime desc.
-    /// Pass an optional <paramref name="search"/> term to filter server-side by
-    /// title across the FULL library (not just the capped preview slice), so
-    /// users with more than <see cref="SteamOptions.SteamSubOptions.PreviewCap"/>
-    /// games can still find, import, or repair lower-playtime titles.
+    /// The caller supplies the search, pagination, and visibility inputs.
+    /// Search applies across the full library before paging so users can still
+    /// find, import, or repair lower-playtime titles.
     /// </summary>
     public async Task<SteamPreviewResult> GetOwnedTitlesAsync(
         string ownerId,
-        string? search = null,
-        int offset = 0,
-        int? limit = null,
-        bool hideImported = false,
-        CancellationToken ct = default)
+        string? search,
+        int offset,
+        int limit,
+        bool hideImported,
+        CancellationToken ct)
     {
         var connection = await GetConnectionAsync(ownerId, ct);
         if (connection is null)
@@ -232,8 +231,8 @@ public sealed class SteamStoreImportService
             .OrderByDescending(t => t.PlaytimeMinutes)
             .ToList();
 
-        // Apply an optional server-side search over the WHOLE library first so a
-        // matching lower-playtime title outside the capped preview is reachable.
+        // Apply an optional server-side search over the whole library first so a
+        // matching lower-playtime title outside the current page is reachable.
         if (!string.IsNullOrEmpty(searchTerm))
             all = all.Where(t => t.Title.ToLowerInvariant().Contains(searchTerm)).ToList();
 
@@ -244,8 +243,7 @@ public sealed class SteamStoreImportService
         // (before paging); Truncated means "more results after this page".
         var total = all.Count;
         var effOffset = Math.Max(0, offset);
-        var effLimit = limit ?? _options.PreviewCap;
-        var page = all.Skip(effOffset).Take(effLimit).ToList();
+        var page = all.Skip(effOffset).Take(limit).ToList();
         var truncated = effOffset + page.Count < total;
         return new SteamPreviewResult(SteamPreviewStatus.Ok, page, truncated, total);
     }

--- a/src/server/Collectify.Infrastructure/Store/SteamStoreServiceCollectionExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Store/SteamStoreServiceCollectionExtensions.cs
@@ -28,6 +28,9 @@ public static class SteamStoreServiceCollectionExtensions
             .Validate(
                 options => options.Steam.CacheTtl > TimeSpan.Zero,
                 "Collectify:Platforms:Steam:CacheTtl must be greater than zero.")
+            .Validate(
+                options => options.Steam.ImportCap > 0,
+                "Collectify:Platforms:Steam:ImportCap must be greater than zero.")
             .ValidateOnStart();
 
         services.AddHttpClient(SteamClient.HttpClientName, (sp, client) =>

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -616,11 +616,14 @@ public class SteamEndpointsTests
         Assert.Equal("4", page2.Titles[1].ExternalGameId);
         Assert.False(page2.Truncated); // end of set
 
-        // Search composes with paging: "Game" matches all 4; search within page.
-        var searchPage = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?q=beta&offset=0&limit=2");
+        // Search composes with paging across the FULL library BEFORE paging.
+        // "delta" is the 4th title — outside page 0 of size 2 — so this proves
+        // search is applied to the whole library first: a search-after-paging
+        // bug would find nothing here because "delta" is not on this page.
+        var searchPage = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?q=delta&offset=0&limit=2");
         Assert.Equal(1, searchPage!.Total); // only 1 matches the search
         Assert.Single(searchPage.Titles);
-        Assert.Equal("2", searchPage.Titles[0].ExternalGameId);
+        Assert.Equal("4", searchPage.Titles[0].ExternalGameId);
         Assert.False(searchPage.Truncated);
 
         // Default (no offset/limit): unchanged, full preview set, Total = library size.

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -559,7 +559,7 @@ public class SteamEndpointsTests
     [Theory]
     [InlineData("-1", null)]
     [InlineData(null, "0")]
-    [InlineData(null, "1001")]
+    [InlineData(null, "101")]
     public async Task Games_InvalidPagination_Returns400(string? offset, string? limit)
     {
         await using var factory = new CollectifyApiFactory
@@ -631,6 +631,42 @@ public class SteamEndpointsTests
         Assert.Equal(4, def!.Total);
         Assert.Equal(4, def.Titles.Length);
         Assert.False(def.Truncated);
+    }
+
+    [Fact]
+    public async Task Games_HideImported_FiltersBeforePaginationAndTotal()
+    {
+        await using var factory = new CollectifyApiFactory
+        {
+            SteamClient = new ScriptedSteamClient
+            {
+                OwnedGames = Enumerable.Range(1, 120)
+                    .Select(id => new SteamOwnedGame { AppId = (uint)id, Name = $"Game {id:D3}" })
+                    .ToArray(),
+            },
+            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
+        };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await LinkSteamAsync(factory, alice);
+        await alice.Client.PostAsJsonAsync("/api/accounts/steam/import", new
+        {
+            ExternalGameIds = Enumerable.Range(1, 20).Select(id => id.ToString()).ToArray(),
+        });
+
+        var hidden = await alice.Client.GetJsonAsync<SteamPreviewDto>(
+            "/api/accounts/steam/games?hideImported=true&offset=0&limit=100");
+
+        Assert.Equal(100, hidden!.Titles.Length);
+        Assert.All(hidden.Titles, title => Assert.Equal("importable", title.State));
+        Assert.Equal(100, hidden.Total);
+        Assert.False(hidden.Truncated);
+
+        var all = await alice.Client.GetJsonAsync<SteamPreviewDto>(
+            "/api/accounts/steam/games?offset=0&limit=100");
+
+        Assert.Equal(120, all!.Total);
+        Assert.Equal(100, all.Titles.Length);
+        Assert.Contains(all.Titles, title => title.State == "imported");
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -517,7 +517,7 @@ public class SteamEndpointsTests
         Assert.Equal(3, all!.Titles.Length);
 
         // Case-insensitive title search filters server-side across the full
-        // library, so a user with more than PreviewCap games can still reach a
+        // library, so a user with more than one page of games can still reach a
         // specific lower-playtime title no matter where it sorts.
         var celeste = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?q=celeste");
         Assert.Single(celeste!.Titles);

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -14,7 +14,7 @@ public class SteamEndpointsTests
     private record SteamConnectDto(bool Configured, string? RedirectUrl);
     private record SteamConnectionDto(bool Connected, string? SteamId, string? PersonaName);
     private record SteamOwnedTitleDto(string ExternalGameId, string Title, long PlaytimeMinutes, string? IconUrl, string? LogoUrl, string State);
-    private record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total);
+    private record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total, int ImportCap);
     private record SteamImportResultDto(int Imported, int AlreadyImported, SteamImportItemDto[] Items);
     private record SteamImportItemDto(string ExternalGameId, bool Imported, bool AlreadyImported);
 
@@ -469,6 +469,7 @@ public class SteamEndpointsTests
         var hades = preview!.Titles.Single(t => t.ExternalGameId == "1");
         var celeste = preview.Titles.Single(t => t.ExternalGameId == "2");
         Assert.Equal("ok", preview.Status);
+        Assert.Equal(500, preview.ImportCap);
         Assert.Equal("imported", hades.State);
         Assert.Equal("importable", celeste.State);
     }

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -718,7 +718,7 @@ public class SteamEndpointsTests
     }
 
     [Fact]
-    public async Task Import_OverCap_ReturnsBadRequest()
+    public async Task Import_OverBatchCap_ReturnsBadRequest()
     {
         await using var factory = new CollectifyApiFactory
         {
@@ -728,10 +728,35 @@ public class SteamEndpointsTests
         var alice = await factory.CreateAuthenticatedUserAsync("alice");
         await LinkSteamAsync(factory, alice);
 
-        // ImportCap defaults to 500; build a 501-element selection.
-        var ids = Enumerable.Range(0, 501).Select(i => i.ToString()).ToArray();
+        // MaxImportBatch defaults to 5000; build a 5001-element selection.
+        var ids = Enumerable.Range(0, 5001).Select(i => i.ToString()).ToArray();
         var response = await alice.Client.PostAsJsonAsync("/api/accounts/steam/import", new { ExternalGameIds = ids });
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Import_OverSingleChunkCap_IsChunkedAndSucceeds()
+    {
+        var owned = Enumerable.Range(1, 501)
+            .Select(i => new SteamOwnedGame { AppId = (uint)i, Name = $"Game {i}" })
+            .ToArray();
+        await using var factory = new CollectifyApiFactory
+        {
+            SteamClient = new ScriptedSteamClient { OwnedGames = owned },
+            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
+        };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await LinkSteamAsync(factory, alice);
+
+        var ids = Enumerable.Range(1, 501).Select(i => i.ToString()).ToArray();
+        var body = await (await alice.Client.PostAsJsonAsync("/api/accounts/steam/import",
+            new { ExternalGameIds = ids })).ReadJsonAsync<SteamImportResultDto>();
+
+        // All 501 are owned, so both chunks fully import: nothing is silently
+        // truncated by the per-call .Take(ImportCap) floor.
+        Assert.Equal(501, body!.Imported);
+        Assert.Equal(0, body.AlreadyImported);
+        Assert.Equal(501, body.Items.Length);
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -718,7 +718,7 @@ public class SteamEndpointsTests
     }
 
     [Fact]
-    public async Task Import_OverBatchCap_ReturnsBadRequest()
+    public async Task Import_OverCap_ReturnsBadRequest()
     {
         await using var factory = new CollectifyApiFactory
         {
@@ -728,35 +728,10 @@ public class SteamEndpointsTests
         var alice = await factory.CreateAuthenticatedUserAsync("alice");
         await LinkSteamAsync(factory, alice);
 
-        // MaxImportBatch defaults to 5000; build a 5001-element selection.
-        var ids = Enumerable.Range(0, 5001).Select(i => i.ToString()).ToArray();
+        // ImportCap defaults to 500; build a 501-element selection.
+        var ids = Enumerable.Range(0, 501).Select(i => i.ToString()).ToArray();
         var response = await alice.Client.PostAsJsonAsync("/api/accounts/steam/import", new { ExternalGameIds = ids });
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Import_OverSingleChunkCap_IsChunkedAndSucceeds()
-    {
-        var owned = Enumerable.Range(1, 501)
-            .Select(i => new SteamOwnedGame { AppId = (uint)i, Name = $"Game {i}" })
-            .ToArray();
-        await using var factory = new CollectifyApiFactory
-        {
-            SteamClient = new ScriptedSteamClient { OwnedGames = owned },
-            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
-        };
-        var alice = await factory.CreateAuthenticatedUserAsync("alice");
-        await LinkSteamAsync(factory, alice);
-
-        var ids = Enumerable.Range(1, 501).Select(i => i.ToString()).ToArray();
-        var body = await (await alice.Client.PostAsJsonAsync("/api/accounts/steam/import",
-            new { ExternalGameIds = ids })).ReadJsonAsync<SteamImportResultDto>();
-
-        // All 501 are owned, so both chunks fully import: nothing is silently
-        // truncated by the per-call .Take(ImportCap) floor.
-        Assert.Equal(501, body!.Imported);
-        Assert.Equal(0, body.AlreadyImported);
-        Assert.Equal(501, body.Items.Length);
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -545,6 +545,17 @@ public class SteamEndpointsTests
         Assert.Empty(preview.Titles);
     }
 
+    [Fact]
+    public async Task Games_Unauthenticated_ReturnsUnauthorized()
+    {
+        await using var factory = new CollectifyApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/accounts/steam/games");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
     [Theory]
     [InlineData("-1", null)]
     [InlineData(null, "0")]

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -475,6 +475,25 @@ public class SteamEndpointsTests
     }
 
     [Fact]
+    public async Task Games_ExposesConfiguredImportCap()
+    {
+        await using var factory = new CollectifyApiFactory
+        {
+            SteamImportCap = 2,
+            SteamClient = new ScriptedSteamClient(),
+            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
+        };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await LinkSteamAsync(factory, alice);
+
+        var response = await alice.Client.GetAsync("/api/accounts/steam/games");
+        var preview = await response.ReadJsonAsync<SteamPreviewDto>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, preview!.ImportCap);
+    }
+
+    [Fact]
     public async Task Games_SearchFiltersAcrossFullLibrary()
     {
         await using var factory = new CollectifyApiFactory

--- a/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/SteamEndpointsTests.cs
@@ -14,7 +14,7 @@ public class SteamEndpointsTests
     private record SteamConnectDto(bool Configured, string? RedirectUrl);
     private record SteamConnectionDto(bool Connected, string? SteamId, string? PersonaName);
     private record SteamOwnedTitleDto(string ExternalGameId, string Title, long PlaytimeMinutes, string? IconUrl, string? LogoUrl, string State);
-    private record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated);
+    private record SteamPreviewDto(string Status, SteamOwnedTitleDto[] Titles, bool Truncated, int Total);
     private record SteamImportResultDto(int Imported, int AlreadyImported, SteamImportItemDto[] Items);
     private record SteamImportItemDto(string ExternalGameId, bool Imported, bool AlreadyImported);
 
@@ -543,6 +543,80 @@ public class SteamEndpointsTests
         // qualified private/offline message), NOT a blank "you own nothing".
         Assert.Equal("unavailable", preview!.Status);
         Assert.Empty(preview.Titles);
+    }
+
+    [Theory]
+    [InlineData("-1", null)]
+    [InlineData(null, "0")]
+    [InlineData(null, "1001")]
+    public async Task Games_InvalidPagination_Returns400(string? offset, string? limit)
+    {
+        await using var factory = new CollectifyApiFactory
+        {
+            SteamClient = new ScriptedSteamClient { OwnedGames = [new SteamOwnedGame { AppId = 1, Name = "Hades" }] },
+            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
+        };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await LinkSteamAsync(factory, alice);
+
+        var query = string.Join("&", new[]
+        {
+            offset is null ? null : $"offset={offset}",
+            limit is null ? null : $"limit={limit}",
+        }.Where(s => s is not null));
+        var res = await alice.Client.GetAsync($"/api/accounts/steam/games{(query.Length > 0 ? "?" + query : "")}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Games_PaginatesWithinSearchedLibrary_WithTotal()
+    {
+        await using var factory = new CollectifyApiFactory
+        {
+            SteamClient = new ScriptedSteamClient
+            {
+                OwnedGames =
+                [
+                    new SteamOwnedGame { AppId = 1, Name = "Game Alpha" },
+                    new SteamOwnedGame { AppId = 2, Name = "Game Beta" },
+                    new SteamOwnedGame { AppId = 3, Name = "Game Gamma" },
+                    new SteamOwnedGame { AppId = 4, Name = "Game Delta" },
+                ],
+            },
+            SteamOpenIdVerifier = new ScriptedSteamOpenIdVerifier(),
+        };
+        var alice = await factory.CreateAuthenticatedUserAsync("alice");
+        await LinkSteamAsync(factory, alice);
+
+        // Page 0 of size 2: first 2 of the full, searched library.
+        var page1 = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?offset=0&limit=2");
+        Assert.Equal(4, page1!.Total);
+        Assert.Equal(2, page1.Titles.Length);
+        Assert.Equal("1", page1.Titles[0].ExternalGameId);
+        Assert.Equal("2", page1.Titles[1].ExternalGameId);
+        Assert.True(page1.Truncated); // more after this page
+
+        // Page 1 of size 2: the remaining slice.
+        var page2 = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?offset=2&limit=2");
+        Assert.Equal(4, page2!.Total);
+        Assert.Equal(2, page2.Titles.Length);
+        Assert.Equal("3", page2.Titles[0].ExternalGameId);
+        Assert.Equal("4", page2.Titles[1].ExternalGameId);
+        Assert.False(page2.Truncated); // end of set
+
+        // Search composes with paging: "Game" matches all 4; search within page.
+        var searchPage = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games?q=beta&offset=0&limit=2");
+        Assert.Equal(1, searchPage!.Total); // only 1 matches the search
+        Assert.Single(searchPage.Titles);
+        Assert.Equal("2", searchPage.Titles[0].ExternalGameId);
+        Assert.False(searchPage.Truncated);
+
+        // Default (no offset/limit): unchanged, full preview set, Total = library size.
+        var def = await alice.Client.GetJsonAsync<SteamPreviewDto>("/api/accounts/steam/games");
+        Assert.Equal(4, def!.Total);
+        Assert.Equal(4, def.Titles.Length);
+        Assert.False(def.Truncated);
     }
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/CollectifyApiFactory.cs
@@ -41,6 +41,9 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
     /// <summary>Optional override for tests that want a scripted Steam OpenID verifier.</summary>
     public ISteamOpenIdVerifier? SteamOpenIdVerifier { get; init; }
 
+    /// <summary>Optional override for the configured Steam import cap.</summary>
+    public int? SteamImportCap { get; init; }
+
     /// <summary>
     /// Toggles the <c>Collectify:Auth:AllowRegistration</c> flag. Defaults
     /// to <c>false</c> so the registration endpoint stays 404 unless a
@@ -60,7 +63,7 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
 
         builder.ConfigureAppConfiguration((_, config) =>
         {
-            config.AddInMemoryCollection(new Dictionary<string, string?>
+            var values = new Dictionary<string, string?>
             {
                 ["Collectify:Auth:AllowRegistration"] = AllowRegistration ? "true" : "false",
                 // Background IGDB backfill must never run in tests: it would
@@ -68,7 +71,10 @@ public sealed class CollectifyApiFactory : WebApplicationFactory<Program>
                 // when a test injects a configured GameProvider). The hosted
                 // service is still registered but no-ops on exit.
                 ["Collectify:IgdbBackfill:Enabled"] = "false",
-            });
+            };
+            if (SteamImportCap.HasValue)
+                values["Collectify:Platforms:Steam:ImportCap"] = SteamImportCap.Value.ToString();
+            config.AddInMemoryCollection(values);
         });
 
         builder.ConfigureServices(services =>

--- a/src/server/tests/Collectify.Tests/Infrastructure/MetadataLookupServiceCollectionExtensionsTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/MetadataLookupServiceCollectionExtensionsTests.cs
@@ -173,4 +173,17 @@ public class MetadataLookupServiceCollectionExtensionsTests
         var ex = Assert.Throws<OptionsValidationException>(() => host.Start());
         Assert.Contains("Collectify:Platforms:Steam:CacheTtl must be greater than zero.", ex.Message);
     }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public void AddSteamStoreImport_InvalidImportCap_FailsOnStart(string importCap)
+    {
+        using var host = new HostBuilder()
+            .ConfigureServices((_, s) => s.AddSteamStoreImport(ConfigWith(("Collectify:Platforms:Steam:ImportCap", importCap))))
+            .Build();
+
+        var ex = Assert.Throws<OptionsValidationException>(() => host.Start());
+        Assert.Contains("Collectify:Platforms:Steam:ImportCap must be greater than zero.", ex.Message);
+    }
 }


### PR DESCRIPTION
Closes #180
Closes #181

## Summary
- paginate Steam owned-game previews after full-library search, with validated offset/limit and total counts
- add Prev/Next paging controls and reset paging when search changes
- add a Hide imported toggle without changing the page-wide importable selection count

## Verification
- Server build: 0 errors
- Server tests: 627/627 SQLite/integration and 13/13 PostgreSQL passed
- Targeted Steam Games tests: 27/27 passed
- Client build: passed
- Client tests: 26 files, 181/181 passed
- Enum parity: passed

## RED phase
- Invalid pagination: all 3 rows failed with Expected BadRequest / Actual OK
- Pagination: failed with Expected 4 / Actual 0 for Total
- Client ImportSteam: 4 failures (missing Hide imported label, missing Next button, and expected hook-arity noise)

## Mutation checks
- Removed Skip(offset): pagination test failed, expected id 3 / actual id 1; restored green
- Forced total = 0: pagination test failed, expected 4 / actual 0; restored green
- Search-after-paging mutation skipped as runbook-identified ambiguous (beta is already in the first page)
- Disabled hide filtering: hide-imported test failed because Celeste remained visible; restored green
- Importable-count mutation skipped as non-load-bearing: filtering imported rows cannot alter the importable subset
- Next-always-enabled mutation skipped per runbook because no test directly asserts the disabled case
- Removed search offset reset with temporary assertion: paging test failed, expected offset 0 / actual 100; restored component and removed temporary assertion; full suite green