### PR TITLE
feat(database): back up SQLite before startup migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,10 @@
 # Required when Provider=postgres. Full .NET connection string.
 # Collectify__Database__ConnectionString=Host=postgres;Port=5432;Database=collectify;Username=collectify;Password=secret
 
+# SQLite only: number of completed pre-migration snapshots to retain in
+# <DataDir>/backups. Must be a positive integer. Default: 10.
+# Collectify__Database__BackupRetention=10
+
 # ----------------------------------------------------------------------
 # OCR noise words — extend the built-in sets with category-specific words.
 # The app ships with ~50 words per category covering platforms (PS5, Xbox),

--- a/README.md
+++ b/README.md
@@ -24,6 +24,36 @@ PUID=$(id -u) PGID=$(id -g) docker compose up -d
 
 For named volumes the defaults usually work. For bind mounts, set `PUID` and `PGID` to the host user that should own the data directory.
 
+### Automatic SQLite migration backups
+
+Before Collectify applies pending migrations to an existing SQLite database, it creates a verified snapshot in `/data/backups`. Fresh installs and ordinary restarts with no pending migration do not create a snapshot. The newest 10 completed snapshots are retained by default; set `Collectify__Database__BackupRetention` to another positive integer to change that limit. An invalid value, a failed backup, or a failed integrity check stops startup before the database is migrated.
+
+Snapshots contain the full collection, including cached cover images. Protect the backup directory like the primary database. PostgreSQL deployments are not copied by Collectify; use PostgreSQL's provider-native backup and restore tools.
+
+To recover from a failed SQLite upgrade:
+
+1. Download the previous release's `image.json` asset and note its immutable `reference` digest (see [Releases & container images](#releases--container-images)).
+2. Stop Collectify:
+
+   ```bash
+   docker compose stop collectify
+   ```
+
+3. Replace `<snapshot>` with the selected filename from `/data/backups` and restore it while the application is stopped:
+
+   ```bash
+   docker compose run --rm --no-deps --entrypoint sh collectify -c \
+     'cp "/data/backups/<snapshot>" /data/collectify.db && rm -f /data/collectify.db-wal /data/collectify.db-shm'
+   ```
+
+4. Temporarily set the compose service's `image:` to the exact `reference` from `image.json` (for example, `ghcr.io/mforce/collectify@sha256:…`), then start it:
+
+   ```bash
+   docker compose up -d
+   ```
+
+Do not recover with a mutable tag such as `latest`; it may already point at the image whose migration failed.
+
 ### PostgreSQL (optional)
 
 Collectify defaults to SQLite (zero-config, single-file DB). If you prefer PostgreSQL for persistence, backups, or operational tooling:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,8 @@ through `MetadataLookupOptions.Vision`.
 ## Migrations
 
 - Always generated via `dotnet ef migrations add <Name> --project Collectify.Infrastructure --startup-project Collectify.Api --output-dir Data/Migrations`.
-- Applied automatically on container start (`db.Database.MigrateAsync()` in `Program.cs`).
+- `DatabaseMigrationCoordinator` owns startup schema changes for both providers. PostgreSQL is provisioned when its target database is missing, then migrated through its provider-native lineage.
+- Before applying pending SQLite migrations to an existing file, the coordinator creates and verifies a snapshot under `<DataDir>/backups`. It prunes completed snapshots only after migration succeeds; a backup, verification, or migration failure stops startup.
 - Never edit a migration once it's been applied to anyone's database — write a new migration instead.
 
 ## What we are NOT doing (to keep things small)

--- a/src/server/Collectify.Api/Program.cs
+++ b/src/server/Collectify.Api/Program.cs
@@ -167,17 +167,11 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<CollectifyDbContext>();
 
-    // Both providers own their schema through EF Core migrations (issue #100).
-    // PostgreSQL is provisioned (created if missing) then migrated; SQLite is
-    // migrated in place. Failure to migrate stops startup.
-    var provider = (builder.Configuration[Collectify.Infrastructure.DatabaseOptions.ProviderKey]
-        ?? Collectify.Infrastructure.DatabaseOptions.DefaultProvider).Trim();
-    if (provider.Equals(Collectify.Infrastructure.DatabaseOptions.PostgresProvider, StringComparison.OrdinalIgnoreCase))
-    {
-        await CollectifyDbContextExtensions.EnsurePostgresDatabaseAsync(builder.Configuration);
-    }
-
-    await db.Database.MigrateAsync();
+    // The coordinator preserves PostgreSQL's provision-then-migrate lifecycle
+    // and creates a verified SQLite snapshot before applying pending migrations.
+    // Any provisioning, backup, verification, or migration failure stops startup.
+    await scope.ServiceProvider.GetRequiredService<DatabaseMigrationCoordinator>()
+        .MigrateAsync(db, app.Lifetime.ApplicationStopping);
 
     // Record whether the Steam store-import tables exist. On Postgres an upgrade
     // of an existing install leaves them absent (EnsureCreated is a no-op); the

--- a/src/server/Collectify.Infrastructure/Data/BackupFileDeleter.cs
+++ b/src/server/Collectify.Infrastructure/Data/BackupFileDeleter.cs
@@ -1,0 +1,6 @@
+namespace Collectify.Infrastructure.Data;
+
+public sealed class BackupFileDeleter : IBackupFileDeleter
+{
+    public void Delete(string path) => File.Delete(path);
+}

--- a/src/server/Collectify.Infrastructure/Data/CollectifyDbContextExtensions.cs
+++ b/src/server/Collectify.Infrastructure/Data/CollectifyDbContextExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Npgsql;
 
 namespace Collectify.Infrastructure.Data;
@@ -30,6 +31,11 @@ public static class CollectifyDbContextExtensions
         }
 
         services.AddSingleton<CollectifyDbContextRegistrationMarker>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<ISqliteBackupVerifier, SqliteBackupVerifier>();
