### PR TITLE
feat(collections): add collection list sorting

### DIFF
--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -1,24 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CollectionList from './CollectionList';
 import type { Album, Game, MediaType, Movie } from '../services/types';
 
 const FIXTURE_MOVIES: Movie[] = [
-  { id: 1, title: 'Inception', formats: 2, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
-  { id: 2, title: 'Heat', formats: 1, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
+  { id: 1, title: 'Inception', year: 2010, director: 'Christopher Nolan', addedAt: '2026-08-20T14:30:00Z', personalRating: 9, formats: 2, status: 'Owned', watchStatus: 'Watched', watchCount: 3 },
+  { id: 2, title: 'Heat', year: null, director: 'Michael Mann', addedAt: 'not-a-date', personalRating: null, formats: 1, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
 ];
 
 const FIXTURE_ALBUMS: Album[] = [
-  { id: 1, title: 'OK Computer', artistName: 'Radiohead', format: 'Cd', status: 'Owned', listenCount: 0 },
-  { id: 2, title: 'Kid A', artistName: 'Radiohead', format: 'Cd', status: 'Owned', listenCount: 0 },
+  { id: 1, title: 'OK Computer', artistName: 'Radiohead', year: 1997, addedAt: '2026-08-21', personalRating: 8, format: 'Cd', status: 'Owned', listenCount: 12 },
+  { id: 2, title: 'Kid A', artistName: 'Radiohead', year: null, personalRating: null, format: 'Cd', status: 'Owned', listenCount: 0 },
 ];
 
 const FIXTURE_GAMES: Game[] = [
-  { id: 1, title: 'Hades', platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'NotStarted' },
-  { id: 2, title: 'Celeste', platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'NotStarted' },
+  { id: 1, title: 'Hades', year: 2020, addedAt: '2026-08-22T01:02:03Z', personalRating: 10, platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'HundredPercent', hoursPlayed: 42.5 },
+  { id: 2, title: 'Celeste', year: null, personalRating: null, platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'NotStarted', hoursPlayed: 0 },
 ];
 
 const TITLES: Record<MediaType, string> = { movies: 'Movies', music: 'Music', games: 'Games' };
@@ -63,22 +64,63 @@ function mockFetch(onBulk?: () => unknown) {
   return spy;
 }
 
-function renderList(opts?: { type?: MediaType; initialEntries?: string[] }) {
+function LocationObserver({ onLocation }: { onLocation: (location: { key: string; path: string }) => void }) {
+  const location = useLocation();
+  useEffect(() => {
+    onLocation({ key: location.key, path: `${location.pathname}${location.search}` });
+  }, [location.key, location.pathname, location.search, onLocation]);
+  return null;
+}
+
+function renderList(opts?: {
+  type?: MediaType;
+  initialEntries?: string[];
+  onLocation?: (location: { key: string; path: string }) => void;
+}) {
   const type = opts?.type ?? 'movies';
+  const renderItem = (item: Movie | Album | Game) => {
+    if (type === 'movies') {
+      const movie = item as Movie;
+      return { primary: movie.title, secondary: movie.director, tertiary: 'Blu-ray' };
+    }
+    if (type === 'music') {
+      const album = item as Album;
+      return { primary: album.title, secondary: album.artistName, tertiary: 'CD' };
+    }
+    const game = item as Game;
+    return { primary: game.title, secondary: 'PC', tertiary: 'Physical' };
+  };
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={opts?.initialEntries ?? ['/']}>
+        {opts?.onLocation && <LocationObserver onLocation={opts.onLocation} />}
         <CollectionList
           type={type}
           title={TITLES[type]}
           newPath={`/${type}/new`}
           category={type}
-          renderItem={(m: Movie | Album | Game) => ({ primary: m.title })}
+          renderItem={renderItem}
         />
       </MemoryRouter>
     </QueryClientProvider>,
   );
+}
+
+function metadataPairs(title: string): [string, string][] {
+  const card = screen.getByRole('heading', { level: 3, name: title }).closest('a');
+  const metadata = card?.querySelector('dl[aria-label="Sortable metadata"]');
+  expect(metadata).not.toBeNull();
+  const labels = within(metadata as HTMLElement).getAllByRole('term').map((node) => node.textContent ?? '');
+  const values = within(metadata as HTMLElement).getAllByRole('definition').map((node) => node.textContent ?? '');
+  return labels.map((label, index) => [label, values[index]]);
+}
+
+async function selectViewAndAssertMetadata(mode: string, title: string, expected: [string, string][]) {
+  const user = userEvent.setup();
+  await user.click(screen.getByTitle(mode));
+  expect(metadataPairs(title)).toEqual(expected);
+  expect(metadataPairs(title).filter(([label]) => label === 'Rating')).toHaveLength(1);
 }
 
 describe('CollectionList — bulk select + update', () => {
@@ -351,7 +393,12 @@ describe('CollectionList — sort controls', () => {
 
   it('invalid URL is replaced once with defaults without a second fetch loop', async () => {
     const fetchSpy = mockFetch();
-    renderList({ type: 'movies', initialEntries: ['/?sort=bogus'] });
+    const locations: { key: string; path: string }[] = [];
+    renderList({
+      type: 'movies',
+      initialEntries: ['/?q=heat&sort=bogus'],
+      onLocation: (location) => locations.push(location),
+    });
 
     await screen.findByText('Inception');
 
@@ -360,9 +407,12 @@ describe('CollectionList — sort controls', () => {
     });
     expect((screen.getByLabelText('Direction') as HTMLSelectElement).value).toBe('desc');
 
-    // Give a runaway canonicalization/refetch loop a chance to fire before
-    // asserting the call count is settled at exactly one.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => expect(locations).toHaveLength(2));
+    expect(new Set(locations.map(({ key }) => key)).size).toBe(2);
+    expect(locations.map(({ path }) => path)).toEqual([
+      '/?q=heat&sort=bogus',
+      '/?q=heat&sort=addedAt&dir=desc',
+    ]);
 
     const movieCalls = fetchSpy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies');
     expect(movieCalls).toHaveLength(1);
@@ -397,7 +447,122 @@ describe('CollectionList — sort controls', () => {
     order = [2, 1];
     await user.selectOptions(screen.getByLabelText('Direction'), 'asc');
 
-    await waitFor(() => expect(screen.getAllByText(/^(Inception|Heat)$/)).toHaveLength(2));
+    await waitFor(() => {
+      expect(spy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies')).toHaveLength(2);
+    });
+    await waitFor(() => {
+      const titles = screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
+      expect(titles).toEqual(['Heat', 'Inception']);
+    });
     expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+
+  it('membership change still prunes missing selected IDs', async () => {
+    let narrowed = false;
+    const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (method === 'GET' && pathnameOf(url) === '/api/movies') {
+        return jsonResponse(narrowed ? [FIXTURE_MOVIES[1]] : FIXTURE_MOVIES);
+      }
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    renderList({ type: 'movies' });
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]);
+    await user.click(checkboxes[1]);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+    narrowed = true;
+    await user.type(screen.getByPlaceholderText('Search movies…'), 'h');
+
+    await waitFor(() => {
+      expect(spy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies')).toHaveLength(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Heat')).toBeInTheDocument();
+      expect(screen.queryByText('Inception')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+});
+
+describe('CollectionList — sortable metadata', () => {
+  it.each(['List', 'Medium', 'Big'])('shows movie sortable values in %s view', async (mode) => {
+    mockFetch();
+    renderList({ type: 'movies' });
+    await screen.findByText('Inception');
+
+    await selectViewAndAssertMetadata(mode, 'Inception', [
+      ['Year', '2010'],
+      ['Date added', 'Aug 20, 2026'],
+      ['Rating', '9/10'],
+      ['Watch status', 'Watched'],
+      ['Watch count', '3'],
+    ]);
+    expect(metadataPairs('Heat')).toEqual([
+      ['Year', '—'],
+      ['Date added', '—'],
+      ['Rating', '—'],
+      ['Watch status', 'Unwatched'],
+      ['Watch count', '0'],
+    ]);
+    expect(screen.getByText('Christopher Nolan')).toBeInTheDocument();
+    expect(screen.getAllByText('Blu-ray').length).toBeGreaterThan(0);
+  });
+
+  it.each(['List', 'Medium', 'Big'])('shows only music sortable values in %s view', async (mode) => {
+    mockFetch();
+    renderList({ type: 'music' });
+    await screen.findByText('OK Computer');
+
+    await selectViewAndAssertMetadata(mode, 'OK Computer', [
+      ['Year', '1997'],
+      ['Date added', 'Aug 21, 2026'],
+      ['Rating', '8/10'],
+      ['Listen count', '12'],
+    ]);
+    expect(metadataPairs('Kid A')).toEqual([
+      ['Year', '—'],
+      ['Date added', '—'],
+      ['Rating', '—'],
+      ['Listen count', '0'],
+    ]);
+    expect(metadataPairs('OK Computer').map(([label]) => label)).not.toEqual(
+      expect.arrayContaining(['Watch status', 'Watch count', 'Hours played', 'Completion status']),
+    );
+    expect(screen.getAllByText('Radiohead').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CD').length).toBeGreaterThan(0);
+  });
+
+  it.each(['List', 'Medium', 'Big'])('shows only game sortable values in %s view', async (mode) => {
+    mockFetch();
+    renderList({ type: 'games' });
+    await screen.findByText('Hades');
+
+    await selectViewAndAssertMetadata(mode, 'Hades', [
+      ['Year', '2020'],
+      ['Date added', 'Aug 22, 2026'],
+      ['Rating', '10/10'],
+      ['Hours played', '42.5h'],
+      ['Completion status', '100%'],
+    ]);
+    expect(metadataPairs('Celeste')).toEqual([
+      ['Year', '—'],
+      ['Date added', '—'],
+      ['Rating', '—'],
+      ['Hours played', '0h'],
+      ['Completion status', 'Not started'],
+    ]);
+    expect(metadataPairs('Hades').map(([label]) => label)).not.toEqual(
+      expect.arrayContaining(['Watch status', 'Watch count', 'Listen count']),
+    );
+    expect(screen.getAllByText('PC').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Physical').length).toBeGreaterThan(0);
   });
 });

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -494,6 +494,23 @@ describe('CollectionList — sortable metadata', () => {
   ];
   const viewCases = ['List', 'Medium', 'Big'];
 
+  it('treats an offsetless AddedAt timestamp as UTC', async () => {
+    vi.stubEnv('TZ', 'America/Los_Angeles');
+    try {
+      const movies = FIXTURE_MOVIES.map((movie) => movie.id === 1
+        ? { ...movie, addedAt: '2026-08-20T23:30:00' }
+        : movie);
+      globalThis.fetch = vi.fn(async () => jsonResponse(movies)) as unknown as typeof fetch;
+
+      renderList({ type: 'movies' });
+      await screen.findByText('Inception');
+
+      expect(metadataPairs('Inception')).toEqual([['Date added', 'Aug 20, 2026']]);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it.each(categoryCases.flatMap((category) => viewCases.map((view) => ({ ...category, view }))))(
     'shows exactly the selected Date added row for $type in $view view',
     async ({ type, title, date, identity, view }) => {

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -22,14 +22,18 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 }
 
+function pathnameOf(url: string): string {
+  return new URL(url, 'http://localhost').pathname;
+}
+
 function mockFetch(onBulk?: () => unknown) {
   const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
-    if (method === 'GET' && url === '/api/movies') {
+    if (method === 'GET' && pathnameOf(url) === '/api/movies') {
       return jsonResponse(FIXTURE_MOVIES);
     }
-    if (method === 'PATCH' && url === '/api/movies/bulk') {
+    if (method === 'PATCH' && pathnameOf(url) === '/api/movies/bulk') {
       return jsonResponse(onBulk ? onBulk() : []);
     }
     throw new Error(`Unexpected fetch: ${method} ${url}`);
@@ -92,7 +96,7 @@ describe('CollectionList — bulk select + update', () => {
     const user = userEvent.setup();
 
     await screen.findByText('Inception');
-    expect(fetchSpy.mock.calls.filter(([u]) => String(u) === '/api/movies')).toHaveLength(1);
+    expect(fetchSpy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies')).toHaveLength(1);
 
     const checkboxes = screen.getAllByLabelText('Select item');
     await user.click(checkboxes[0]);
@@ -116,7 +120,7 @@ describe('CollectionList — bulk select + update', () => {
 
     // The bulk mutation invalidates the list query, triggering a refetch.
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.filter(([u]) => String(u) === '/api/movies')).toHaveLength(2);
+      expect(fetchSpy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies')).toHaveLength(2);
     });
   });
 

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -4,12 +4,24 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CollectionList from './CollectionList';
-import type { Movie } from '../services/types';
+import type { Album, Game, MediaType, Movie } from '../services/types';
 
 const FIXTURE_MOVIES: Movie[] = [
   { id: 1, title: 'Inception', formats: 2, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
   { id: 2, title: 'Heat', formats: 1, status: 'Owned', watchStatus: 'Unwatched', watchCount: 0 },
 ];
+
+const FIXTURE_ALBUMS: Album[] = [
+  { id: 1, title: 'OK Computer', artistName: 'Radiohead', format: 'Cd', status: 'Owned', listenCount: 0 },
+  { id: 2, title: 'Kid A', artistName: 'Radiohead', format: 'Cd', status: 'Owned', listenCount: 0 },
+];
+
+const FIXTURE_GAMES: Game[] = [
+  { id: 1, title: 'Hades', platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'NotStarted' },
+  { id: 2, title: 'Celeste', platform: 'Pc', digitalStores: 0, status: 'Owned', completionStatus: 'NotStarted' },
+];
+
+const TITLES: Record<MediaType, string> = { movies: 'Movies', music: 'Music', games: 'Games' };
 
 const originalFetch = globalThis.fetch;
 
@@ -26,14 +38,23 @@ function pathnameOf(url: string): string {
   return new URL(url, 'http://localhost').pathname;
 }
 
+/** Most recent GET call to the given pathname, or undefined if none match. */
+function lastCallTo(calls: [input: RequestInfo | URL, init?: RequestInit][], pathname: string) {
+  for (let i = calls.length - 1; i >= 0; i--) {
+    if (pathnameOf(String(calls[i][0])) === pathname) return calls[i];
+  }
+  return undefined;
+}
+
 function mockFetch(onBulk?: () => unknown) {
   const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
-    if (method === 'GET' && pathnameOf(url) === '/api/movies') {
-      return jsonResponse(FIXTURE_MOVIES);
-    }
-    if (method === 'PATCH' && pathnameOf(url) === '/api/movies/bulk') {
+    const pathname = pathnameOf(url);
+    if (method === 'GET' && pathname === '/api/movies') return jsonResponse(FIXTURE_MOVIES);
+    if (method === 'GET' && pathname === '/api/music') return jsonResponse(FIXTURE_ALBUMS);
+    if (method === 'GET' && pathname === '/api/games') return jsonResponse(FIXTURE_GAMES);
+    if (method === 'PATCH' && pathname === '/api/movies/bulk') {
       return jsonResponse(onBulk ? onBulk() : []);
     }
     throw new Error(`Unexpected fetch: ${method} ${url}`);
@@ -42,17 +63,18 @@ function mockFetch(onBulk?: () => unknown) {
   return spy;
 }
 
-function renderList() {
+function renderList(opts?: { type?: MediaType; initialEntries?: string[] }) {
+  const type = opts?.type ?? 'movies';
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={opts?.initialEntries ?? ['/']}>
         <CollectionList
-          type="movies"
-          title="Movies"
-          newPath="/movies/new"
-          category="movies"
-          renderItem={(m: Movie) => ({ primary: m.title })}
+          type={type}
+          title={TITLES[type]}
+          newPath={`/${type}/new`}
+          category={type}
+          renderItem={(m: Movie | Album | Game) => ({ primary: m.title })}
         />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -243,5 +265,139 @@ describe('CollectionList — bulk select + update', () => {
 
     vi.doUnmock('../services/collection');
     vi.resetModules();
+  });
+});
+
+describe('CollectionList — sort controls', () => {
+  it('sort controls expose shared and current-type options', async () => {
+    mockFetch();
+    const movies = renderList({ type: 'movies' });
+    await screen.findByText('Inception');
+    const movieOptions = Array.from((screen.getByLabelText('Sort by') as HTMLSelectElement).options).map((o) => o.value);
+    expect(movieOptions).toEqual(expect.arrayContaining(['title', 'year', 'addedAt', 'personalRating', 'watchStatus', 'watchCount']));
+    expect(movieOptions).not.toEqual(expect.arrayContaining(['listenCount']));
+    expect(movieOptions).not.toEqual(expect.arrayContaining(['hoursPlayed']));
+    expect(movieOptions).not.toEqual(expect.arrayContaining(['completionStatus']));
+    movies.unmount();
+
+    mockFetch();
+    const music = renderList({ type: 'music' });
+    await screen.findByText('OK Computer');
+    const musicOptions = Array.from((screen.getByLabelText('Sort by') as HTMLSelectElement).options).map((o) => o.value);
+    expect(musicOptions).toEqual(expect.arrayContaining(['listenCount']));
+    expect(musicOptions).not.toEqual(expect.arrayContaining(['watchStatus']));
+    expect(musicOptions).not.toEqual(expect.arrayContaining(['watchCount']));
+    expect(musicOptions).not.toEqual(expect.arrayContaining(['hoursPlayed']));
+    expect(musicOptions).not.toEqual(expect.arrayContaining(['completionStatus']));
+    music.unmount();
+
+    mockFetch();
+    const games = renderList({ type: 'games' });
+    await screen.findByText('Hades');
+    const gameOptions = Array.from((screen.getByLabelText('Sort by') as HTMLSelectElement).options).map((o) => o.value);
+    expect(gameOptions).toEqual(expect.arrayContaining(['hoursPlayed', 'completionStatus']));
+    expect(gameOptions).not.toEqual(expect.arrayContaining(['watchStatus']));
+    expect(gameOptions).not.toEqual(expect.arrayContaining(['watchCount']));
+    expect(gameOptions).not.toEqual(expect.arrayContaining(['listenCount']));
+    games.unmount();
+  });
+
+  it('changing sort field or direction updates URL and refetches canonical request', async () => {
+    const fetchSpy = mockFetch();
+    renderList({ type: 'movies', initialEntries: ['/?q=heat&director=Nolan'] });
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+
+    await user.selectOptions(screen.getByLabelText('Sort by'), 'year');
+
+    await waitFor(() => {
+      const call = lastCallTo(fetchSpy.mock.calls, '/api/movies');
+      expect(call).toBeDefined();
+      const params = new URL(String(call![0]), 'http://localhost').searchParams;
+      expect(params.get('query')).toBe('heat');
+      expect(params.get('director')).toBe('Nolan');
+      expect(params.get('sort')).toBe('year');
+      expect(params.get('dir')).toBe('desc');
+    });
+
+    await user.selectOptions(screen.getByLabelText('Direction'), 'asc');
+
+    await waitFor(() => {
+      const call = lastCallTo(fetchSpy.mock.calls, '/api/movies');
+      const params = new URL(String(call![0]), 'http://localhost').searchParams;
+      expect(params.get('query')).toBe('heat');
+      expect(params.get('director')).toBe('Nolan');
+      expect(params.get('sort')).toBe('year');
+      expect(params.get('dir')).toBe('asc');
+    });
+  });
+
+  it('initial URL selects controls and drives first request', async () => {
+    const fetchSpy = mockFetch();
+    renderList({ type: 'movies', initialEntries: ['/?sort=personalRating&dir=asc'] });
+
+    await screen.findByText('Inception');
+
+    expect((screen.getByLabelText('Sort by') as HTMLSelectElement).value).toBe('personalRating');
+    expect((screen.getByLabelText('Direction') as HTMLSelectElement).value).toBe('asc');
+
+    const call = fetchSpy.mock.calls.find(([u]) => pathnameOf(String(u)) === '/api/movies');
+    expect(call).toBeDefined();
+    const params = new URL(String(call![0]), 'http://localhost').searchParams;
+    expect(params.get('sort')).toBe('personalRating');
+    expect(params.get('dir')).toBe('asc');
+  });
+
+  it('invalid URL is replaced once with defaults without a second fetch loop', async () => {
+    const fetchSpy = mockFetch();
+    renderList({ type: 'movies', initialEntries: ['/?sort=bogus'] });
+
+    await screen.findByText('Inception');
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Sort by') as HTMLSelectElement).value).toBe('addedAt');
+    });
+    expect((screen.getByLabelText('Direction') as HTMLSelectElement).value).toBe('desc');
+
+    // Give a runaway canonicalization/refetch loop a chance to fire before
+    // asserting the call count is settled at exactly one.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const movieCalls = fetchSpy.mock.calls.filter(([u]) => pathnameOf(String(u)) === '/api/movies');
+    expect(movieCalls).toHaveLength(1);
+    const params = new URL(String(movieCalls[0][0]), 'http://localhost').searchParams;
+    expect(params.get('sort')).toBe('addedAt');
+    expect(params.get('dir')).toBe('desc');
+  });
+
+  it('sorting a stable result preserves selected IDs', async () => {
+    let order: number[] = [1, 2];
+    const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (method === 'GET' && pathnameOf(url) === '/api/movies') {
+        const byId = new Map(FIXTURE_MOVIES.map((m) => [m.id, m]));
+        return jsonResponse(order.map((id) => byId.get(id)));
+      }
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    renderList({ type: 'movies' });
+    const user = userEvent.setup();
+
+    await screen.findByText('Inception');
+    const checkboxes = screen.getAllByLabelText('Select item');
+    await user.click(checkboxes[0]); // Inception (id 1).
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    // Same IDs, reverse order: a refetch triggered by a direction change
+    // must not treat the reordering as a membership change.
+    order = [2, 1];
+    await user.selectOptions(screen.getByLabelText('Direction'), 'asc');
+
+    await waitFor(() => expect(screen.getAllByText(/^(Inception|Heat)$/)).toHaveLength(2));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
   });
 });

--- a/src/client/components/CollectionList.test.tsx
+++ b/src/client/components/CollectionList.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CollectionList from './CollectionList';
+import { sortOptions } from '../services/sorting';
 import type { Album, Game, MediaType, Movie } from '../services/types';
 
 const FIXTURE_MOVIES: Movie[] = [
@@ -114,13 +115,6 @@ function metadataPairs(title: string): [string, string][] {
   const labels = within(metadata as HTMLElement).getAllByRole('term').map((node) => node.textContent ?? '');
   const values = within(metadata as HTMLElement).getAllByRole('definition').map((node) => node.textContent ?? '');
   return labels.map((label, index) => [label, values[index]]);
-}
-
-async function selectViewAndAssertMetadata(mode: string, title: string, expected: [string, string][]) {
-  const user = userEvent.setup();
-  await user.click(screen.getByTitle(mode));
-  expect(metadataPairs(title)).toEqual(expected);
-  expect(metadataPairs(title).filter(([label]) => label === 'Rating')).toHaveLength(1);
 }
 
 describe('CollectionList — bulk select + update', () => {
@@ -493,76 +487,83 @@ describe('CollectionList — sort controls', () => {
 });
 
 describe('CollectionList — sortable metadata', () => {
-  it.each(['List', 'Medium', 'Big'])('shows movie sortable values in %s view', async (mode) => {
-    mockFetch();
-    renderList({ type: 'movies' });
-    await screen.findByText('Inception');
+  const categoryCases = [
+    { type: 'movies' as const, title: 'Inception', date: 'Aug 20, 2026', identity: 'Christopher Nolan' },
+    { type: 'music' as const, title: 'OK Computer', date: 'Aug 21, 2026', identity: 'Radiohead' },
+    { type: 'games' as const, title: 'Hades', date: 'Aug 22, 2026', identity: 'PC' },
+  ];
+  const viewCases = ['List', 'Medium', 'Big'];
 
-    await selectViewAndAssertMetadata(mode, 'Inception', [
-      ['Year', '2010'],
-      ['Date added', 'Aug 20, 2026'],
-      ['Rating', '9/10'],
-      ['Watch status', 'Watched'],
-      ['Watch count', '3'],
-    ]);
-    expect(metadataPairs('Heat')).toEqual([
-      ['Year', '—'],
-      ['Date added', '—'],
-      ['Rating', '—'],
-      ['Watch status', 'Unwatched'],
-      ['Watch count', '0'],
-    ]);
-    expect(screen.getByText('Christopher Nolan')).toBeInTheDocument();
-    expect(screen.getAllByText('Blu-ray').length).toBeGreaterThan(0);
+  it.each(categoryCases.flatMap((category) => viewCases.map((view) => ({ ...category, view }))))(
+    'shows exactly the selected Date added row for $type in $view view',
+    async ({ type, title, date, identity, view }) => {
+      mockFetch();
+      renderList({ type });
+      await screen.findByText(title);
+      await userEvent.setup().click(screen.getByTitle(view));
+
+      expect(metadataPairs(title)).toEqual([['Date added', date]]);
+      expect(screen.getAllByText(identity).length).toBeGreaterThan(0);
+    },
+  );
+
+  const fieldCases = categoryCases.flatMap(({ type, title }) => {
+    const values: Record<string, string> = type === 'movies'
+      ? { title: 'Inception', year: '2010', addedAt: 'Aug 20, 2026', personalRating: '9/10', watchStatus: 'Watched', watchCount: '3' }
+      : type === 'music'
+        ? { title: 'OK Computer', year: '1997', addedAt: 'Aug 21, 2026', personalRating: '8/10', listenCount: '12' }
+        : { title: 'Hades', year: '2020', addedAt: 'Aug 22, 2026', personalRating: '10/10', hoursPlayed: '42.5h', completionStatus: '100%' };
+    return sortOptions(type).map((option) => ({ type, title, option, expected: values[option.value] }));
   });
 
-  it.each(['List', 'Medium', 'Big'])('shows only music sortable values in %s view', async (mode) => {
-    mockFetch();
-    renderList({ type: 'music' });
-    await screen.findByText('OK Computer');
+  it.each(fieldCases)(
+    'uses the selected $option.value field for $type',
+    async ({ type, title, option, expected }) => {
+      const fetchSpy = mockFetch();
+      renderList({ type });
+      await screen.findByText(title);
 
-    await selectViewAndAssertMetadata(mode, 'OK Computer', [
-      ['Year', '1997'],
-      ['Date added', 'Aug 21, 2026'],
-      ['Rating', '8/10'],
-      ['Listen count', '12'],
-    ]);
-    expect(metadataPairs('Kid A')).toEqual([
-      ['Year', '—'],
-      ['Date added', '—'],
-      ['Rating', '—'],
-      ['Listen count', '0'],
-    ]);
-    expect(metadataPairs('OK Computer').map(([label]) => label)).not.toEqual(
-      expect.arrayContaining(['Watch status', 'Watch count', 'Hours played', 'Completion status']),
-    );
-    expect(screen.getAllByText('Radiohead').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('CD').length).toBeGreaterThan(0);
+      await userEvent.setup().click(screen.getByTitle('List'));
+      await userEvent.setup().selectOptions(screen.getByLabelText('Sort by'), option.value);
+      await waitFor(() => {
+        const call = lastCallTo(fetchSpy.mock.calls, `/api/${type}`);
+        expect(new URL(String(call![0]), 'http://localhost').searchParams.get('sort')).toBe(option.value);
+      });
+
+      expect(metadataPairs(title)).toEqual([[option.label, expected]]);
+      const inactiveLabel = sortOptions(type).find((candidate) => candidate.value !== option.value)!.label;
+      expect(metadataPairs(title).map(([label]) => label)).not.toContain(inactiveLabel);
+    },
+  );
+
+  it.each([
+    { type: 'movies' as const, title: 'Heat', field: 'year', expected: '—' },
+    { type: 'movies' as const, title: 'Heat', field: 'personalRating', expected: '—' },
+    { type: 'games' as const, title: 'Celeste', field: 'hoursPlayed', expected: '0h' },
+    { type: 'movies' as const, title: 'Heat', field: 'watchCount', expected: '0' },
+    { type: 'music' as const, title: 'Kid A', field: 'listenCount', expected: '0' },
+  ])('formats missing and zero $field values for $type', async ({ type, title, field, expected }) => {
+    mockFetch();
+    renderList({ type });
+    await screen.findByText(title);
+
+    await userEvent.setup().click(screen.getByTitle('List'));
+    await userEvent.setup().selectOptions(screen.getByLabelText('Sort by'), field);
+
+    const label = sortOptions(type).find((option) => option.value === field)!.label;
+    await waitFor(() => expect(metadataPairs(title)).toEqual([[label, expected]]));
   });
 
-  it.each(['List', 'Medium', 'Big'])('shows only game sortable values in %s view', async (mode) => {
-    mockFetch();
+  it('renders an em dash for selected nullable Hours played', async () => {
+    const games = FIXTURE_GAMES.map((game) => game.id === 2 ? { ...game, hoursPlayed: null } : game);
+    const spy = vi.fn(async () => jsonResponse(games));
+    globalThis.fetch = spy as unknown as typeof fetch;
     renderList({ type: 'games' });
-    await screen.findByText('Hades');
+    await screen.findByText('Celeste');
 
-    await selectViewAndAssertMetadata(mode, 'Hades', [
-      ['Year', '2020'],
-      ['Date added', 'Aug 22, 2026'],
-      ['Rating', '10/10'],
-      ['Hours played', '42.5h'],
-      ['Completion status', '100%'],
-    ]);
-    expect(metadataPairs('Celeste')).toEqual([
-      ['Year', '—'],
-      ['Date added', '—'],
-      ['Rating', '—'],
-      ['Hours played', '0h'],
-      ['Completion status', 'Not started'],
-    ]);
-    expect(metadataPairs('Hades').map(([label]) => label)).not.toEqual(
-      expect.arrayContaining(['Watch status', 'Watch count', 'Listen count']),
-    );
-    expect(screen.getAllByText('PC').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Physical').length).toBeGreaterThan(0);
+    await userEvent.setup().click(screen.getByTitle('List'));
+    await userEvent.setup().selectOptions(screen.getByLabelText('Sort by'), 'hoursPlayed');
+
+    await waitFor(() => expect(metadataPairs('Celeste')).toEqual([['Hours played', '—']]));
   });
 });

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -87,7 +87,8 @@ function formatAddedAt(value?: string): string {
       || date.getUTCDate() !== Number(dateOnly[3])
     ) return '—';
   } else {
-    date = new Date(value);
+    const offsetlessDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value);
+    date = new Date(offsetlessDateTime ? `${value}Z` : value);
   }
   if (Number.isNaN(date.getTime())) return '—';
   return new Intl.DateTimeFormat('en-US', {

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -13,7 +13,10 @@ import { useViewPreference, type ViewMode } from '../hooks/useViewPreference';
 import {
   COLLECTION_STATUSES,
   WATCH_STATUSES,
+  completionStatusLabel,
+  watchStatusLabel,
   type CollectionItemBase,
+  type CompletionStatus,
   type CollectionStatus,
   type MediaType,
   type WatchStatus,
@@ -57,6 +60,76 @@ const CARD_BORDER: Record<string, string> = {
 interface BaseItem extends CollectionItemBase {
   id?: number;
   imagePath?: string | null;
+  year?: number | null;
+  addedAt?: string;
+  watchStatus?: WatchStatus;
+  watchCount?: number | null;
+  listenCount?: number | null;
+  hoursPlayed?: number | null;
+  completionStatus?: CompletionStatus;
+}
+
+interface MetadataRow {
+  label: string;
+  value: string;
+}
+
+function formatAddedAt(value?: string): string {
+  if (!value) return '—';
+  let date: Date;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    date = new Date(Date.UTC(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3])));
+    if (
+      date.getUTCFullYear() !== Number(dateOnly[1])
+      || date.getUTCMonth() !== Number(dateOnly[2]) - 1
+      || date.getUTCDate() !== Number(dateOnly[3])
+    ) return '—';
+  } else {
+    date = new Date(value);
+  }
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function sortableMetadata(item: BaseItem, category?: string): MetadataRow[] {
+  const rows: MetadataRow[] = [
+    { label: 'Year', value: item.year != null ? String(item.year) : '—' },
+    { label: 'Date added', value: formatAddedAt(item.addedAt) },
+    { label: 'Rating', value: item.personalRating != null ? `${item.personalRating}/10` : '—' },
+  ];
+  if (category === 'movies') {
+    rows.push(
+      { label: 'Watch status', value: item.watchStatus ? (watchStatusLabel(item.watchStatus) ?? '—') : '—' },
+      { label: 'Watch count', value: item.watchCount != null ? String(item.watchCount) : '—' },
+    );
+  } else if (category === 'music') {
+    rows.push({ label: 'Listen count', value: item.listenCount != null ? String(item.listenCount) : '—' });
+  } else if (category === 'games') {
+    rows.push(
+      { label: 'Hours played', value: item.hoursPlayed != null ? `${item.hoursPlayed}h` : '—' },
+      { label: 'Completion status', value: item.completionStatus ? (completionStatusLabel(item.completionStatus) ?? '—') : '—' },
+    );
+  }
+  return rows;
+}
+
+function SortableMetadata({ item, category }: { item: BaseItem; category?: string }) {
+  return (
+    <dl aria-label="Sortable metadata" className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
+      {sortableMetadata(item, category).map(({ label, value }) => (
+        <div key={label} className="flex min-w-0 gap-1">
+          <dt className="font-semibold text-text-tertiary">{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
 }
 
 // A checkbox rendered as a sibling of the surrounding <Link>; stopping
@@ -122,6 +195,7 @@ function ListCard({ item, r, category, selected, onToggle }: { item: BaseItem; r
           {r.tertiary && (
             <span className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</span>
           )}
+          <SortableMetadata item={item} category={category} />
         </div>
       </div>
     </Card>
@@ -149,9 +223,7 @@ function MediumCard({ item, r, category, selected, onToggle }: { item: BaseItem;
           {r.tertiary && (
             <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
           )}
-          {item.personalRating != null && (
-            <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
-          )}
+          <SortableMetadata item={item} category={category} />
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-1">
               {tags.slice(0, 3).map((t) => (
@@ -187,9 +259,7 @@ function BigCard({ item, r, category, selected, onToggle }: { item: BaseItem; r:
           {r.tertiary && (
             <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
           )}
-          {item.personalRating != null && (
-            <div className={`text-sm font-medium ${titleClass}`}>★ {item.personalRating}/10</div>
-          )}
+          <SortableMetadata item={item} category={category} />
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-auto pt-1">
               {tags.slice(0, 4).map((t) => (

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useState, useEffect, type ReactNode } from 'react';
 import { useBulkUpdate, useList, type BulkUpdates } from '../services/collection';
 import { useFiltersState } from '../services/filters';
+import { DIRECTION_OPTIONS, sortOptions, useSortState, type SortDirection } from '../services/sorting';
 import { ApiError } from '../services/client';
 import { Button, Card, Field, Input, RatingInput, Select, StatusPill, TagChip, TagInput, ViewSwitcher } from './ui';
 import BarcodeLookup from './BarcodeLookup';
@@ -215,7 +216,8 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
     setSearchParams(params, { replace: true });
   };
   const { filters, setFilters, clear } = useFiltersState(type);
-  const list = useList(type, query, filters);
+  const { state: sortState, setSortState } = useSortState(type);
+  const list = useList(type, query, filters, sortState);
   const items = list.data ?? [];
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useViewPreference(type);
@@ -357,6 +359,31 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
       </div>
 
       <Input placeholder={`Search ${title.toLowerCase()}…`} value={query} onChange={(e) => setQuery(e.target.value)} />
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label="Sort by">
+          <Select
+            aria-label="Sort by"
+            value={sortState.field}
+            onChange={(e) => setSortState({ field: e.target.value as typeof sortState.field, direction: sortState.direction })}
+          >
+            {sortOptions(type).map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </Select>
+        </Field>
+        <Field label="Direction">
+          <Select
+            aria-label="Direction"
+            value={sortState.direction}
+            onChange={(e) => setSortState({ field: sortState.field, direction: e.target.value as SortDirection })}
+          >
+            {DIRECTION_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </Select>
+        </Field>
+      </div>
 
       <FiltersPanel type={type} value={filters} onChange={setFilters} onClear={clear} />
 

--- a/src/client/components/CollectionList.tsx
+++ b/src/client/components/CollectionList.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useState, useEffect, type ReactNode } from 'react';
 import { useBulkUpdate, useList, type BulkUpdates } from '../services/collection';
 import { useFiltersState } from '../services/filters';
-import { DIRECTION_OPTIONS, sortOptions, useSortState, type SortDirection } from '../services/sorting';
+import { DIRECTION_OPTIONS, sortOptions, useSortState, type SortDirection, type SortField } from '../services/sorting';
 import { ApiError } from '../services/client';
 import { Button, Card, Field, Input, RatingInput, Select, StatusPill, TagChip, TagInput, ViewSwitcher } from './ui';
 import BarcodeLookup from './BarcodeLookup';
@@ -59,6 +59,7 @@ const CARD_BORDER: Record<string, string> = {
 
 interface BaseItem extends CollectionItemBase {
   id?: number;
+  title: string;
   imagePath?: string | null;
   year?: number | null;
   addedAt?: string;
@@ -97,37 +98,51 @@ function formatAddedAt(value?: string): string {
   }).format(date);
 }
 
-function sortableMetadata(item: BaseItem, category?: string): MetadataRow[] {
-  const rows: MetadataRow[] = [
-    { label: 'Year', value: item.year != null ? String(item.year) : '—' },
-    { label: 'Date added', value: formatAddedAt(item.addedAt) },
-    { label: 'Rating', value: item.personalRating != null ? `${item.personalRating}/10` : '—' },
-  ];
-  if (category === 'movies') {
-    rows.push(
-      { label: 'Watch status', value: item.watchStatus ? (watchStatusLabel(item.watchStatus) ?? '—') : '—' },
-      { label: 'Watch count', value: item.watchCount != null ? String(item.watchCount) : '—' },
-    );
-  } else if (category === 'music') {
-    rows.push({ label: 'Listen count', value: item.listenCount != null ? String(item.listenCount) : '—' });
-  } else if (category === 'games') {
-    rows.push(
-      { label: 'Hours played', value: item.hoursPlayed != null ? `${item.hoursPlayed}h` : '—' },
-      { label: 'Completion status', value: item.completionStatus ? (completionStatusLabel(item.completionStatus) ?? '—') : '—' },
-    );
+function selectedSortMetadata(item: BaseItem, type: MediaType, sortKey: SortField<MediaType>): MetadataRow {
+  const option = sortOptions(type).find(({ value }) => value === sortKey);
+  if (!option) throw new Error(`Unreachable sort field "${sortKey}" for ${type}`);
+
+  let value: string;
+  switch (sortKey) {
+    case 'title':
+      value = item.title;
+      break;
+    case 'year':
+      value = item.year != null ? String(item.year) : '—';
+      break;
+    case 'addedAt':
+      value = formatAddedAt(item.addedAt);
+      break;
+    case 'personalRating':
+      value = item.personalRating != null ? `${item.personalRating}/10` : '—';
+      break;
+    case 'watchStatus':
+      value = item.watchStatus ? (watchStatusLabel(item.watchStatus) ?? '—') : '—';
+      break;
+    case 'watchCount':
+      value = item.watchCount != null ? String(item.watchCount) : '—';
+      break;
+    case 'listenCount':
+      value = item.listenCount != null ? String(item.listenCount) : '—';
+      break;
+    case 'hoursPlayed':
+      value = item.hoursPlayed != null ? `${item.hoursPlayed}h` : '—';
+      break;
+    case 'completionStatus':
+      value = item.completionStatus ? (completionStatusLabel(item.completionStatus) ?? '—') : '—';
+      break;
   }
-  return rows;
+  return { label: option.label, value };
 }
 
-function SortableMetadata({ item, category }: { item: BaseItem; category?: string }) {
+function SortableMetadata({ item, type, sortKey }: { item: BaseItem; type: MediaType; sortKey: SortField<MediaType> }) {
+  const { label, value } = selectedSortMetadata(item, type, sortKey);
   return (
     <dl aria-label="Sortable metadata" className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
-      {sortableMetadata(item, category).map(({ label, value }) => (
-        <div key={label} className="flex min-w-0 gap-1">
-          <dt className="font-semibold text-text-tertiary">{label}</dt>
-          <dd>{value}</dd>
-        </div>
-      ))}
+      <div className="flex min-w-0 gap-1">
+        <dt className="font-semibold text-text-tertiary">{label}</dt>
+        <dd>{value}</dd>
+      </div>
     </dl>
   );
 }
@@ -175,7 +190,7 @@ interface CardSelectProps {
   onToggle: (id: number) => void;
 }
 
-function ListCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
+function ListCard({ item, r, type, sortKey, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; type: MediaType; sortKey: SortField<MediaType>; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   return (
     <Card className={`relative !p-0 overflow-hidden transition-all hover:-translate-y-0.5 ${category ? CARD_BORDER[category] : 'group-hover:border-brand/30'}`}>
@@ -195,14 +210,14 @@ function ListCard({ item, r, category, selected, onToggle }: { item: BaseItem; r
           {r.tertiary && (
             <span className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</span>
           )}
-          <SortableMetadata item={item} category={category} />
+          <SortableMetadata item={item} type={type} sortKey={sortKey} />
         </div>
       </div>
     </Card>
   );
 }
 
-function MediumCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
+function MediumCard({ item, r, type, sortKey, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; type: MediaType; sortKey: SortField<MediaType>; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   const tags = item.tags ?? [];
   return (
@@ -223,7 +238,7 @@ function MediumCard({ item, r, category, selected, onToggle }: { item: BaseItem;
           {r.tertiary && (
             <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
           )}
-          <SortableMetadata item={item} category={category} />
+          <SortableMetadata item={item} type={type} sortKey={sortKey} />
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-1">
               {tags.slice(0, 3).map((t) => (
@@ -238,7 +253,7 @@ function MediumCard({ item, r, category, selected, onToggle }: { item: BaseItem;
   );
 }
 
-function BigCard({ item, r, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; category?: string } & CardSelectProps) {
+function BigCard({ item, r, type, sortKey, category, selected, onToggle }: { item: BaseItem; r: RenderedItem; type: MediaType; sortKey: SortField<MediaType>; category?: string } & CardSelectProps) {
   const titleClass = category ? TITLE_CLASS[category] : 'text-text-primary';
   const tags = item.tags ?? [];
   return (
@@ -259,7 +274,7 @@ function BigCard({ item, r, category, selected, onToggle }: { item: BaseItem; r:
           {r.tertiary && (
             <div className="text-xs text-text-tertiary truncate shrink-0">{r.tertiary}</div>
           )}
-          <SortableMetadata item={item} category={category} />
+          <SortableMetadata item={item} type={type} sortKey={sortKey} />
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-auto pt-1">
               {tags.slice(0, 4).map((t) => (
@@ -480,9 +495,9 @@ export default function CollectionList<T extends MediaType>({ type, title, newPa
           const isSelected = base.id != null && selected.has(base.id);
           return (
             <Link key={base.id} to={`${newPath.replace(/\/new$/, '')}/${base.id}`} className="group block">
-              {viewMode === 'list' && <ListCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
-              {viewMode === 'medium' && <MediumCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
-              {viewMode === 'big' && <BigCard item={base} r={r} category={category} selected={isSelected} onToggle={toggleSelected} />}
+              {viewMode === 'list' && <ListCard item={base} r={r} type={type} sortKey={sortState.field} category={category} selected={isSelected} onToggle={toggleSelected} />}
+              {viewMode === 'medium' && <MediumCard item={base} r={r} type={type} sortKey={sortState.field} category={category} selected={isSelected} onToggle={toggleSelected} />}
+              {viewMode === 'big' && <BigCard item={base} r={r} type={type} sortKey={sortState.field} category={category} selected={isSelected} onToggle={toggleSelected} />}
             </Link>
           );
         })}

--- a/src/client/pages/GamesList.tsx
+++ b/src/client/pages/GamesList.tsx
@@ -33,8 +33,7 @@ export default function GamesList() {
             g.platform && g.platform !== 'Other'
               ? gamePlatformLabel(g.platform)
               : g.platformLegacy ?? null;
-          const year = g.year ? String(g.year) : null;
-          const meta = [platform, year].filter(Boolean).join(' · ');
+          const meta = platform ?? '';
           const showIcon = Boolean(g.platform && g.platform !== 'Other');
           return {
             primary: g.title,

--- a/src/client/pages/MoviesList.tsx
+++ b/src/client/pages/MoviesList.tsx
@@ -13,7 +13,7 @@ export default function MoviesList() {
         const fmts = MOVIE_FORMAT_FLAGS.filter((f) => ((m.formats ?? 0) & f.value) !== 0);
         return {
           primary: m.title,
-          secondary: [m.year, m.director].filter(Boolean).join(' · '),
+          secondary: m.director,
           tertiary:
             fmts.length > 0 ? (
               <span className="inline-flex items-center gap-1">

--- a/src/client/pages/MusicList.tsx
+++ b/src/client/pages/MusicList.tsx
@@ -13,7 +13,7 @@ export default function MusicList() {
         const label = musicFormatLabel(a.format);
         return {
           primary: a.title,
-          secondary: [a.artistName, a.year].filter(Boolean).join(' · '),
+          secondary: a.artistName,
           tertiary:
             label ? (
               <span className="inline-flex items-center gap-1">

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './client';
 import { filtersToParams, type Filters } from './filters';
+import { serializeSortParams, DEFAULT_SORT_FIELD, DEFAULT_SORT_DIRECTION, type SortState } from './sorting';
 import type {
   Album,
   CollectionStatus,
@@ -15,19 +16,26 @@ import type {
 
 type ItemMap = { movies: Movie; music: Album; games: Game };
 
+const DEFAULT_SORT_STATE: SortState<MediaType> = { field: DEFAULT_SORT_FIELD, direction: DEFAULT_SORT_DIRECTION };
+
 /**
- * List with an optional filter object. `query` stays the free-text
- * search; the filter object gets serialised to the per-endpoint query
- * params via {@link filtersToParams}. The query key includes both so
- * TanStack Query caches by the full (query + filters) pair and a
- * filter change refetches deterministically.
+ * List with an optional filter object and an optional resolved sort state.
+ * `query` stays the free-text search; the filter object gets serialised to
+ * the per-endpoint query params via {@link filtersToParams}. Sort defaults
+ * internally to addedAt/desc when omitted (matching the server's default) so
+ * every caller gets a canonical request even before it has sort controls.
+ * The query key includes query, filters, AND the resolved sort state so
+ * TanStack Query caches by the full request shape and any change refetches
+ * deterministically.
  */
-export function useList<T extends MediaType>(type: T, query: string, filters?: Filters<T>) {
+export function useList<T extends MediaType>(type: T, query: string, filters?: Filters<T>, sort?: SortState<T>) {
+  const resolvedSort = sort ?? (DEFAULT_SORT_STATE as SortState<T>);
   return useQuery({
-    queryKey: [type, 'list', query, filters ?? {}],
+    queryKey: [type, 'list', query, filters ?? {}, resolvedSort],
     queryFn: () => {
       const params = filters ? filtersToParams(filters as Record<string, unknown>) : new URLSearchParams();
       if (query) params.set('query', query);
+      for (const [k, v] of serializeSortParams(resolvedSort).entries()) params.set(k, v);
       const qs = params.toString();
       return api<ItemMap[T][]>(`/api/${type}${qs ? `?${qs}` : ''}`);
     },

--- a/src/client/services/collection.ts
+++ b/src/client/services/collection.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './client';
 import { filtersToParams, type Filters } from './filters';
 import { serializeSortParams, DEFAULT_SORT_FIELD, DEFAULT_SORT_DIRECTION, type SortState } from './sorting';
@@ -39,6 +39,11 @@ export function useList<T extends MediaType>(type: T, query: string, filters?: F
       const qs = params.toString();
       return api<ItemMap[T][]>(`/api/${type}${qs ? `?${qs}` : ''}`);
     },
+    // A sort/filter/search change is a NEW query key, not a background
+    // refetch of the same one; without this, TanStack Query briefly reports
+    // `data: undefined` for the new key, which would spuriously prune bulk
+    // selection (the membership effect reads an empty list) on every change.
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/client/services/sorting.test.ts
+++ b/src/client/services/sorting.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { readSortState, serializeSortParams, sortOptions, writeSortState, type SortState } from './sorting';
+
+describe('sortOptions', () => {
+  it('sortOptions_ForEachType_ContainsSharedAndOnlyItsOwnExtras', () => {
+    const shared = ['title', 'year', 'addedAt', 'personalRating'];
+
+    const movieValues = sortOptions('movies').map((o) => o.value);
+    const musicValues = sortOptions('music').map((o) => o.value);
+    const gameValues = sortOptions('games').map((o) => o.value);
+
+    for (const key of shared) {
+      expect(movieValues).toContain(key);
+      expect(musicValues).toContain(key);
+      expect(gameValues).toContain(key);
+    }
+
+    expect(movieValues).toEqual(expect.arrayContaining(['watchStatus', 'watchCount']));
+    expect(musicValues).toEqual(expect.arrayContaining(['listenCount']));
+    expect(gameValues).toEqual(expect.arrayContaining(['hoursPlayed', 'completionStatus']));
+
+    // Cross-type extras must never leak onto another type's option list.
+    expect(movieValues).not.toEqual(expect.arrayContaining(['listenCount', 'hoursPlayed', 'completionStatus']));
+    expect(musicValues).not.toEqual(expect.arrayContaining(['watchStatus', 'watchCount', 'hoursPlayed', 'completionStatus']));
+    expect(gameValues).not.toEqual(expect.arrayContaining(['watchStatus', 'watchCount', 'listenCount']));
+  });
+});
+
+describe('readSortState', () => {
+  it('readSortState_AbsentValuesUsesAddedAtDescending', () => {
+    const { state, needsReplace } = readSortState('movies', new URLSearchParams());
+
+    expect(state).toEqual({ field: 'addedAt', direction: 'desc' });
+    expect(needsReplace).toBe(false);
+  });
+
+  it('readSortState_InvalidOrRepeatedValuesReturnsCanonicalDefaultsAndNeedsReplace', () => {
+    const malformedQueryStrings = [
+      'sort=bogus',
+      'dir=bogus',
+      'sort=title&sort=year',
+      'dir=asc&dir=desc',
+      'sort=',
+      'dir=',
+    ];
+
+    for (const qs of malformedQueryStrings) {
+      const { state, needsReplace } = readSortState('movies', new URLSearchParams(qs));
+      expect(state).toEqual({ field: 'addedAt', direction: 'desc' });
+      expect(needsReplace).toBe(true);
+    }
+  });
+});
+
+describe('writeSortState', () => {
+  it('writeSortState_PreservesQueryFiltersAndUnrelatedParams', () => {
+    const current = new URLSearchParams('q=heat&director=Nolan&sort=title&dir=asc');
+
+    const next = writeSortState(current, { field: 'year', direction: 'desc' } satisfies SortState<'movies'>);
+
+    expect(next.get('q')).toBe('heat');
+    expect(next.get('director')).toBe('Nolan');
+    expect(next.get('sort')).toBe('year');
+    expect(next.get('dir')).toBe('desc');
+  });
+});
+
+describe('serializeSortParams', () => {
+  it('serializeSortParams_EmitsCanonicalSortAndDirection', () => {
+    const params = serializeSortParams({ field: 'personalRating', direction: 'asc' } satisfies SortState<'games'>);
+
+    expect(params.toString()).toBe('sort=personalRating&dir=asc');
+  });
+});

--- a/src/client/services/sorting.test.ts
+++ b/src/client/services/sorting.test.ts
@@ -3,26 +3,13 @@ import { readSortState, serializeSortParams, sortOptions, writeSortState, type S
 
 describe('sortOptions', () => {
   it('sortOptions_ForEachType_ContainsSharedAndOnlyItsOwnExtras', () => {
-    const shared = ['title', 'year', 'addedAt', 'personalRating'];
-
     const movieValues = sortOptions('movies').map((o) => o.value);
     const musicValues = sortOptions('music').map((o) => o.value);
     const gameValues = sortOptions('games').map((o) => o.value);
 
-    for (const key of shared) {
-      expect(movieValues).toContain(key);
-      expect(musicValues).toContain(key);
-      expect(gameValues).toContain(key);
-    }
-
-    expect(movieValues).toEqual(expect.arrayContaining(['watchStatus', 'watchCount']));
-    expect(musicValues).toEqual(expect.arrayContaining(['listenCount']));
-    expect(gameValues).toEqual(expect.arrayContaining(['hoursPlayed', 'completionStatus']));
-
-    // Cross-type extras must never leak onto another type's option list.
-    expect(movieValues).not.toEqual(expect.arrayContaining(['listenCount', 'hoursPlayed', 'completionStatus']));
-    expect(musicValues).not.toEqual(expect.arrayContaining(['watchStatus', 'watchCount', 'hoursPlayed', 'completionStatus']));
-    expect(gameValues).not.toEqual(expect.arrayContaining(['watchStatus', 'watchCount', 'listenCount']));
+    expect(movieValues).toEqual(['title', 'year', 'addedAt', 'personalRating', 'watchStatus', 'watchCount']);
+    expect(musicValues).toEqual(['title', 'year', 'addedAt', 'personalRating', 'listenCount']);
+    expect(gameValues).toEqual(['title', 'year', 'addedAt', 'personalRating', 'hoursPlayed', 'completionStatus']);
   });
 });
 

--- a/src/client/services/sorting.ts
+++ b/src/client/services/sorting.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { MediaType } from './types';
+
+export type SortDirection = 'asc' | 'desc';
+
+export type SharedSortField = 'title' | 'year' | 'addedAt' | 'personalRating';
+
+/** Per-type ?sort= keys: the shared fields plus each type's own extras.
+ * Wire values match the server's exact keys. */
+export interface SortFieldMap {
+  movies: SharedSortField | 'watchStatus' | 'watchCount';
+  music: SharedSortField | 'listenCount';
+  games: SharedSortField | 'hoursPlayed' | 'completionStatus';
+}
+
+export type SortField<T extends MediaType> = SortFieldMap[T];
+
+export interface SortState<T extends MediaType> {
+  field: SortField<T>;
+  direction: SortDirection;
+}
+
+export const DEFAULT_SORT_FIELD: SharedSortField = 'addedAt';
+export const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
+
+export interface SortOption {
+  value: string;
+  label: string;
+}
+
+const SHARED_SORT_OPTIONS: SortOption[] = [
+  { value: 'title', label: 'Title' },
+  { value: 'year', label: 'Year' },
+  { value: 'addedAt', label: 'Date added' },
+  { value: 'personalRating', label: 'Rating' },
+];
+
+const TYPE_SORT_OPTIONS: Record<MediaType, SortOption[]> = {
+  movies: [
+    { value: 'watchStatus', label: 'Watch status' },
+    { value: 'watchCount', label: 'Watch count' },
+  ],
+  music: [
+    { value: 'listenCount', label: 'Listen count' },
+  ],
+  games: [
+    { value: 'hoursPlayed', label: 'Hours played' },
+    { value: 'completionStatus', label: 'Completion status' },
+  ],
+};
+
+export const DIRECTION_OPTIONS: { value: SortDirection; label: string }[] = [
+  { value: 'asc', label: 'Ascending' },
+  { value: 'desc', label: 'Descending' },
+];
+
+/** Sort options for a media type: the four shared fields plus that type's own
+ * extras only (never another type's extras). */
+export function sortOptions<T extends MediaType>(type: T): SortOption[] {
+  return [...SHARED_SORT_OPTIONS, ...TYPE_SORT_OPTIONS[type]];
+}
+
+function isValidField<T extends MediaType>(type: T, value: string): value is SortField<T> {
+  return sortOptions(type).some((o) => o.value === value);
+}
+
+export interface ReadSortStateResult<T extends MediaType> {
+  state: SortState<T>;
+  /** True when the URL held a present-but-invalid sort/dir value (unknown,
+   * empty, or repeated) and must be canonicalized with a single replace
+   * navigation. Absent values resolve to the default WITHOUT this flag. */
+  needsReplace: boolean;
+}
+
+/**
+ * Reads sort state out of a URLSearchParams, mirroring the server's
+ * unknown/empty/repeated-value contract client-side. Absent `sort`/`dir`
+ * silently resolve to addedAt/desc; a present-but-invalid value also
+ * resolves to the default but reports `needsReplace` so the caller can
+ * canonicalize the URL exactly once.
+ */
+export function readSortState<T extends MediaType>(type: T, params: URLSearchParams): ReadSortStateResult<T> {
+  const sortValues = params.getAll('sort');
+  const dirValues = params.getAll('dir');
+
+  let field: SortField<T> = DEFAULT_SORT_FIELD as SortField<T>;
+  let needsReplace = false;
+
+  if (sortValues.length === 1 && sortValues[0].length > 0 && isValidField(type, sortValues[0])) {
+    field = sortValues[0] as SortField<T>;
+  } else if (sortValues.length > 0) {
+    needsReplace = true;
+  }
+
+  let direction: SortDirection = DEFAULT_SORT_DIRECTION;
+  if (dirValues.length === 1 && (dirValues[0] === 'asc' || dirValues[0] === 'desc')) {
+    direction = dirValues[0];
+  } else if (dirValues.length > 0) {
+    needsReplace = true;
+  }
+
+  return { state: { field, direction }, needsReplace };
+}
+
+/** Writes sort state into a copy of `current`, preserving every other
+ * (filter, query, or unrelated) param untouched. */
+export function writeSortState<T extends MediaType>(
+  current: URLSearchParams,
+  state: SortState<T>,
+): URLSearchParams {
+  const next = new URLSearchParams(current);
+  next.set('sort', state.field);
+  next.set('dir', state.direction);
+  return next;
+}
+
+/** Canonical `sort`/`dir` request params. The caller appends these after
+ * existing filter/query params are serialized. */
+export function serializeSortParams<T extends MediaType>(state: SortState<T>): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('sort', state.field);
+  params.set('dir', state.direction);
+  return params;
+}
+
+/**
+ * URL-synced sort state, mirroring {@link ../services/filters.useFiltersState}.
+ * A malformed URL is canonicalized with a single `replace` navigation; once
+ * the canonical URL is installed, `readSortState` no longer reports
+ * `needsReplace` and the effect goes inert.
+ */
+export function useSortState<T extends MediaType>(type: T) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { state, needsReplace } = readSortState(type, searchParams);
+
+  useEffect(() => {
+    if (needsReplace) {
+      setSearchParams(writeSortState(searchParams, state), { replace: true });
+    }
+    // Re-run only when the canonicalization need itself changes; `state` at
+    // that moment is already captured via `needsReplace`'s computation above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needsReplace]);
+
+  const setSortState = useCallback(
+    (next: SortState<T>) => {
+      setSearchParams(writeSortState(searchParams, next), { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return { state, setSortState };
+}

--- a/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/CollectionEndpoints.cs
@@ -38,6 +38,16 @@ public sealed class BulkField<TEntity> where TEntity : class, ICollectionEntry
 /// map — only named fields are set on each row; absent fields are untouched.</summary>
 public sealed record BulkUpdateRequest(int[] Ids, Dictionary<string, JsonElement> Updates);
 
+/// <summary>A named sortable field. <see cref="Ascending"/> and
+/// <see cref="Descending"/> each apply that field's order (plus any nulls-last
+/// discriminator) as the PRIMARY order term; the caller appends the ascending
+/// <c>Id</c> tie-breaker afterwards.</summary>
+public sealed class SortDescriptor<TEntity> where TEntity : class, ICollectionEntry
+{
+    public required Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> Ascending { get; init; }
+    public required Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> Descending { get; init; }
+}
+
 public sealed class CollectionEndpointConfig<TEntity, TDto>
     where TEntity : class, ICollectionEntry, new()
     where TDto : ICollectionEntryDto
@@ -57,16 +67,111 @@ public sealed class CollectionEndpointConfig<TEntity, TDto>
     // Bulk-updatable fields keyed by their JSON name (see BulkField<TEntity>).
     // Absent (or empty) => the resource has no bulk PATCH surface.
     public IReadOnlyDictionary<string, BulkField<TEntity>>? BulkFields { get; init; }
+    // Type-specific ?sort= keys layered on top of the shared keys (title,
+    // year, addedAt, personalRating). Absent (or empty) => shared keys only.
+    public IReadOnlyDictionary<string, SortDescriptor<TEntity>>? SortFields { get; init; }
+}
+
+// Shared ?sort= keys available to every collection type, keyed by the exact
+// wire value. Scoped per closed TEntity via a nested generic static class so
+// each media type gets its own lazily-initialized dictionary instance without
+// needing CollectionEndpoints itself to be generic.
+file static class SharedSortFields<TEntity> where TEntity : class, ICollectionEntry
+{
+    public static readonly IReadOnlyDictionary<string, SortDescriptor<TEntity>> Value = new Dictionary<string, SortDescriptor<TEntity>>
+    {
+        ["title"] = new SortDescriptor<TEntity>
+        {
+            // .ToLower() (not ToLowerInvariant/ToUpper) so EF translates it to
+            // the provider's SQL LOWER(), which SQLite maps ASCII-only —
+            // matching this field's documented ASCII case-insensitive contract.
+            Ascending = q => q.OrderBy(e => e.Title.ToLower()),
+            Descending = q => q.OrderByDescending(e => e.Title.ToLower()),
+        },
+        ["year"] = new SortDescriptor<TEntity>
+        {
+            // Leading `== null` term keeps nulls last in BOTH directions —
+            // SQLite's native NULL ordering differs by direction, so this
+            // discriminator can't be dropped for either one.
+            Ascending = q => q.OrderBy(e => e.Year == null).ThenBy(e => e.Year),
+            Descending = q => q.OrderBy(e => e.Year == null).ThenByDescending(e => e.Year),
+        },
+        ["addedAt"] = new SortDescriptor<TEntity>
+        {
+            Ascending = q => q.OrderBy(e => e.AddedAt),
+            Descending = q => q.OrderByDescending(e => e.AddedAt),
+        },
+        ["personalRating"] = new SortDescriptor<TEntity>
+        {
+            Ascending = q => q.OrderBy(e => e.PersonalRating == null).ThenBy(e => e.PersonalRating),
+            Descending = q => q.OrderBy(e => e.PersonalRating == null).ThenByDescending(e => e.PersonalRating),
+        },
+    };
 }
 
 public static class CollectionEndpoints
 {
+    // Merges the shared sort keys with any type-specific ones once per
+    // registered endpoint (not per request). Type-specific entries with the
+    // same key would overwrite a shared one, but no config does that today.
+    private static IReadOnlyDictionary<string, SortDescriptor<TEntity>> BuildSortFields<TEntity, TDto>(
+        CollectionEndpointConfig<TEntity, TDto> cfg)
+        where TEntity : class, ICollectionEntry, new()
+        where TDto : ICollectionEntryDto
+    {
+        var fields = new Dictionary<string, SortDescriptor<TEntity>>(SharedSortFields<TEntity>.Value);
+        if (cfg.SortFields is { } extra)
+            foreach (var (key, descriptor) in extra)
+                fields[key] = descriptor;
+        return fields;
+    }
+
+    // Reads the raw ?sort=/?dir= query values (bypassing model binding) so
+    // repeated or empty-but-present values can be told apart from "absent",
+    // then resolves them against the given field map. A present-but-invalid
+    // value (unknown key, repeated, or empty) returns a pinned 400 rather
+    // than silently falling back to the default.
+    private static (Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? Apply, IResult? Error) ResolveSort<TEntity>(
+        HttpRequest request, IReadOnlyDictionary<string, SortDescriptor<TEntity>> fields)
+        where TEntity : class, ICollectionEntry
+    {
+        var sortValues = request.Query["sort"];
+        var dirValues = request.Query["dir"];
+
+        if (sortValues.Count > 1)
+            return (null, Results.BadRequest(new { error = "Query parameter 'sort' must have a single value." }));
+        if (dirValues.Count > 1)
+            return (null, Results.BadRequest(new { error = "Query parameter 'dir' must have a single value." }));
+
+        var sortKey = "addedAt";
+        if (sortValues.Count == 1)
+        {
+            var raw = sortValues[0];
+            if (string.IsNullOrEmpty(raw) || !fields.ContainsKey(raw))
+                return (null, Results.BadRequest(new { error = "Invalid value for query parameter 'sort'." }));
+            sortKey = raw;
+        }
+
+        var descending = true;
+        if (dirValues.Count == 1)
+        {
+            var raw = dirValues[0];
+            if (raw != "asc" && raw != "desc")
+                return (null, Results.BadRequest(new { error = "Invalid value for query parameter 'dir'." }));
+            descending = raw == "desc";
+        }
+
+        var descriptor = fields[sortKey];
+        return (descending ? descriptor.Descending : descriptor.Ascending, null);
+    }
+
     public static IEndpointRouteBuilder MapCollectionEndpoints<TEntity, TDto>(
         this IEndpointRouteBuilder app, CollectionEndpointConfig<TEntity, TDto> cfg)
         where TEntity : class, ICollectionEntry, new()
         where TDto : ICollectionEntryDto
     {
         var group = app.MapGroup(cfg.RoutePrefix).RequireAuthorization();
+        var sortFields = BuildSortFields(cfg);
 
         group.MapGet("/", async (
             [FromQuery] string? query,
@@ -105,7 +210,11 @@ public static class CollectionEndpoints
                 q = filtered;
             }
 
-            var items = await q.OrderByDescending(e => e.AddedAt).Take(500).ToListAsync();
+            var (applySort, sortError) = ResolveSort(ctx.Request, sortFields);
+            if (sortError is { } se) return se;
+
+            var ordered = applySort!(q).ThenBy(e => e.Id);
+            var items = await ordered.Take(500).ToListAsync();
             return Results.Ok(items.Select(cfg.ToDto));
         });
 

--- a/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/GamesEndpoints.cs
@@ -166,6 +166,19 @@ public static class GamesEndpoints
                 child.UpdatedAt = DateTime.UtcNow;
             }
         },
+        SortFields = new Dictionary<string, SortDescriptor<Game>>
+        {
+            ["hoursPlayed"] = new SortDescriptor<Game>
+            {
+                Ascending = q => q.OrderBy(g => g.HoursPlayed == null).ThenBy(g => g.HoursPlayed),
+                Descending = q => q.OrderBy(g => g.HoursPlayed == null).ThenByDescending(g => g.HoursPlayed),
+            },
+            ["completionStatus"] = new SortDescriptor<Game>
+            {
+                Ascending = q => q.OrderBy(g => g.CompletionStatus),
+                Descending = q => q.OrderByDescending(g => g.CompletionStatus),
+            },
+        },
         BulkFields = new Dictionary<string, BulkField<Game>>
         {
             ["status"] = BulkFieldBuilder.Enum<Game, CollectionStatus>("status", (e, v) => e.Status = v),

--- a/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MoviesEndpoints.cs
@@ -123,6 +123,19 @@ public static class MoviesEndpoints
             return (q, null);
         },
         OnDelete = null,
+        SortFields = new Dictionary<string, SortDescriptor<Movie>>
+        {
+            ["watchStatus"] = new SortDescriptor<Movie>
+            {
+                Ascending = q => q.OrderBy(m => m.WatchStatus),
+                Descending = q => q.OrderByDescending(m => m.WatchStatus),
+            },
+            ["watchCount"] = new SortDescriptor<Movie>
+            {
+                Ascending = q => q.OrderBy(m => m.WatchCount),
+                Descending = q => q.OrderByDescending(m => m.WatchCount),
+            },
+        },
         BulkFields = new Dictionary<string, BulkField<Movie>>
         {
             ["status"] = BulkFieldBuilder.Enum<Movie, CollectionStatus>("status", (e, v) => e.Status = v),

--- a/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
+++ b/src/server/Collectify.Api/Endpoints/MusicEndpoints.cs
@@ -101,6 +101,14 @@ public static class MusicEndpoints
             return (q, null);
         },
         OnDelete = null,
+        SortFields = new Dictionary<string, SortDescriptor<MusicAlbum>>
+        {
+            ["listenCount"] = new SortDescriptor<MusicAlbum>
+            {
+                Ascending = q => q.OrderBy(a => a.ListenCount),
+                Descending = q => q.OrderByDescending(a => a.ListenCount),
+            },
+        },
         BulkFields = new Dictionary<string, BulkField<MusicAlbum>>
         {
             ["status"] = BulkFieldBuilder.Enum<MusicAlbum, CollectionStatus>("status", (e, v) => e.Status = v),

--- a/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
+++ b/src/server/tests/Collectify.Tests/Api/CollectionEndpointsTestsBase.cs
@@ -39,6 +39,12 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
 
     protected abstract TEntity NewMinimalEntity(string ownerId, string title);
 
+    /// <summary>Constructs an entity with explicit sortable field values, used
+    /// only by the shared sort tests below (list-endpoint sorting is generic
+    /// across media types, so the fixtures must be too).</summary>
+    protected abstract TEntity NewSortableEntity(
+        string ownerId, string title, int? year = null, int? personalRating = null, DateTime? addedAt = null);
+
     protected abstract int IdOf(TEntity entity);
     protected abstract string OwnerIdOf(TEntity entity);
     protected abstract string TitleOf(TEntity entity);
@@ -223,6 +229,132 @@ public abstract class CollectionEndpointsTestsBase<TEntity, TResponse>
 
         Assert.Single(aliceList!);
         Assert.Equal("Alice-Row", aliceList![0].Title);
+    }
+
+    // -------- Sorting --------
+
+    [Fact]
+    public async Task List_WithoutSort_DefaultsToAddedAtDescendingThenId()
+    {
+        var alice = await NewAliceAsync();
+        var now = DateTime.UtcNow;
+
+        // Seeded out of AddedAt order so a bug that relies on insertion/ID
+        // order for the default sort would not accidentally pass.
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "Middle", addedAt: now.AddDays(-1)));
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "Newest", addedAt: now));
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "Oldest", addedAt: now.AddDays(-2)));
+        // Equal timestamps: the tie must break on ascending ID, i.e. seed order.
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "TieFirst", addedAt: now.AddDays(-3)));
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "TieSecond", addedAt: now.AddDays(-3)));
+
+        var items = await alice.Client.GetJsonAsync<TResponse[]>(RoutePrefix);
+
+        var titles = items!.Select(i => i.Title).ToArray();
+        Assert.Equal(new[] { "Newest", "Middle", "Oldest", "TieFirst", "TieSecond" }, titles);
+    }
+
+    public static IEnumerable<object[]> SharedSortCases()
+    {
+        yield return new object[] { "title", "asc" };
+        yield return new object[] { "title", "desc" };
+        yield return new object[] { "year", "asc" };
+        yield return new object[] { "year", "desc" };
+        yield return new object[] { "addedAt", "asc" };
+        yield return new object[] { "addedAt", "desc" };
+        yield return new object[] { "personalRating", "asc" };
+        yield return new object[] { "personalRating", "desc" };
+    }
+
+    [Theory]
+    [MemberData(nameof(SharedSortCases))]
+    public async Task List_SortsSharedFieldsInBothDirections(string sort, string dir)
+    {
+        var alice = await NewAliceAsync();
+        var now = DateTime.UtcNow;
+
+        // Title, year, addedAt, and personalRating are deliberately
+        // discordant across these three rows so each theory case actually
+        // exercises its own field rather than coasting on a coincidental
+        // shared order. "alpha" vs "Zulu"/"Mike" also discriminates raw
+        // (case-sensitive) title ordering from ASCII case-insensitive order.
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "Zulu", year: 2000, personalRating: 3, addedAt: now.AddDays(-10)));
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "alpha", year: 2010, personalRating: 9, addedAt: now.AddDays(-5)));
+        await Factory.SeedAsync(NewSortableEntity(alice.Id, "Mike", year: null, personalRating: null, addedAt: now));
+
+        var items = await alice.Client.GetJsonAsync<TResponse[]>($"{RoutePrefix}?sort={sort}&dir={dir}");
+        var titles = items!.Select(i => i.Title).ToArray();
+
+        var expected = (sort, dir) switch
+        {
+            ("title", "asc") => new[] { "alpha", "Mike", "Zulu" },
+            ("title", "desc") => new[] { "Zulu", "Mike", "alpha" },
+            ("year", "asc") => new[] { "Zulu", "alpha", "Mike" },       // Mike (null) last.
+            ("year", "desc") => new[] { "alpha", "Zulu", "Mike" },     // Mike (null) last.
+            ("addedAt", "asc") => new[] { "Zulu", "alpha", "Mike" },
+            ("addedAt", "desc") => new[] { "Mike", "alpha", "Zulu" },
+            ("personalRating", "asc") => new[] { "Zulu", "alpha", "Mike" },   // Mike (null) last.
+            ("personalRating", "desc") => new[] { "alpha", "Zulu", "Mike" }, // Mike (null) last.
+            _ => throw new InvalidOperationException($"Unhandled case: {sort}/{dir}"),
+        };
+        Assert.Equal(expected, titles);
+    }
+
+    [Fact]
+    public async Task List_SortsFilteredSubsetBeforeCap()
+    {
+        var alice = await NewAliceAsync();
+        var now = DateTime.UtcNow;
+
+        // 500 rows that all sort after the 501st ("AAAA-Row-Final") when
+        // sorted by title ascending. A Take(500)-before-sort bug would apply
+        // the cap by insertion/ID order first, dropping the final-seeded row
+        // (which would otherwise legitimately sort first).
+        var bulk = Enumerable.Range(0, 500)
+            .Select(i => NewSortableEntity(alice.Id, $"ZRow-{i:D4}", addedAt: now))
+            .ToArray();
+        var finalRow = NewSortableEntity(alice.Id, "AAAA-Row-Final", addedAt: now);
+
+        await Factory.WithDbAsync(async db =>
+        {
+            db.Set<TEntity>().AddRange(bulk);
+            db.Set<TEntity>().Add(finalRow);
+            await db.SaveChangesAsync();
+            return true;
+        });
+
+        var items = await alice.Client.GetJsonAsync<TResponse[]>($"{RoutePrefix}?query=Row&sort=title&dir=asc");
+
+        Assert.Equal(500, items!.Length);
+        Assert.Equal("AAAA-Row-Final", items[0].Title);
+    }
+
+    public static IEnumerable<object[]> SharedSortQueryCases()
+    {
+        yield return new object[] { "sort=bogus", HttpStatusCode.BadRequest, "Invalid value for query parameter 'sort'." };
+        yield return new object[] { "dir=bogus", HttpStatusCode.BadRequest, "Invalid value for query parameter 'dir'." };
+        yield return new object[] { "sort=title&sort=year", HttpStatusCode.BadRequest, "Query parameter 'sort' must have a single value." };
+        yield return new object[] { "dir=asc&dir=desc", HttpStatusCode.BadRequest, "Query parameter 'dir' must have a single value." };
+        yield return new object[] { "sort=", HttpStatusCode.BadRequest, "Invalid value for query parameter 'sort'." };
+        yield return new object[] { "dir=", HttpStatusCode.BadRequest, "Invalid value for query parameter 'dir'." };
+        // Valid control case: must stay 200 while every malformed case above 400s.
+        yield return new object[] { "sort=title&dir=asc", HttpStatusCode.OK, null! };
+    }
+
+    [Theory]
+    [MemberData(nameof(SharedSortQueryCases))]
+    public async Task List_InvalidSharedSortQuery_ReturnsPinnedBadRequest(string queryString, HttpStatusCode expectedStatus, string? expectedError)
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.GetAsync($"{RoutePrefix}?{queryString}");
+
+        Assert.Equal(expectedStatus, response.StatusCode);
+        if (expectedError is not null)
+        {
+            var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+            Assert.Equal(expectedError, body.GetProperty("error").GetString());
+        }
     }
 
     // -------- Validation --------

--- a/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
@@ -59,6 +59,53 @@ public class GamesEndpointsTests : CollectionEndpointsTestsBase<Game, GameRespon
     protected override Task<int> GenreLinkCountAsync(int itemId) =>
         Factory.WithDbAsync(db => db.Set<Genre>().AsNoTracking().CountAsync(g => g.Games.Any(x => x.Id == itemId)));
 
+    // -------- Sorting (game-specific type keys) --------
+
+    public static IEnumerable<object[]> GameSortCases()
+    {
+        yield return new object[] { "completionStatus", "asc" };
+        yield return new object[] { "completionStatus", "desc" };
+        yield return new object[] { "hoursPlayed", "asc" };
+        yield return new object[] { "hoursPlayed", "desc" };
+    }
+
+    [Theory]
+    [MemberData(nameof(GameSortCases))]
+    public async Task List_SortsByHoursPlayedAndCompletionStatus(string sort, string dir)
+    {
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "A", CompletionStatus = CompletionStatus.Beaten, HoursPlayed = 10 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "B", CompletionStatus = CompletionStatus.NotStarted, HoursPlayed = null });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "C", CompletionStatus = CompletionStatus.Playing, HoursPlayed = 3 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "D", CompletionStatus = CompletionStatus.HundredPercent, HoursPlayed = 50 });
+        await Factory.SeedAsync(new Game { OwnerId = alice.Id, Title = "E", CompletionStatus = CompletionStatus.Abandoned, HoursPlayed = 1 });
+
+        var items = await alice.Client.GetJsonAsync<GameResponse[]>($"{RoutePrefix}?sort={sort}&dir={dir}");
+        var titles = items!.Select(i => i.Title).ToArray();
+
+        var expected = (sort, dir) switch
+        {
+            ("completionStatus", "asc") => new[] { "B", "C", "A", "D", "E" },   // NotStarted..Abandoned.
+            ("completionStatus", "desc") => new[] { "E", "D", "A", "C", "B" },
+            ("hoursPlayed", "asc") => new[] { "E", "C", "A", "D", "B" },        // B (null) last.
+            ("hoursPlayed", "desc") => new[] { "D", "A", "C", "E", "B" },       // B (null) last.
+            _ => throw new InvalidOperationException($"Unhandled case: {sort}/{dir}"),
+        };
+        Assert.Equal(expected, titles);
+    }
+
+    [Fact]
+    public async Task List_RejectsWrongTypeSortKey_WatchCount()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.GetAsync($"{RoutePrefix}?sort=watchCount");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Invalid value for query parameter 'sort'.", body.GetProperty("error").GetString());
+    }
+
     [Fact]
     public async Task CreateAndGet_RoundTripsRichDetailFields()
     {

--- a/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/GamesEndpointsTests.cs
@@ -40,6 +40,17 @@ public class GamesEndpointsTests : CollectionEndpointsTestsBase<Game, GameRespon
         UpdatedAt = DateTime.UtcNow.AddDays(-1),
     };
 
+    protected override Game NewSortableEntity(
+        string ownerId, string title, int? year = null, int? personalRating = null, DateTime? addedAt = null) => new()
+    {
+        OwnerId = ownerId,
+        Title = title,
+        Year = year,
+        PersonalRating = personalRating,
+        AddedAt = addedAt ?? DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
+
     protected override int IdOf(Game entity) => entity.Id;
     protected override string OwnerIdOf(Game entity) => entity.OwnerId;
     protected override string TitleOf(Game entity) => entity.Title;

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -122,6 +122,51 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         Assert.Equal(MovieFormat.Vhs | MovieFormat.Digital, stored.Formats);
     }
 
+    // -------- Sorting (movie-specific type keys) --------
+
+    public static IEnumerable<object[]> MovieSortCases()
+    {
+        yield return new object[] { "watchStatus", "asc" };
+        yield return new object[] { "watchStatus", "desc" };
+        yield return new object[] { "watchCount", "asc" };
+        yield return new object[] { "watchCount", "desc" };
+    }
+
+    [Theory]
+    [MemberData(nameof(MovieSortCases))]
+    public async Task List_SortsByWatchStatusAndWatchCount(string sort, string dir)
+    {
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "A", WatchStatus = WatchStatus.Watched, WatchCount = 5 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "B", WatchStatus = WatchStatus.Unwatched, WatchCount = 1 });
+        await Factory.SeedAsync(new Movie { OwnerId = alice.Id, Title = "C", WatchStatus = WatchStatus.Watching, WatchCount = 9 });
+
+        var items = await alice.Client.GetJsonAsync<MovieResponse[]>($"{RoutePrefix}?sort={sort}&dir={dir}");
+        var titles = items!.Select(i => i.Title).ToArray();
+
+        var expected = (sort, dir) switch
+        {
+            ("watchStatus", "asc") => new[] { "B", "C", "A" },   // Unwatched, Watching, Watched.
+            ("watchStatus", "desc") => new[] { "A", "C", "B" },
+            ("watchCount", "asc") => new[] { "B", "A", "C" },
+            ("watchCount", "desc") => new[] { "C", "A", "B" },
+            _ => throw new InvalidOperationException($"Unhandled case: {sort}/{dir}"),
+        };
+        Assert.Equal(expected, titles);
+    }
+
+    [Fact]
+    public async Task List_RejectsWrongTypeSortKey_ListenCount()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.GetAsync($"{RoutePrefix}?sort=listenCount");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Invalid value for query parameter 'sort'.", body.GetProperty("error").GetString());
+    }
+
     // -------- Personal / acquisition / watch fields round-trip --------
 
     [Fact]

--- a/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MoviesEndpointsTests.cs
@@ -38,6 +38,17 @@ public class MoviesEndpointsTests : CollectionEndpointsTestsBase<Movie, MovieRes
         UpdatedAt = DateTime.UtcNow.AddDays(-1),
     };
 
+    protected override Movie NewSortableEntity(
+        string ownerId, string title, int? year = null, int? personalRating = null, DateTime? addedAt = null) => new()
+    {
+        OwnerId = ownerId,
+        Title = title,
+        Year = year,
+        PersonalRating = personalRating,
+        AddedAt = addedAt ?? DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
+
     protected override int IdOf(Movie entity) => entity.Id;
     protected override string OwnerIdOf(Movie entity) => entity.OwnerId;
     protected override string TitleOf(Movie entity) => entity.Title;

--- a/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
@@ -38,6 +38,18 @@ public class MusicEndpointsTests : CollectionEndpointsTestsBase<MusicAlbum, Albu
         UpdatedAt = DateTime.UtcNow.AddDays(-1),
     };
 
+    protected override MusicAlbum NewSortableEntity(
+        string ownerId, string title, int? year = null, int? personalRating = null, DateTime? addedAt = null) => new()
+    {
+        OwnerId = ownerId,
+        Title = title,
+        ArtistName = "Radiohead",
+        Year = year,
+        PersonalRating = personalRating,
+        AddedAt = addedAt ?? DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+    };
+
     protected override int IdOf(MusicAlbum entity) => entity.Id;
     protected override string OwnerIdOf(MusicAlbum entity) => entity.OwnerId;
     protected override string TitleOf(MusicAlbum entity) => entity.Title;

--- a/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
+++ b/src/server/tests/Collectify.Tests/Api/MusicEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Collectify.Domain.Entities;
 using Collectify.Domain.Enums;
 using Collectify.Tests.Infrastructure;
@@ -57,6 +58,37 @@ public class MusicEndpointsTests : CollectionEndpointsTestsBase<MusicAlbum, Albu
 
     protected override Task<int> GenreLinkCountAsync(int itemId) =>
         Factory.WithDbAsync(db => db.Set<Genre>().AsNoTracking().CountAsync(g => g.MusicAlbums.Any(a => a.Id == itemId)));
+
+    // -------- Sorting (music-specific type key) --------
+
+    [Theory]
+    [InlineData("asc")]
+    [InlineData("desc")]
+    public async Task List_SortsByListenCount(string dir)
+    {
+        var alice = await NewAliceAsync();
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "A", ArtistName = "X", ListenCount = 5 });
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "B", ArtistName = "X", ListenCount = 1 });
+        await Factory.SeedAsync(new MusicAlbum { OwnerId = alice.Id, Title = "C", ArtistName = "X", ListenCount = 9 });
+
+        var items = await alice.Client.GetJsonAsync<AlbumResponse[]>($"{RoutePrefix}?sort=listenCount&dir={dir}");
+        var titles = items!.Select(i => i.Title).ToArray();
+
+        var expected = dir == "asc" ? new[] { "B", "A", "C" } : new[] { "C", "A", "B" };
+        Assert.Equal(expected, titles);
+    }
+
+    [Fact]
+    public async Task List_RejectsWrongTypeSortKey_HoursPlayed()
+    {
+        var alice = await NewAliceAsync();
+
+        var response = await alice.Client.GetAsync($"{RoutePrefix}?sort=hoursPlayed");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Invalid value for query parameter 'sort'.", body.GetProperty("error").GetString());
+    }
 
     [Fact]
     public async Task CreateAndGet_RoundTripsReleaseDate()

--- a/src/server/tests/Collectify.Tests/TestSupport/CollectionTestSupport.cs
+++ b/src/server/tests/Collectify.Tests/TestSupport/CollectionTestSupport.cs
@@ -11,11 +11,13 @@ public interface ICollectionResponse
 {
     int Id { get; }
     string Title { get; }
+    int? Year { get; }
     int? PersonalRating { get; }
     string? AcquisitionCurrency { get; }
     string? ImagePath { get; }
     string[] Tags { get; }
     string[] Genres { get; }
+    DateTime AddedAt { get; }
     DateTime UpdatedAt { get; }
 }
 


### PR DESCRIPTION
## Summary

- add server-side sorting for movie, music, and game collection lists
- apply owner scope and filters before sorting, then retain the existing 500-row cap
- add typed URL-synchronized sort controls and per-media sort options
- show every applicable sortable value on every item in List, Medium, and Big views
- preserve list selection when sorting only changes result order

## Sort contract

Shared fields:
- title
- year
- date added
- personal rating

Per-type fields:
- movies: watch status, watch count
- music: listen count
- games: hours played, completion status

Ordering guarantees:
- null values sort last
- IDs provide a stable ascending tie-breaker
- title ordering is ASCII case-insensitive; full Unicode case-fold parity remains outside this slice

## Verification status

Current head: `c954663bee293d3d1ddc07a160f367a1c4f4d251`.

Driver-verified on this head:
- local CI passed: server 761/761, client 224/224, client production build, vulnerability gates, enum parity, and Docker entrypoint
- client mutation checks M12-M20 and expanded checks M14/M17/M19/U1-U6 reddened at their expected mechanisms, restored byte-identically, rebuilt, and reran green
- suite ledger: baseline 697 server / 204 client; current 761 server / 224 client

The PR remains draft while the external review loop runs. No merge action is authorized.

Closes #178