+        services.TryAddSingleton<IBackupFileDeleter, BackupFileDeleter>();
+        services.AddScoped<ISqliteMigrationBackup, SqliteMigrationBackup>();
+        services.AddScoped<DatabaseMigrationCoordinator>();
 
         return services.AddDbContext<CollectifyDbContext>((serviceProvider, options) =>
         {

--- a/src/server/Collectify.Infrastructure/Data/DatabaseMigrationCoordinator.cs
+++ b/src/server/Collectify.Infrastructure/Data/DatabaseMigrationCoordinator.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using Collectify.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Collectify.Infrastructure.Data;
+
+public sealed class DatabaseMigrationCoordinator
+{
+    private readonly IConfiguration _configuration;
+    private readonly ISqliteMigrationBackup _sqliteBackup;
+    private readonly ILogger<DatabaseMigrationCoordinator> _logger;
+
+    public DatabaseMigrationCoordinator(
+        IConfiguration configuration,
+        ISqliteMigrationBackup sqliteBackup,
+        ILogger<DatabaseMigrationCoordinator> logger)
+    {
+        _configuration = configuration;
+        _sqliteBackup = sqliteBackup;
+        _logger = logger;
+    }
+
+    public async Task MigrateAsync(
+        CollectifyDbContext db,
+        CancellationToken cancellationToken = default)
+    {
+        if (db.Database.IsNpgsql())
+        {
+            await CollectifyDbContextExtensions.EnsurePostgresDatabaseAsync(_configuration);
+            await db.Database.MigrateAsync(cancellationToken);
+            return;
+        }
+
+        if (!db.Database.IsSqlite())
+        {
+            throw new InvalidOperationException(
+                $"Unsupported EF Core database provider '{db.Database.ProviderName ?? "(unknown)"}'.");
+        }
+
+        var retention = ReadRetention();
+        var snapshot = await _sqliteBackup.CreateIfNeededAsync(db, cancellationToken);
+        await db.Database.MigrateAsync(cancellationToken);
+
+        if (snapshot is not null)
+        {
+            await _sqliteBackup.PruneAsync(snapshot, retention, cancellationToken);
+            _logger.LogInformation(
+                "SQLite migration completed with pre-migration backup {BackupPath}",
+                snapshot);
+        }
+    }
+
+    private int ReadRetention()
+    {
+        var configured = _configuration[DatabaseOptions.BackupRetentionKey];
+        if (configured is null) return DatabaseOptions.DefaultBackupRetention;
+
+        if (!int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var retention)
+            || retention <= 0)
+        {
+            throw new InvalidOperationException(
+                $"'{DatabaseOptions.BackupRetentionKey}' must be a positive integer; received '{configured}'.");
+        }
+
+        return retention;
+    }
+}

--- a/src/server/Collectify.Infrastructure/Data/IBackupFileDeleter.cs
+++ b/src/server/Collectify.Infrastructure/Data/IBackupFileDeleter.cs
@@ -1,0 +1,6 @@
+namespace Collectify.Infrastructure.Data;
+
+public interface IBackupFileDeleter
+{
+    void Delete(string path);
+}

--- a/src/server/Collectify.Infrastructure/Data/ISqliteBackupVerifier.cs
+++ b/src/server/Collectify.Infrastructure/Data/ISqliteBackupVerifier.cs
@@ -1,0 +1,6 @@
+namespace Collectify.Infrastructure.Data;
+
+public interface ISqliteBackupVerifier
+{
+    Task VerifyAsync(string path, CancellationToken cancellationToken = default);
+}

--- a/src/server/Collectify.Infrastructure/Data/ISqliteMigrationBackup.cs
+++ b/src/server/Collectify.Infrastructure/Data/ISqliteMigrationBackup.cs
@@ -1,0 +1,13 @@
+namespace Collectify.Infrastructure.Data;
+
+public interface ISqliteMigrationBackup
+{
+    Task<string?> CreateIfNeededAsync(
+        CollectifyDbContext db,
+        CancellationToken cancellationToken = default);
+
+    Task PruneAsync(
+        string newestBackupPath,
+        int retention,
+        CancellationToken cancellationToken = default);
+}

--- a/src/server/Collectify.Infrastructure/Data/SqliteBackupVerifier.cs
+++ b/src/server/Collectify.Infrastructure/Data/SqliteBackupVerifier.cs
@@ -1,0 +1,40 @@
+using Microsoft.Data.Sqlite;
+
+namespace Collectify.Infrastructure.Data;
+
+public sealed class SqliteBackupVerifier : ISqliteBackupVerifier
+{
+    public async Task VerifyAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadOnly,
+            }.ToString();
+
+            await using var connection = new SqliteConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "PRAGMA quick_check;";
+
+            var results = new List<string>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                results.Add(reader.GetString(0));
+
+            if (results.Count != 1 || !string.Equals(results[0], "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    $"SQLite backup integrity check failed: {string.Join("; ", results)}");
+            }
+        }
+        catch (SqliteException exception)
+        {
+            throw new InvalidDataException("SQLite backup integrity check failed.", exception);
+        }
+    }
+}

--- a/src/server/Collectify.Infrastructure/Data/SqliteMigrationBackup.cs
+++ b/src/server/Collectify.Infrastructure/Data/SqliteMigrationBackup.cs
@@ -1,0 +1,184 @@
+using System.Data;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Collectify.Infrastructure.Data;
+
+public sealed class SqliteMigrationBackup : ISqliteMigrationBackup
+{
+    private const string TimestampFormat = "yyyyMMdd'T'HHmmssfff'Z'";
+    private static readonly Regex CompletedBackupPattern = new(
+        @"^collectify-[A-Za-z0-9_]+-(?<timestamp>\d{8}T\d{9}Z)\.db$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private readonly TimeProvider _timeProvider;
+    private readonly ISqliteBackupVerifier _verifier;
+    private readonly IBackupFileDeleter _fileDeleter;
+    private readonly ILogger<SqliteMigrationBackup> _logger;
+
+    public SqliteMigrationBackup(
+        TimeProvider timeProvider,
+        ISqliteBackupVerifier verifier,
+        IBackupFileDeleter fileDeleter,
+        ILogger<SqliteMigrationBackup> logger)
+    {
+        _timeProvider = timeProvider;
+        _verifier = verifier;
+        _fileDeleter = fileDeleter;
+        _logger = logger;
+    }
+
+    public async Task<string?> CreateIfNeededAsync(
+        CollectifyDbContext db,
+        CancellationToken cancellationToken = default)
+    {
+        var source = db.Database.GetDbConnection() as SqliteConnection
+            ?? throw new InvalidOperationException("SQLite migration backup requires a SQLite connection.");
+
+        if (IsInMemory(source)) return null;
+
+        var sourcePath = Path.GetFullPath(source.DataSource);
+        if (!File.Exists(sourcePath)) return null;
+
+        var pending = await db.Database.GetPendingMigrationsAsync(cancellationToken);
+        if (!pending.Any()) return null;
+
+        var applied = await db.Database.GetAppliedMigrationsAsync(cancellationToken);
+        var oldMigration = SanitizeMigrationName(applied.LastOrDefault() ?? "unversioned");
+        var backupDirectory = Path.Combine(Path.GetDirectoryName(sourcePath)!, "backups");
+        Directory.CreateDirectory(backupDirectory);
+
+        var timestamp = _timeProvider.GetUtcNow().ToString(TimestampFormat, CultureInfo.InvariantCulture);
+        var finalPath = Path.Combine(
+            backupDirectory,
+            $"collectify-{oldMigration}-{timestamp}.db");
+        var temporaryPath = finalPath + ".tmp";
+
+        await using (new FileStream(
+            temporaryPath,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 1,
+            options: FileOptions.None))
+        {
+        }
+
+        try
+        {
+            var sourceWasOpen = source.State == ConnectionState.Open;
+            try
+            {
+                if (!sourceWasOpen)
+                    await db.Database.OpenConnectionAsync(cancellationToken);
+
+                var destinationConnectionString = new SqliteConnectionStringBuilder
+                {
+                    DataSource = temporaryPath,
+                    Mode = SqliteOpenMode.ReadWriteCreate,
+                }.ToString();
+                await using var destination = new SqliteConnection(destinationConnectionString);
+                await destination.OpenAsync(cancellationToken);
+                source.BackupDatabase(destination);
+            }
+            finally
+            {
+                if (!sourceWasOpen && source.State == ConnectionState.Open)
+                    await db.Database.CloseConnectionAsync();
+            }
+
+            await _verifier.VerifyAsync(temporaryPath, cancellationToken);
+            File.Move(temporaryPath, finalPath);
+            _logger.LogInformation("Created pre-migration SQLite backup at {BackupPath}", finalPath);
+            return finalPath;
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(temporaryPath)) File.Delete(temporaryPath);
+            }
+            catch (Exception cleanupException)
+            {
+                _logger.LogWarning(
+                    cleanupException,
+                    "Could not remove incomplete SQLite backup {BackupPath}",
+                    temporaryPath);
+            }
+
+            throw;
+        }
+    }
+
+    public Task PruneAsync(
+        string newestBackupPath,
+        int retention,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newestBackupPath);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(retention);
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(newestBackupPath))
+            ?? throw new InvalidOperationException("The SQLite backup path has no parent directory.");
+        if (!Directory.Exists(directory)) return Task.CompletedTask;
+
+        var completed = Directory.EnumerateFiles(directory)
+            .Select(path => (Path: path, Match: CompletedBackupPattern.Match(Path.GetFileName(path))))
+            .Where(item => item.Match.Success)
+            .Select(item => (
+                item.Path,
+                Timestamp: DateTimeOffset.ParseExact(
+                    item.Match.Groups["timestamp"].Value,
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal)))
+            .OrderByDescending(item => item.Timestamp)
+            .ThenByDescending(item => item.Path, StringComparer.Ordinal)
+            .Skip(retention)
+            .ToArray();
+
+        foreach (var item in completed)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                _fileDeleter.Delete(item.Path);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Could not remove old SQLite migration backup {BackupPath}",
+                    item.Path);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool IsInMemory(SqliteConnection connection)
+    {
+        if (string.Equals(connection.DataSource, ":memory:", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var builder = new SqliteConnectionStringBuilder(connection.ConnectionString);
+        return builder.Mode == SqliteOpenMode.Memory
+            || string.Equals(builder.DataSource, ":memory:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string SanitizeMigrationName(string migration)
+    {
+        var value = new StringBuilder(migration.Length);
+        foreach (var character in migration)
+        {
+            if (char.IsAsciiLetterOrDigit(character) || character == '_')
+                value.Append(character);
+        }
+
+        return value.Length == 0 ? "unversioned" : value.ToString();
+    }
+}

--- a/src/server/Collectify.Infrastructure/Data/SqliteMigrationBackup.cs
+++ b/src/server/Collectify.Infrastructure/Data/SqliteMigrationBackup.cs
@@ -126,19 +126,47 @@ public sealed class SqliteMigrationBackup : ISqliteMigrationBackup
             ?? throw new InvalidOperationException("The SQLite backup path has no parent directory.");
         if (!Directory.Exists(directory)) return Task.CompletedTask;
 
-        var completed = Directory.EnumerateFiles(directory)
-            .Select(path => (Path: path, Match: CompletedBackupPattern.Match(Path.GetFileName(path))))
-            .Where(item => item.Match.Success)
-            .Select(item => (
-                item.Path,
-                Timestamp: DateTimeOffset.ParseExact(
-                    item.Match.Groups["timestamp"].Value,
+        var normalizedNewestBackupPath = Path.GetFullPath(newestBackupPath);
+        var pathComparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var candidates = new List<(string Path, DateTimeOffset Timestamp)>();
+
+        foreach (var path in Directory.EnumerateFiles(directory))
+        {
+            var match = CompletedBackupPattern.Match(Path.GetFileName(path));
+            if (!match.Success) continue;
+
+            if (!DateTimeOffset.TryParseExact(
+                    match.Groups["timestamp"].Value,
                     TimestampFormat,
                     CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal)))
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var timestamp))
+            {
+                _logger.LogWarning(
+                    "Ignoring SQLite migration backup with invalid timestamp {BackupPath}",
+                    path);
+                continue;
+            }
+
+            candidates.Add((path, timestamp));
+        }
+
+        var protectsNewestBackup = candidates.Any(item =>
+            string.Equals(
+                Path.GetFullPath(item.Path),
+                normalizedNewestBackupPath,
+                pathComparison));
+        var remainingRetention = retention - (protectsNewestBackup ? 1 : 0);
+        var completed = candidates
+            .Where(item => !string.Equals(
+                Path.GetFullPath(item.Path),
+                normalizedNewestBackupPath,
+                pathComparison))
             .OrderByDescending(item => item.Timestamp)
             .ThenByDescending(item => item.Path, StringComparer.Ordinal)
-            .Skip(retention)
+            .Skip(remainingRetention)
             .ToArray();
 
         foreach (var item in completed)

--- a/src/server/Collectify.Infrastructure/DatabaseOptions.cs
+++ b/src/server/Collectify.Infrastructure/DatabaseOptions.cs
@@ -11,6 +11,8 @@ public static class DatabaseOptions
     public const string ConnectionStringKey = SectionName + ":ConnectionString";
     public const string AdminConnectionStringKey = SectionName + ":AdminConnectionString";
     public const string AdminDatabaseKey = SectionName + ":AdminDatabase";
+    public const string BackupRetentionKey = SectionName + ":BackupRetention";
+    public const int DefaultBackupRetention = 10;
 
     public const string SqliteProvider = "sqlite";
     public const string PostgresProvider = "postgres";

--- a/src/server/tests/Collectify.PostgresTests/DatabaseMigrationCoordinatorPostgresTests.cs
+++ b/src/server/tests/Collectify.PostgresTests/DatabaseMigrationCoordinatorPostgresTests.cs
@@ -1,0 +1,74 @@
+using Collectify.Infrastructure;
+using Collectify.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Collectify.PostgresTests;
+
+public sealed class DatabaseMigrationCoordinatorPostgresTests
+{
+    private const string Image = "postgres:17-alpine@sha256:d4bb0a8c1b7bb2e29f976d099e7bfb9a5d8858cffe9e46b35cd302cd1f1f8168";
+
+    [Fact]
+    public async Task MigrateAsync_MissingPostgresTarget_ProvisionsThenMigratesWithoutSqliteBackup()
+    {
+        await using var container = new PostgreSqlBuilder(Image).Build();
+        await container.StartAsync();
+
+        var target = new NpgsqlConnectionStringBuilder(container.GetConnectionString())
+        {
+            Database = $"collectify_backup_{Guid.NewGuid():N}",
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DatabaseOptions.ConnectionStringKey] = target.ConnectionString,
+            })
+            .Build();
+        var options = new DbContextOptionsBuilder<CollectifyDbContext>()
+            .UseNpgsql(target.ConnectionString, npgsql =>
+            {
+                npgsql.MigrationsAssembly(DatabaseOptions.PostgresMigrationsAssembly);
+                npgsql.MigrationsHistoryTable(
+                    DatabaseOptions.MigrationsHistoryTable,
+                    DatabaseOptions.PostgresSchema);
+            })
+            .Options;
+        await using var db = new CollectifyDbContext(options);
+        var backup = new RecordingBackup();
+        var coordinator = new DatabaseMigrationCoordinator(
+            configuration,
+            backup,
+            NullLogger<DatabaseMigrationCoordinator>.Instance);
+
+        await coordinator.MigrateAsync(db);
+
+        Assert.Equal(0, backup.CreateCalls);
+        var known = db.Database.GetMigrations().ToArray();
+        var applied = (await db.Database.GetAppliedMigrationsAsync()).ToArray();
+        Assert.NotEmpty(known);
+        Assert.Equal(known, applied);
+    }
+
+    private sealed class RecordingBackup : ISqliteMigrationBackup
+    {
+        public int CreateCalls { get; private set; }
+
+        public Task<string?> CreateIfNeededAsync(
+            CollectifyDbContext db,
+            CancellationToken cancellationToken = default)
+        {
+            CreateCalls++;
+            throw new InvalidOperationException("SQLite backup must not run for PostgreSQL.");
+        }
+
+        public Task PruneAsync(
+            string newestBackupPath,
+            int retention,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("SQLite pruning must not run for PostgreSQL.");
+    }
+}

--- a/src/server/tests/Collectify.PostgresTests/PostgresBootstrapMigrationTests.cs
+++ b/src/server/tests/Collectify.PostgresTests/PostgresBootstrapMigrationTests.cs
@@ -59,7 +59,7 @@ public sealed class PostgresBootstrapMigrationTests
             })
             .Build();
 
-        // This is the production entry point Program.cs calls before MigrateAsync().
+        // This is the provisioning step DatabaseMigrationCoordinator runs before MigrateAsync().
         await CollectifyDbContextExtensions.EnsurePostgresDatabaseAsync(configuration);
 
         // Assert the exact hostile name exists as a single database...

--- a/src/server/tests/Collectify.Tests/Infrastructure/DatabaseMigrationCoordinatorTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/DatabaseMigrationCoordinatorTests.cs
@@ -1,0 +1,244 @@
+using Collectify.Infrastructure.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public sealed class DatabaseMigrationCoordinatorTests : IDisposable
+{
+    private const string InitialMigration = "20260505174247_InitialCreate";
+    private const string RetentionKey = "Collectify:Database:BackupRetention";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(), $"collectify-migration-coordinator-{Guid.NewGuid():N}");
+
+    public DatabaseMigrationCoordinatorTests() => Directory.CreateDirectory(_directory);
+
+    [Fact]
+    public async Task MigrateAsync_OldSqlite_BackupContainsOldSchemaBeforeLiveMigration()
+    {
+        var path = Path.Combine(_directory, "ordered.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db);
+        var backup = NewBackup();
+        var coordinator = NewCoordinator(backup);
+
+        await coordinator.MigrateAsync(db);
+
+        Assert.NotEqual(InitialMigration, await LastMigrationAsync(path));
+        var snapshot = Assert.Single(Directory.EnumerateFiles(
+            Path.Combine(_directory, "backups"), "*.db"));
+        Assert.Equal(InitialMigration, await LastMigrationAsync(snapshot));
+        Assert.Equal("pre-migration", await ScalarAsync(snapshot, "SELECT Value FROM BackupSentinel"));
+    }
+
+    [Fact]
+    public async Task MigrateAsync_BackupFailure_DoesNotApplyPendingMigration()
+    {
+        var path = Path.Combine(_directory, "backup-failure.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db);
+        File.WriteAllText(Path.Combine(_directory, "backups"), "blocks directory creation");
+
+        await Assert.ThrowsAsync<IOException>(() => NewCoordinator(NewBackup()).MigrateAsync(db));
+
+        Assert.Equal(InitialMigration, await LastMigrationAsync(path));
+    }
+
+    [Fact]
+    public async Task MigrateAsync_VerifierFailure_DoesNotApplyPendingMigration()
+    {
+        var path = Path.Combine(_directory, "verify-failure.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db);
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => NewCoordinator(NewBackup(new RejectingVerifier())).MigrateAsync(db));
+
+        Assert.Equal(InitialMigration, await LastMigrationAsync(path));
+    }
+
+    [Fact]
+    public async Task MigrateAsync_ReadOnlyMigrationFailure_DoesNotPruneOlderSnapshots()
+    {
+        var dataDirectory = Path.Combine(_directory, "read-only");
+        Directory.CreateDirectory(dataDirectory);
+        var path = Path.Combine(dataDirectory, "collectify.db");
+        await using (var setup = NewContext(path))
+            await MigrateToInitialAndSeedAsync(setup);
+
+        var backupDirectory = Path.Combine(dataDirectory, "backups");
+        Directory.CreateDirectory(backupDirectory);
+        var older1 = CreateBackupFile(backupDirectory, "OldA", "20260101T000000000Z");
+        var older2 = CreateBackupFile(backupDirectory, "OldB", "20260201T000000000Z");
+        await using var readOnly = NewContext($"Data Source={path};Mode=ReadOnly");
+        var coordinator = NewCoordinator(NewBackup(), retention: "1");
+
+        await Assert.ThrowsAsync<SqliteException>(() => coordinator.MigrateAsync(readOnly));
+
+        Assert.True(File.Exists(older1));
+        Assert.True(File.Exists(older2));
+        Assert.Equal(3, Directory.EnumerateFiles(backupDirectory, "*.db").Count());
+        Assert.Equal(InitialMigration, await LastMigrationAsync(path));
+    }
+
+    [Fact]
+    public async Task MigrateAsync_InMemorySqlite_CallsBackupAndMigrates()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await using var db = NewContext(connection);
+        var backup = new RecordingBackup();
+
+        await NewCoordinator(backup).MigrateAsync(db);
+
+        Assert.Equal(1, backup.CreateCalls);
+        Assert.NotEmpty(await db.Database.GetAppliedMigrationsAsync());
+        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("not-an-int")]
+    public async Task MigrateAsync_InvalidRetention_FailsBeforeAnyInMemoryShortcut(string value)
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await using var db = NewContext(connection);
+        var backup = new RecordingBackup();
+        var coordinator = NewCoordinator(backup, value);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => coordinator.MigrateAsync(db));
+
+        Assert.Contains(RetentionKey, exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, backup.CreateCalls);
+        Assert.Empty(await db.Database.GetAppliedMigrationsAsync());
+    }
+
+    [Fact]
+    public async Task MigrateAsync_PruneDeletionFailure_DoesNotFailStartup()
+    {
+        var dataDirectory = Path.Combine(_directory, "delete-failure");
+        Directory.CreateDirectory(dataDirectory);
+        var path = Path.Combine(dataDirectory, "collectify.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db);
+        var backupDirectory = Path.Combine(dataDirectory, "backups");
+        Directory.CreateDirectory(backupDirectory);
+        var old = CreateBackupFile(backupDirectory, "Old", "20260101T000000000Z");
+        var backup = NewBackup(fileDeleter: new ThrowingDeleter());
+
+        await NewCoordinator(backup, retention: "1").MigrateAsync(db);
+
+        Assert.NotEqual(InitialMigration, await LastMigrationAsync(path));
+        Assert.True(File.Exists(old));
+        Assert.Equal(2, Directory.EnumerateFiles(backupDirectory, "*.db").Count());
+    }
+
+    private DatabaseMigrationCoordinator NewCoordinator(
+        ISqliteMigrationBackup backup,
+        string retention = "10")
+        => new(
+            new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [RetentionKey] = retention,
+            }).Build(),
+            backup,
+            NullLogger<DatabaseMigrationCoordinator>.Instance);
+
+    private SqliteMigrationBackup NewBackup(
+        ISqliteBackupVerifier? verifier = null,
+        IBackupFileDeleter? fileDeleter = null)
+        => new(
+            new FakeTimeProvider(new DateTimeOffset(2026, 8, 28, 12, 34, 56, 789, TimeSpan.Zero)),
+            verifier ?? new SqliteBackupVerifier(),
+            fileDeleter ?? new BackupFileDeleter(),
+            NullLogger<SqliteMigrationBackup>.Instance);
+
+    private static CollectifyDbContext NewContext(string pathOrConnectionString)
+    {
+        var connectionString = pathOrConnectionString.Contains('=')
+            ? pathOrConnectionString
+            : $"Data Source={pathOrConnectionString}";
+        return new CollectifyDbContext(new DbContextOptionsBuilder<CollectifyDbContext>()
+            .UseSqlite(connectionString, sqlite =>
+                sqlite.MigrationsAssembly("Collectify.Infrastructure"))
+            .Options);
+    }
+
+    private static CollectifyDbContext NewContext(SqliteConnection connection)
+        => new(new DbContextOptionsBuilder<CollectifyDbContext>()
+            .UseSqlite(connection, sqlite =>
+                sqlite.MigrationsAssembly("Collectify.Infrastructure"))
+            .Options);
+
+    private static async Task MigrateToInitialAndSeedAsync(CollectifyDbContext db)
+    {
+        await db.GetService<IMigrator>().MigrateAsync(InitialMigration);
+        await db.Database.ExecuteSqlRawAsync("CREATE TABLE BackupSentinel(Value TEXT NOT NULL);");
+        await db.Database.ExecuteSqlRawAsync(
+            "INSERT INTO BackupSentinel(Value) VALUES ('pre-migration');");
+    }
+
+    private static async Task<object?> ScalarAsync(string path, string sql)
+    {
+        await using var connection = new SqliteConnection($"Data Source={path};Mode=ReadOnly");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return await command.ExecuteScalarAsync();
+    }
+
+    private static async Task<string?> LastMigrationAsync(string path)
+        => (string?)await ScalarAsync(
+            path,
+            "SELECT MigrationId FROM __EFMigrationsHistory ORDER BY MigrationId DESC LIMIT 1");
+
+    private static string CreateBackupFile(string directory, string migration, string timestamp)
+    {
+        var path = Path.Combine(directory, $"collectify-{migration}-{timestamp}.db");
+        File.WriteAllText(path, migration);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+
+    private sealed class RecordingBackup : ISqliteMigrationBackup
+    {
+        public int CreateCalls { get; private set; }
+
+        public Task<string?> CreateIfNeededAsync(
+            CollectifyDbContext db,
+            CancellationToken cancellationToken = default)
+        {
+            CreateCalls++;
+            return Task.FromResult<string?>(null);
+        }
+
+        public Task PruneAsync(
+            string newestBackupPath,
+            int retention,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class RejectingVerifier : ISqliteBackupVerifier
+    {
+        public Task VerifyAsync(string path, CancellationToken cancellationToken = default)
+            => throw new InvalidDataException("intentional verifier rejection");
+    }
+
+    private sealed class ThrowingDeleter : IBackupFileDeleter
+    {
+        public void Delete(string path) => throw new IOException("intentional deletion failure");
+    }
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/SqliteBackupVerifierTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/SqliteBackupVerifierTests.cs
@@ -1,0 +1,61 @@
+using Collectify.Infrastructure.Data;
+using Microsoft.Data.Sqlite;
+
+namespace Collectify.Tests.Infrastructure;
+
+public sealed class SqliteBackupVerifierTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(), $"collectify-backup-verifier-{Guid.NewGuid():N}");
+
+    public SqliteBackupVerifierTests() => Directory.CreateDirectory(_directory);
+
+    [Fact]
+    public async Task VerifyAsync_HealthyDatabase_Completes()
+    {
+        var path = Path.Combine(_directory, "healthy.db");
+        await using (var connection = new SqliteConnection($"Data Source={path}"))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);";
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await new SqliteBackupVerifier().VerifyAsync(path);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MalformedSchema_ThrowsIntegrityFailure()
+    {
+        var path = Path.Combine(_directory, "malformed.db");
+        await using (var connection = new SqliteConnection($"Data Source={path}"))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);
+                INSERT INTO Items(Value) VALUES ('sentinel');
+                PRAGMA writable_schema=ON;
+                UPDATE sqlite_master SET rootpage=999999 WHERE name='Items';
+                PRAGMA writable_schema=OFF;
+                """;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await using (var readOnly = new SqliteConnection($"Data Source={path};Mode=ReadOnly"))
+        {
+            await readOnly.OpenAsync();
+            Assert.Equal(System.Data.ConnectionState.Open, readOnly.State);
+        }
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => new SqliteBackupVerifier().VerifyAsync(path));
+        Assert.Contains("integrity", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/src/server/tests/Collectify.Tests/Infrastructure/SqliteMigrationBackupTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/SqliteMigrationBackupTests.cs
@@ -118,6 +118,44 @@ public sealed class SqliteMigrationBackupTests : IDisposable
     }
 
     [Fact]
+    public async Task PruneAsync_FutureDatedOlderBackup_ProtectsNewestBackupPath()
+    {
+        var backupDirectory = Path.Combine(_directory, "backups-clock-skew");
+        Directory.CreateDirectory(backupDirectory);
+        var older = CreateBackupFile(backupDirectory, "Older", "20250101T000000000Z");
+        var newestBackupPath = CreateBackupFile(backupDirectory, "Current", "20260101T000000000Z");
+        var futureDatedOlderBackup = CreateBackupFile(
+            backupDirectory,
+            "FutureDatedOlder",
+            "20270101T000000000Z");
+
+        await NewBackup().PruneAsync(newestBackupPath, retention: 1);
+
+        Assert.True(File.Exists(newestBackupPath));
+        Assert.False(File.Exists(futureDatedOlderBackup));
+        Assert.False(File.Exists(older));
+    }
+
+    [Fact]
+    public async Task PruneAsync_InvalidMatchingTimestamp_IgnoresFileAndCompletes()
+    {
+        var backupDirectory = Path.Combine(_directory, "backups-invalid-timestamp");
+        Directory.CreateDirectory(backupDirectory);
+        var newestBackupPath = CreateBackupFile(backupDirectory, "Current", "20260301T000000000Z");
+        var old = CreateBackupFile(backupDirectory, "Old", "20250101T000000000Z");
+        var invalidTimestamp = Path.Combine(
+            backupDirectory,
+            "collectify-Invalid-20261301T000000000Z.db");
+        File.WriteAllText(invalidTimestamp, "invalid-timestamp");
+
+        await NewBackup().PruneAsync(newestBackupPath, retention: 1);
+
+        Assert.True(File.Exists(newestBackupPath));
+        Assert.False(File.Exists(old));
+        Assert.True(File.Exists(invalidTimestamp));
+    }
+
+    [Fact]
     public async Task PruneAsync_UsesParsedTimestampAcrossMigrationPrefixes()
     {
         var backupDirectory = Path.Combine(_directory, "backups-order");

--- a/src/server/tests/Collectify.Tests/Infrastructure/SqliteMigrationBackupTests.cs
+++ b/src/server/tests/Collectify.Tests/Infrastructure/SqliteMigrationBackupTests.cs
@@ -1,0 +1,246 @@
+using System.Data;
+using Collectify.Infrastructure.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Collectify.Tests.Infrastructure;
+
+public sealed class SqliteMigrationBackupTests : IDisposable
+{
+    private const string InitialMigration = "20260505174247_InitialCreate";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(), $"collectify-migration-backup-{Guid.NewGuid():N}");
+
+    public SqliteMigrationBackupTests() => Directory.CreateDirectory(_directory);
+
+    [Fact]
+    public async Task CreateIfNeededAsync_PendingMigration_CreatesOldSchemaSnapshot()
+    {
+        var path = Path.Combine(_directory, "collectify.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db, "old-schema-sentinel");
+
+        var backup = NewBackup();
+        var snapshot = await backup.CreateIfNeededAsync(db);
+
+        Assert.NotNull(snapshot);
+        Assert.True(File.Exists(snapshot));
+        Assert.Equal("old-schema-sentinel", await ScalarAsync(snapshot!, "SELECT Value FROM BackupSentinel"));
+        Assert.Equal(InitialMigration, await LastMigrationAsync(snapshot!));
+    }
+
+    [Fact]
+    public async Task CreateIfNeededAsync_UncheckpointedWal_CapturesCommittedFrames()
+    {
+        var path = Path.Combine(_directory, "wal.db");
+        await using var source = new SqliteConnection($"Data Source={path}");
+        await source.OpenAsync();
+        await using var db = NewContext(source);
+        await db.GetService<IMigrator>().MigrateAsync(InitialMigration);
+        await db.Database.ExecuteSqlRawAsync("CREATE TABLE BackupSentinel(Value TEXT NOT NULL);");
+
+        await ExecuteAsync(source, "PRAGMA wal_checkpoint(TRUNCATE);");
+        await ExecuteAsync(source, "PRAGMA journal_mode=WAL;");
+        await ExecuteAsync(source, "PRAGMA wal_autocheckpoint=0;");
+        await ExecuteAsync(source, "INSERT INTO BackupSentinel(Value) VALUES ('wal-only-sentinel');");
+
+        Assert.True(File.Exists(path + "-wal"));
+        var rawCopy = Path.Combine(_directory, "raw-copy.db");
+        File.Copy(path, rawCopy);
+        Assert.Equal(0L, Convert.ToInt64(await ScalarAsync(rawCopy, "SELECT COUNT(*) FROM BackupSentinel")));
+
+        var snapshot = await NewBackup().CreateIfNeededAsync(db);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal("wal-only-sentinel", await ScalarAsync(snapshot!, "SELECT Value FROM BackupSentinel"));
+        Assert.Equal(ConnectionState.Open, source.State);
+    }
+
+    [Fact]
+    public async Task CreateIfNeededAsync_CurrentDatabase_DoesNotCreateBackupDirectory()
+    {
+        var path = Path.Combine(_directory, "current.db");
+        await using var db = NewContext(path);
+        await db.Database.MigrateAsync();
+
+        var snapshot = await NewBackup().CreateIfNeededAsync(db);
+
+        Assert.Null(snapshot);
+        Assert.False(Directory.Exists(Path.Combine(_directory, "backups")));
+    }
+
+    [Fact]
+    public async Task CreateIfNeededAsync_MissingFile_ReturnsNullWithoutCreatingDirectory()
+    {
+        var dataDirectory = Path.Combine(_directory, "missing");
+        Directory.CreateDirectory(dataDirectory);
+        var path = Path.Combine(dataDirectory, "collectify.db");
+        await using var db = NewContext(path);
+
+        var snapshot = await NewBackup().CreateIfNeededAsync(db);
+
+        Assert.Null(snapshot);
+        Assert.False(File.Exists(path));
+        Assert.False(Directory.Exists(Path.Combine(dataDirectory, "backups")));
+    }
+
+    [Fact]
+    public async Task CreateIfNeededAsync_InMemory_ReturnsNullAndLeavesConnectionOpen()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await using var db = NewContext(connection);
+
+        var snapshot = await NewBackup().CreateIfNeededAsync(db);
+
+        Assert.Null(snapshot);
+        Assert.Equal(ConnectionState.Open, connection.State);
+    }
+
+    [Fact]
+    public async Task CreateIfNeededAsync_VerifierRejects_DeletesTempAndPublishesNoCompletedBackup()
+    {
+        var path = Path.Combine(_directory, "rejected.db");
+        await using var db = NewContext(path);
+        await MigrateToInitialAndSeedAsync(db, "sentinel");
+        var backup = NewBackup(new RejectingVerifier());
+
+        await Assert.ThrowsAsync<InvalidDataException>(() => backup.CreateIfNeededAsync(db));
+
+        var backupDirectory = Path.Combine(_directory, "backups");
+        Assert.True(Directory.Exists(backupDirectory));
+        Assert.Empty(Directory.EnumerateFiles(backupDirectory));
+        Assert.Equal(InitialMigration, await LastMigrationAsync(path));
+    }
+
+    [Fact]
+    public async Task PruneAsync_UsesParsedTimestampAcrossMigrationPrefixes()
+    {
+        var backupDirectory = Path.Combine(_directory, "backups-order");
+        Directory.CreateDirectory(backupDirectory);
+        var oldest = CreateBackupFile(backupDirectory, "ZMigration", "20260101T000000000Z");
+        var middle = CreateBackupFile(backupDirectory, "AMigration", "20260201T000000000Z");
+        var newest = CreateBackupFile(backupDirectory, "MMigration", "20260301T000000000Z");
+
+        await NewBackup().PruneAsync(newest, retention: 2);
+
+        Assert.False(File.Exists(oldest));
+        Assert.True(File.Exists(middle));
+        Assert.True(File.Exists(newest));
+    }
+
+    [Fact]
+    public async Task PruneAsync_IgnoresTempUnrelatedAndNearMissFiles()
+    {
+        var backupDirectory = Path.Combine(_directory, "backups-match");
+        Directory.CreateDirectory(backupDirectory);
+        var keep = CreateBackupFile(backupDirectory, "Current", "20260301T000000000Z");
+        var remove = CreateBackupFile(backupDirectory, "Old", "20260101T000000000Z");
+        var temp = Path.Combine(backupDirectory, "collectify-Old-20250101T000000000Z.db.tmp");
+        var unrelated = Path.Combine(backupDirectory, "other-Old-20240101T000000000Z.db");
+        var nearMiss = Path.Combine(backupDirectory, "collectify-Old-20230101T000000000Z.db.bak");
+        File.WriteAllText(temp, "temp");
+        File.WriteAllText(unrelated, "unrelated");
+        File.WriteAllText(nearMiss, "near-miss");
+
+        await NewBackup().PruneAsync(keep, retention: 1);
+
+        Assert.True(File.Exists(keep));
+        Assert.False(File.Exists(remove));
+        Assert.True(File.Exists(temp));
+        Assert.True(File.Exists(unrelated));
+        Assert.True(File.Exists(nearMiss));
+    }
+
+    [Fact]
+    public async Task PruneAsync_DeletionFailure_LogsAndCompletes()
+    {
+        var backupDirectory = Path.Combine(_directory, "backups-delete");
+        Directory.CreateDirectory(backupDirectory);
+        var keep = CreateBackupFile(backupDirectory, "Current", "20260301T000000000Z");
+        var protectedPath = CreateBackupFile(backupDirectory, "Old", "20260101T000000000Z");
+        var backup = NewBackup(fileDeleter: new ThrowingDeleter());
+
+        await backup.PruneAsync(keep, retention: 1);
+
+        Assert.True(File.Exists(keep));
+        Assert.True(File.Exists(protectedPath));
+    }
+
+    private SqliteMigrationBackup NewBackup(
+        ISqliteBackupVerifier? verifier = null,
+        IBackupFileDeleter? fileDeleter = null)
+        => new(
+            new FakeTimeProvider(new DateTimeOffset(2026, 8, 28, 12, 34, 56, 789, TimeSpan.Zero)),
+            verifier ?? new SqliteBackupVerifier(),
+            fileDeleter ?? new BackupFileDeleter(),
+            NullLogger<SqliteMigrationBackup>.Instance);
+
+    private static CollectifyDbContext NewContext(string path)
+        => new(new DbContextOptionsBuilder<CollectifyDbContext>()
+            .UseSqlite($"Data Source={path}", sqlite =>
+                sqlite.MigrationsAssembly("Collectify.Infrastructure"))
+            .Options);
+
+    private static CollectifyDbContext NewContext(SqliteConnection connection)
+        => new(new DbContextOptionsBuilder<CollectifyDbContext>()
+            .UseSqlite(connection, sqlite =>
+                sqlite.MigrationsAssembly("Collectify.Infrastructure"))
+            .Options);
+
+    private static async Task MigrateToInitialAndSeedAsync(CollectifyDbContext db, string value)
+    {
+        await db.GetService<IMigrator>().MigrateAsync(InitialMigration);
+        await db.Database.ExecuteSqlRawAsync("CREATE TABLE BackupSentinel(Value TEXT NOT NULL);");
+        await db.Database.ExecuteSqlInterpolatedAsync(
+            $"INSERT INTO BackupSentinel(Value) VALUES ({value});");
+    }
+
+    private static async Task<object?> ScalarAsync(string path, string sql)
+    {
+        await using var connection = new SqliteConnection($"Data Source={path};Mode=ReadOnly");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return await command.ExecuteScalarAsync();
+    }
+
+    private static async Task<string?> LastMigrationAsync(string path)
+        => (string?)await ScalarAsync(
+            path,
+            "SELECT MigrationId FROM __EFMigrationsHistory ORDER BY MigrationId DESC LIMIT 1");
+
+    private static async Task ExecuteAsync(SqliteConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static string CreateBackupFile(string directory, string migration, string timestamp)
+    {
+        var path = Path.Combine(directory, $"collectify-{migration}-{timestamp}.db");
+        File.WriteAllText(path, migration);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+
+    private sealed class RejectingVerifier : ISqliteBackupVerifier
+    {
+        public Task VerifyAsync(string path, CancellationToken cancellationToken = default)
+            => throw new InvalidDataException("intentional verifier rejection");
+    }
+
+    private sealed class ThrowingDeleter : IBackupFileDeleter
+    {
+        public void Delete(string path) => throw new IOException("intentional deletion failure");
+    }
+}


### PR DESCRIPTION
## Summary

- create a verified SQLite snapshot before applying pending startup migrations
- capture committed WAL content through SQLite's backup API, verify with `PRAGMA quick_check`, then publish atomically
- retain the newest configured number of completed snapshots only after migration succeeds
- keep PostgreSQL's existing provision-then-migrate lifecycle unchanged
- document retention and digest-pinned manual recovery

Refs #39

## Deliberate exclusions

- PostgreSQL backup/restore automation
- scheduled or continuous backups
- automatic rollback
- Alpine runtime changes
- generated `graphify-out/` artifacts

The committed graph was validated against this feature head with `uvx --from graphifyy graphify update .`: the new coordinator, backup, and verifier types were present and `GRAPH_REPORT.md` named input `c8ee805b`. Per the project rule that generated graph artifacts stay out of feature PRs, those changes were reverted. After this feature merges, a separate graph-only PR from updated `main` will refresh the committed graph and use `Closes #39`.

## Verification — driver-verified on `16d6dd8bd2dde14b8b694b3c97cdc96ab498b43c`

- `./scripts/ci-local.sh all`
  - server build: passed with the three known baseline warnings and no new warnings
  - `Collectify.Tests`: 783 passed (baseline 761; +22)
  - `Collectify.PostgresTests`: 15 passed (baseline 14; +1)
  - client: 248 passed
  - enum parity: passed
  - npm/NuGet vulnerability gates: passed
  - Docker entrypoint tests: passed
- Graphify code update validation: passed; generated files intentionally reverted
- mutation verification: 12/12 behavior mutants reddened the named test for the predicted mechanism; known-green log-literal control stayed green; every restore reran green

Kyoder implemented the initial three increments. Codex CLI `gpt-5.6-terra` applied the review-fix commit `16d6dd8`; Kyoder independently reran its M11/M12 mutations and the full local CI equivalent on the resulting head.

## Test plan

- [x] snapshot preserves old migration history and seeded data
- [x] uncheckpointed WAL sentinel is absent from a raw primary-file copy and present in the SQLite snapshot
- [x] malformed snapshot fails integrity verification
- [x] backup/verification failures prevent migration
- [x] failed migration does not prune older recovery points
- [x] cleanup deletion failure does not fail an otherwise successful startup
- [x] retention parses timestamps across migration prefixes and ignores near-miss files
- [x] retention always preserves the snapshot created for the current migration despite future-dated older files
- [x] impossible timestamps in matching filenames are ignored without aborting startup cleanup
- [x] missing, current, and in-memory SQLite paths do not create unnecessary snapshots
- [x] invalid retention fails before SQLite startup work
- [x] missing PostgreSQL target is provisioned and migrated without invoking SQLite backup
- [x] full local CI equivalent passes
- [x] mutation matrix and known-green control pass

## Recovery contract

A restore stops the container, copies the selected snapshot over `collectify.db`, removes stale WAL/SHM files, and starts the previous known-good image by immutable digest from that release's `image.json`. Mutable tags such as `latest` are explicitly excluded.
